### PR TITLE
kernel: Include task_stack.h in sucompat.c

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -8,6 +8,7 @@
 #include <linux/printk.h>
 #include <linux/string.h>
 #include <linux/kernel.h>
+#include <linux/sched/task_stack.h>
 #include <linux/slab.h>
 #include <asm-generic/errno-base.h>
 


### PR DESCRIPTION
Fixed the following error when compiling

ld.lld: error: undefined symbol: task_stack_page
>>> referenced by ld-temp.o
>>>               vmlinux.o:(sh_user_path)