### PR TITLE
kernel: fix reboot caused by root_groups

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -30,7 +30,9 @@
 #include "selinux/selinux.h"
 #include "uid_observer.h"
 
-static struct group_info root_groups = { .usage = ATOMIC_INIT(2) };
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	static struct group_info root_groups = { .usage = ATOMIC_INIT(2) };
+#endif
 
 uid_t ksu_manager_uid = INVALID_UID;
 
@@ -64,7 +66,11 @@ void escape_to_root()
 	current->seccomp.filter = NULL;
 
 	// setgroup to root
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
 	cred->group_info = &root_groups;
+#else
+	cred->group_info = &init_groups;
+#endif
 
 	setup_selinux();
 }


### PR DESCRIPTION
After using the latest version of kernelSU, it often reboots, the way to reproduce: after using any application that requires Runtime.getRuntime().exec("su"), close it, reopen it and try to get permission.
After several tests, I found that the problem occurs after modifying init_groups, and after rolling back the code, the compiled kernel runs fine.
Device Redmi/diting, kernel version 5.10.101