### PR TITLE
Fix Navbar color

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
 import androidx.core.view.ViewCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
@@ -46,6 +47,12 @@ fun KernelSUTheme(
         systemUiController.setStatusBarColor(
             color = colorScheme.surface,
             darkIcons = !darkTheme
+        )
+
+        // To match the App Navbar color
+        systemUiController.setNavigationBarColor(
+            color = colorScheme.surfaceColorAtElevation(8.dp),
+            darkIcons = !darkTheme,
         )
     }
 


### PR DESCRIPTION
不是你这为什么Scaffold里套Scaffold啊
那我直接hardcode下navbar的color得了，WindowCompat.setDecorFitsSystemWindows(window, false)又得调一堆padding
before:
![Screenshot_20230129-095009](https://user-images.githubusercontent.com/43900799/215299974-999309a8-dec2-4425-912c-2fffb7113b1d.png)

after:
![Screenshot_20230129-094855](https://user-images.githubusercontent.com/43900799/215299983-7be2f31f-1de0-4940-9e16-c05568e1ee6c.png)
![Screenshot_20230129-094900](https://user-images.githubusercontent.com/43900799/215299985-2fa83f77-289b-468e-b53a-012e136e66f4.png)
![Screenshot_20230129-094919](https://user-images.githubusercontent.com/43900799/215299986-8589883a-bb7f-48c8-9b8b-c963ae6253c4.png)
![Screenshot_20230129-094938](https://user-images.githubusercontent.com/43900799/215299988-da7a091d-c80f-41cc-b1c2-f717d7146d3c.png)
