### PR TITLE
kernel: selinux: fix version check for ACK and qcom kernels

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,8 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) &&                        \
+	LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 #include "avc.h"
 #endif
 
@@ -57,7 +58,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +69,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +79,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;


### PR DESCRIPTION
in 3.14, qcom added a change that removes "#include "avc.h"" from objsec.h,
this change was dropped since 4.14.
    
4.14 ack has selinux_state backported by Google (which we should mainly target).