### PR TITLE
kernel: Migrate the reference of task_stack()

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -15,9 +15,13 @@
 #include <linux/printk.h>
 #include <linux/string.h>
 #include <linux/kernel.h>
-#include <linux/sched/task_stack.h>
 #include <linux/slab.h>
 #include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#include <linux/sched/task_stack.h>
+#else
+#include <linux/sched.h>
+#endif
 #include <asm-generic/errno-base.h>
 
 #include <linux/rcupdate.h>


### PR DESCRIPTION
- task_stack() had been separated when it was in Linux 4.11, so let's do our migration when KernelSU facing the old version of kernel.
- See https://github.com/gregkh/linux/commit/f3ac60671954c8d413532627b1be13a76f394c49
- This allowed KernelSU to be complied into Linux 4.9 kernel after we did the backportation of selinux_state(), validated in SlightlyLookAround/kernel_for_vince.