### PR TITLE
kernel: Fix f6967d2c lost parameters after ack-linux 4.14.y (>=163)

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -168,7 +168,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache() {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163)
 	avc_ss_reset(0);
 #else
 	struct selinux_avc *avc = selinux_state.avc;


### PR DESCRIPTION
* [android-4.14-stable tree: https://github.com/aosp-mirror/kernel_common/commit/5d0939e1]

Change-Id: Ice92dd83df4c4f1ae272156cb57f95998e45819f