### PR TITLE
manager: Add monochrome themed icon on Android 12+

### DIFF
--- a/manager/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/manager/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:fillColor="#ffffff"
+            android:pathData="M 0 0 H 800 V 800 H 0 V 0 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/manager/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#1e110d" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#1e110d"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/manager/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group
+        android:scaleX="0.135"
+        android:scaleY="0.135">
+        <path
+            android:pathData="M 259 259 H 541 V 541 H 259 V 259 Z"
+            android:strokeWidth="18"
+            android:strokeColor="#000000" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 257 257 H 407 V 407 H 257 V 257 Z" />
+        <path
+            android:fillColor="#000000"
+            android:pathData="M 393 393 H 543 V 543 H 393 V 393 Z" />
+    </group>
+</vector>

--- a/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/manager/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>


### PR DESCRIPTION
The icon looks more modern when using themed icon on Android 12+