### PR TITLE
kernel: Correctly judge the version of selinux_state

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163)
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;


### PR DESCRIPTION
* Merged related changes in android-common-kernel-4.14.163 [1] Handle correct checks for older versions (below 4.14.163, 4.9, 4.4)
* fixes 14be7562, it is required in 4.14.163 kernel, it is not needed in 4.14.163 and later

[1]: https://github.com/MiCode/Xiaomi_Kernel_OpenSource/commits/1cfd8419

Change-Id: Iade104312d058a249667ca836259d5608418bb55