### PR TITLE
kernel: switch to syscall_work if CONFIG_GENERIC_ENTRY is enabled

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -57,7 +57,11 @@ void escape_to_root() {
 	memset(&cred->cap_ambient, 0xff, sizeof(cred->cap_ambient));
 
 	// disable seccomp
+#ifdef CONFIG_GENERIC_ENTRY
+	current_thread_info()->syscall_work &= ~SYSCALL_WORK_SECCOMP;
+#else
 	current_thread_info()->flags &= ~TIF_SECCOMP;
+#endif
 	current->seccomp.mode = 0;
 	current->seccomp.filter = NULL;
 


### PR DESCRIPTION
From Kernel 5.11 it migrate to syscall_work instead of tif_*, so check for CONFIG_GENERIC_ENTRY and use syscall_work instead of TIF_SECCOMP

https://www.mail-archive.com/linux-kernel@vger.kernel.org/msg2382193.html