### PR TITLE
fix  KSU_GIT_VERSION is not defined while importing KSU by 'git submodule add'

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -12,8 +12,8 @@ obj-y += embed_ksud.o
 obj-y += kernel_compat.o
 
 obj-y += selinux/
-
-ifeq ($(shell test -d $(srctree)/$(src)/../.git; echo $$?),0)
+# .git is a text file while the module is imported by 'git submodule add'.
+ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
 # We must use the absolute path to git, otherwise the build will fail if git is not in the PATH
 KSU_GIT_VERSION := $(shell cd $(srctree)/$(src);/usr/bin/git rev-list --count HEAD)
 ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)


### PR DESCRIPTION
.git is a text file while the module is imported by 'git submodule add'.