### PR TITLE
ksud: use the same variable type in scripts

### DIFF
--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -148,7 +148,7 @@ pub fn exec_post_fs_data() -> Result<()> {
         Command::new("/system/bin/sh")
             .arg(&post_fs_data)
             .current_dir(path)
-            .env("KSU", "1")
+            .env("KSU", "true")
             .status()
             .with_context(|| format!("Failed to exec {}", post_fs_data.display()))?;
     }


### PR DESCRIPTION
When executing module install scripts, KSU is set to "true"; when executing module post-fs-data scripts, KSU is set to "1". This may cause confusions so use the same value instead.