### PR TITLE
kernel: selinux: Fix build error

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,6 +2,9 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#include "avc.h"
+#endif
 
 #define KERNEL_SU_DOMAIN "u:r:su:s0"
 


### PR DESCRIPTION
* d77ab8d although fixed some typo, but since there is no include avc.h, this will cause the build to fail
* Error:

/mnt/HDD/fish/aospa/kernel/msm-4.9/drivers/staging/ksu/selinux/selinux.c:60:2: error: use of undeclared identifier 'selinux_enforcing'
        selinux_enforcing = enforce;
        ^
/mnt/HDD/fish/aospa/kernel/msm-4.9/drivers/staging/ksu/selinux/selinux.c:81:9: error: use of undeclared identifier 'selinux_enforcing'
        return selinux_enforcing;
               ^
2 errors generated.

Change-Id: I4cc8917b2b73ca467873222e02d498da8718988e