### PR TITLE
Kconfig : Make KSU depends on OVERLAY_FS

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,5 +2,6 @@ config KSU
 	tristate "KernelSU module"
 	default y
 	depends on KPROBES
+	depends on OVERLAY_FS
 	help
 	This is the KSU privilege driver for android system.


### PR DESCRIPTION
As KernelSU now support modules and mounting system as R/W using overlayfs, it's time to require overlayfs when trying to compile it.