### PR TITLE
Fix error for some non-GKI kernel source code

### DIFF
--- a/kernel/selinux/sepolicy.h
+++ b/kernel/selinux/sepolicy.h
@@ -1,6 +1,7 @@
 #ifndef __KSU_H_SEPOLICY
 #define __KSU_H_SEPOLICY
 
+#include <linux/types.h>
 #include <ss/sidtab.h>
 #include <ss/services.h>
 #include <objsec.h>


### PR DESCRIPTION
Idea from @Dreamail

Before fix:
```
make[1]: 进入目录“/home/celica/kernel/out”
  GEN     Makefile
  CALL    ../scripts/checksyscalls.sh
  CALL    ../scripts/atomic/check-atomics.sh
  CHK     include/generated/compile.h
  CHK     kernel/kheaders_data.tar.xz
  CC      drivers/kernelsu/selinux/sepolicy.o
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:14:
In file included from ../include/linux/spinlock_types.h:13:
In file included from ../arch/arm64/include/asm/spinlock_types.h:12:
../include/asm-generic/qspinlock_types.h:24:3: error: unknown type name 'atomic_t'
                atomic_t val;
                ^
../include/asm-generic/qspinlock_types.h:33:4: error: unknown type name 'u8'
                        u8      locked;
                        ^
../include/asm-generic/qspinlock_types.h:34:4: error: unknown type name 'u8'
                        u8      pending;
                        ^
../include/asm-generic/qspinlock_types.h:37:4: error: unknown type name 'u16'
                        u16     locked_pending;
                        ^
../include/asm-generic/qspinlock_types.h:38:4: error: unknown type name 'u16'
                        u16     tail;
                        ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:26:28: error: no member named 'val' in 'struct qspinlock'
        return atomic_read(&lock->val);
                            ~~~~  ^
../include/asm-generic/qspinlock.h:41:28: error: no member named 'val' in 'struct qspinlock'
        return !atomic_read(&lock.val);
                             ~~~~ ^
../include/asm-generic/qspinlock.h:51:28: error: no member named 'val' in 'struct qspinlock'
        return atomic_read(&lock->val) & ~_Q_LOCKED_MASK;
                            ~~~~  ^
../include/asm-generic/qspinlock.h:60:31: error: no member named 'val' in 'struct qspinlock'
        u32 val = atomic_read(&lock->val);
                               ~~~~  ^
../include/asm-generic/qspinlock.h:65:50: error: no member named 'val' in 'struct qspinlock'
        return likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL));
                                                  ~~~~  ^
../include/linux/compiler.h:77:40: note: expanded from macro 'likely'
# define likely(x)      __builtin_expect(!!(x), 1)
                                            ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:78:47: error: no member named 'val' in 'struct qspinlock'
        if (likely(atomic_try_cmpxchg_acquire(&lock->val, &val, _Q_LOCKED_VAL)))
                                               ~~~~  ^
../include/linux/compiler.h:77:40: note: expanded from macro 'likely'
# define likely(x)      __builtin_expect(!!(x), 1)
                                            ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:85:9: note: expanded from macro '__smp_store_release'
        typeof(p) __p = (p);                                            \
               ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:85:19: note: expanded from macro '__smp_store_release'
        typeof(p) __p = (p);                                            \
                         ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:86:18: note: expanded from macro '__smp_store_release'
        union { typeof(*p) __val; char __c[1]; } __u =                  \
                        ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:87:31: note: expanded from macro '__smp_store_release'
                { .__val = (__force typeof(*p)) (v) };                  \
                                            ^
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:88:34: note: expanded from macro '__smp_store_release'
        compiletime_assert_atomic_type(*p);                             \
                                        ^
../include/linux/compiler.h:422:35: note: expanded from macro 'compiletime_assert_atomic_type'
        compiletime_assert(__native_word(t),                            \
                                         ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
../include/linux/compiler.h:419:22: note: expanded from macro 'compiletime_assert'
        _compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
                            ^~~~~~~~~
../include/linux/compiler.h:407:23: note: expanded from macro '_compiletime_assert'
        __compiletime_assert(condition, msg, prefix, suffix)
                             ^~~~~~~~~
../include/linux/compiler.h:399:9: note: expanded from macro '__compiletime_assert'
                if (!(condition))                                       \
                      ^~~~~~~~~
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:88:34: note: expanded from macro '__smp_store_release'
        compiletime_assert_atomic_type(*p);                             \
                                        ^
../include/linux/compiler.h:422:35: note: expanded from macro 'compiletime_assert_atomic_type'
        compiletime_assert(__native_word(t),                            \
                                         ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
../include/linux/compiler.h:419:22: note: expanded from macro 'compiletime_assert'
        _compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
                            ^~~~~~~~~
../include/linux/compiler.h:407:23: note: expanded from macro '_compiletime_assert'
        __compiletime_assert(condition, msg, prefix, suffix)
                             ^~~~~~~~~
../include/linux/compiler.h:399:9: note: expanded from macro '__compiletime_assert'
                if (!(condition))                                       \
                      ^~~~~~~~~
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:88:34: note: expanded from macro '__smp_store_release'
        compiletime_assert_atomic_type(*p);                             \
                                        ^
../include/linux/compiler.h:422:35: note: expanded from macro 'compiletime_assert_atomic_type'
        compiletime_assert(__native_word(t),                            \
                                         ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
../include/linux/compiler.h:419:22: note: expanded from macro 'compiletime_assert'
        _compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
                            ^~~~~~~~~
../include/linux/compiler.h:407:23: note: expanded from macro '_compiletime_assert'
        __compiletime_assert(condition, msg, prefix, suffix)
                             ^~~~~~~~~
../include/linux/compiler.h:399:9: note: expanded from macro '__compiletime_assert'
                if (!(condition))                                       \
                      ^~~~~~~~~
In file included from ../drivers/kernelsu/selinux/sepolicy.c:2:
In file included from ../drivers/kernelsu/selinux/sepolicy.h:4:
In file included from ../security/selinux/ss/sidtab.h:18:
In file included from ../security/selinux/ss/context.h:19:
In file included from ../security/selinux/ss/ebitmap.h:18:
In file included from ../include/net/netlabel.h:19:
In file included from ../include/linux/slab.h:15:
In file included from ../include/linux/gfp.h:6:
In file included from ../include/linux/mmzone.h:8:
In file included from ../include/linux/spinlock.h:89:
In file included from ../arch/arm64/include/asm/spinlock.h:9:
In file included from ./arch/arm64/include/generated/asm/qspinlock.h:1:
../include/asm-generic/qspinlock.h:94:27: error: no member named 'locked' in 'struct qspinlock'
        smp_store_release(&lock->locked, 0);
                           ~~~~  ^
../include/asm-generic/barrier.h:153:53: note: expanded from macro 'smp_store_release'
#define smp_store_release(p, v) __smp_store_release(p, v)
                                                    ^
../arch/arm64/include/asm/barrier.h:88:34: note: expanded from macro '__smp_store_release'
        compiletime_assert_atomic_type(*p);                             \
                                        ^
../include/linux/compiler.h:422:35: note: expanded from macro 'compiletime_assert_atomic_type'
        compiletime_assert(__native_word(t),                            \
                                         ^
note: (skipping 1 expansions in backtrace; use -fmacro-backtrace-limit=0 to see all)
../include/linux/compiler.h:419:22: note: expanded from macro 'compiletime_assert'
        _compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
                            ^~~~~~~~~
../include/linux/compiler.h:407:23: note: expanded from macro '_compiletime_assert'
        __compiletime_assert(condition, msg, prefix, suffix)
                             ^~~~~~~~~
../include/linux/compiler.h:399:9: note: expanded from macro '__compiletime_assert'
                if (!(condition))                                       \
                      ^~~~~~~~~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[4]: *** [../scripts/Makefile.build:288：drivers/kernelsu/selinux/sepolicy.o] 错误 1
make[3]: *** [../scripts/Makefile.build:558：drivers/kernelsu/selinux] 错误 2
make[2]: *** [../scripts/Makefile.build:558：drivers/kernelsu] 错误 2
make[1]: *** [/home/celica/kernel/Makefile:1845：drivers] 错误 2
make[1]: 离开目录“/home/celica/kernel/out”
make: *** [Makefile:183：sub-make] 错误 2
```