### PR TITLE
kernel: allow override EXPECTED_* by env

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -7,8 +7,14 @@ obj-y += sucompat.o
 
 obj-y += selinux/
 
+ifndef EXPECTED_SIZE
 EXPECTED_SIZE := 0x033b
+endif
+
+ifndef EXPECTED_HASH
 EXPECTED_HASH := 0xb0b91415
+endif
+
 ccflags-y += -DEXPECTED_SIZE=$(EXPECTED_SIZE)
 ccflags-y += -DEXPECTED_HASH=$(EXPECTED_HASH)
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion -Wno-gcc-compat


### PR DESCRIPTION
The original one can only override by `make EXPECTED_SIZE=123 EXPECTED_HASH=123`