### PR TITLE
ksud: support set-manager

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -439,6 +439,7 @@ name = "ksud"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cc",
  "clap",
  "const_format",
  "encoding",

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -23,6 +23,9 @@ encoding = "0.2.33"
 retry = "2.0.0"
 humansize = "2.0.0"
 
+[build-dependencies]
+cc = "1.0"
+
 [profile.release]
 strip = true
 opt-level = "z"

--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    cc::Build::new()
+        .file("src/apk_sign.c")
+        .compile("apk_sign");
+}

--- a/userspace/ksud/src/apk_sign.c
+++ b/userspace/ksud/src/apk_sign.c
@@ -1,0 +1,145 @@
+//
+// Created by Thom on 2019/3/8.
+//
+
+// Credits: https://github.com/brevent/genuine/blob/master/src/main/jni/apk-sign-v2.c
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+static bool isApkSigBlock42(const char *buffer) {
+    // APK Sig Block 42
+    return *buffer == 'A'
+           && *++buffer == 'P'
+           && *++buffer == 'K'
+           && *++buffer == ' '
+           && *++buffer == 'S'
+           && *++buffer == 'i'
+           && *++buffer == 'g'
+           && *++buffer == ' '
+           && *++buffer == 'B'
+           && *++buffer == 'l'
+           && *++buffer == 'o'
+           && *++buffer == 'c'
+           && *++buffer == 'k'
+           && *++buffer == ' '
+           && *++buffer == '4'
+           && *++buffer == '2';
+}
+
+int get_signature(const char *path, unsigned int* out_size, unsigned int* out_hash) {
+    unsigned char buffer[0x11] = {0};
+    uint32_t size4;
+    uint64_t size8, size_of_block;
+    int sign = -1;
+    int fd = (int) openat(AT_FDCWD, path, O_RDONLY);
+    if (fd < 0) {
+        return sign;
+    }
+    sign = 1;
+    // https://en.wikipedia.org/wiki/Zip_(file_format)#End_of_central_directory_record_(EOCD)
+    for (int i = 0;; ++i) {
+        unsigned short n;
+        lseek(fd, -i - 2, SEEK_END);
+        read(fd, &n, 2);
+        if (n == i) {
+            lseek(fd, -22, SEEK_CUR);
+            read(fd, &size4, 4);
+            if ((size4 ^ 0xcafebabeu) == 0xccfbf1eeu) {
+                if (i > 0) {
+                    printf("warning: comment length is %d\n", i);
+                }
+                break;
+            }
+        }
+        if (i == 0xffff) {
+            printf("error: cannot find eocd\n");
+            goto clean;
+        }
+    }
+
+    lseek(fd, 12, SEEK_CUR);
+    // offset
+    read(fd, &size4, 0x4);
+    lseek(fd, (off_t) (size4 - 0x18), SEEK_SET);
+
+    read(fd, &size8, 0x8);
+    read(fd, buffer, 0x10);
+    if (!isApkSigBlock42((char *) buffer)) {
+        goto clean;
+    }
+
+    lseek(fd, (off_t) (size4 - (size8 + 0x8)), SEEK_SET);
+    read(fd, &size_of_block, 0x8);
+    if (size_of_block != size8) {
+        goto clean;
+    }
+
+    for (;;) {
+        uint32_t id;
+        uint32_t offset;
+        read(fd, &size8, 0x8); // sequence length
+        if (size8 == size_of_block) {
+            break;
+        }
+        read(fd, &id, 0x4); // id
+        offset = 4;
+        if ((id ^ 0xdeadbeefu) == 0xafa439f5u || (id ^ 0xdeadbeefu) == 0x2efed62f) {
+            read(fd, &size4, 0x4); // signer-sequence length
+            read(fd, &size4, 0x4); // signer length
+            read(fd, &size4, 0x4); // signed data length
+            offset += 0x4 * 3;
+
+            read(fd, &size4, 0x4); // digests-sequence length
+            lseek(fd, (off_t) (size4), SEEK_CUR);// skip digests
+            offset += 0x4 + size4;
+
+            read(fd, &size4, 0x4); // certificates length
+            read(fd, &size4, 0x4); // certificate length
+            offset += 0x4 * 2;
+
+            int hash = 1;
+            signed char c;
+            for (unsigned i = 0; i < size4; ++i) {
+                read(fd, &c, 0x1);
+                hash = 31 * hash + c;
+            }
+            offset += size4;
+            // printf("    size: 0x%04x, hash: 0x%08x\n", size4, ((unsigned) hash) ^ 0x14131211u);
+            printf("size = 0x%04x = %u\n", size4, size4);
+            printf("hash = 0x%08x = %u\n", ((unsigned) hash) ^ 0x14131211u, ((unsigned) hash) ^ 0x14131211u);
+            *out_size = size4;
+            *out_hash = ((unsigned) hash) ^ 0x14131211u;
+
+        }
+        lseek(fd, (off_t) (size8 - offset), SEEK_CUR);
+    }
+
+clean:
+    close(fd);
+
+    return sign;
+}
+
+int set_kernel_param(unsigned int size, unsigned int hash){
+    if (access("/sys/module/kernelsu", F_OK) != 0) {
+        return 0;
+    }
+    if (size == 0 || hash == 0) {
+        return 0;
+    }
+    printf("before:\n");
+    system("printf 'ksu_expected_size: ';cat /sys/module/kernelsu/parameters/ksu_expected_size");
+    system("printf 'ksu_expected_hash: ';cat /sys/module/kernelsu/parameters/ksu_expected_hash");
+    char buf[128];
+    snprintf(buf, 128, "echo %u > /sys/module/kernelsu/parameters/ksu_expected_size", size);
+    system(buf);
+    snprintf(buf, 128, "echo %u > /sys/module/kernelsu/parameters/ksu_expected_hash", hash);
+    system(buf);
+    printf("after:\n");
+    system("printf 'ksu_expected_size: ';cat /sys/module/kernelsu/parameters/ksu_expected_size");
+    system("printf 'ksu_expected_hash: ';cat /sys/module/kernelsu/parameters/ksu_expected_hash");
+    return 1;
+}

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 
-use crate::{event, module};
+use crate::{event, module, debug};
 
 /// KernelSU userspace cli
 #[derive(Parser, Debug)]
@@ -39,6 +39,19 @@ enum Commands {
 
     /// For test
     Test,
+
+    /// For KSU_DEBUG
+    Debug {
+        #[command(subcommand)]
+        command: Debug,
+    },
+}
+#[derive(clap::Subcommand, Debug)]
+enum Debug {
+    SetManager {
+        /// manager apk path or package name
+        apk: String,
+    }
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -94,6 +107,12 @@ pub fn run() -> Result<()> {
         Commands::Sepolicy => todo!(),
         Commands::Services => event::on_services(),
         Commands::Test => event::do_systemless_mount("/data/adb/ksu/modules"),
+
+        Commands::Debug { command } => {
+            match command {
+                Debug::SetManager { apk } => debug::set_manager(&apk),
+            }
+        }
     };
 
     if let Err(e) = &result {

--- a/userspace/ksud/src/debug.rs
+++ b/userspace/ksud/src/debug.rs
@@ -1,0 +1,54 @@
+use anyhow::{Result, Ok};
+use std::{ffi::c_int, process::Command};
+
+extern {
+    fn get_signature(input: *const u8,
+        out_size: *mut u32,
+        out_hash: *mut u32) -> c_int;
+
+    fn set_kernel_param(size: u32, hash: u32) -> c_int;
+}
+
+fn get_apk_signature(apk: &str) -> (u32, u32){
+    let mut out_size: u32 = 0;
+    let mut out_hash: u32 = 0;
+    unsafe{
+        get_signature(apk.as_ptr(), &mut out_size, &mut out_hash);
+    }
+    (out_size, out_hash)
+}
+
+fn get_apk_path(package_name: &str) -> String {
+    let mut cmd = "pm path ".to_string();
+    cmd += package_name;
+    cmd += &" | sed 's/package://g'".to_string();
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        .output()
+        .unwrap();
+    let out = String::from_utf8(output.stdout).unwrap();
+    return out;
+}
+
+pub fn set_manager(apk: &str) -> Result<()> {
+    if apk.ends_with(".apk") {
+        let sign = get_apk_signature(apk);
+        unsafe{
+            set_kernel_param(sign.0, sign.1);
+        }
+    } else {
+        let path = get_apk_path(apk);
+        let path = String::from(path.trim());
+        println!("path: {}", path);
+        if path.ends_with(".apk") {
+            let sign = get_apk_signature(path.as_str());
+            unsafe{
+                set_kernel_param(sign.0, sign.1);
+            }
+        }else{
+            println!("Invalid argument!");
+        }
+    }
+    Ok(())
+}

--- a/userspace/ksud/src/main.rs
+++ b/userspace/ksud/src/main.rs
@@ -4,6 +4,7 @@ mod module;
 mod defs;
 mod utils;
 mod restorecon;
+mod debug;
 
 fn main() -> anyhow::Result<()> {
     cli::run()


### PR DESCRIPTION
```
rubens:/data/local/tmp # ./ksud debug set-manager me.weishu.kernelsu
path: /data/app/~~ZwJ4luNp9CbpsvYNjju-yA==/me.weishu.kernelsu-HzTy2dCAyVeBQuPj26RNag==/base.apk
size = 0x033b = 827
hash = 0xb0b91415 = 2964919317
before:
ksu_expected_size: 827
ksu_expected_hash: 2964919317
after:
ksu_expected_size: 827
ksu_expected_hash: 2964919317
rubens:/data/local/tmp # ./ksud debug set-manager /data/app/~~ZwJ4luNp9CbpsvYNjju-yA==/me.weishu.kernelsu-HzTy2dCAyVeBQuPj26RNag==/base.apk
size = 0x033b = 827
hash = 0xb0b91415 = 2964919317
before:
ksu_expected_size: 827
ksu_expected_hash: 2964919317
after:
ksu_expected_size: 827
ksu_expected_hash: 2964919317
```