### PR TITLE
website: Remove "For LineageOS" on MI 8 SE

### DIFF
--- a/website/docs/repos.js
+++ b/website/docs/repos.js
@@ -49,7 +49,7 @@ const repos = [
         maintainer_link: 'https://github.com/SakuraNotStupid', 
         kernel_name: 'android_kernel_xiaomi_sdm710', 
         kernel_link: 'https://github.com/SakuraNotStupid/android_kernel_xiaomi_sdm710',
-        devices: 'MI8SE(sirius) for LineageOS' 
+        devices: 'Xiaomi MI 8 SE(sirius)' 
     },
     { 
         maintainer: 'Aquarius223(paper)', 


### PR DESCRIPTION
Change _MI8SE(sirius) for LineageOS_ To _Xiaomi MI 8 SE(sirius)_

With a lot of tests, it also can use on Crdroid, PixelExperience and so on.