### PR TITLE
use selinux_state for 4.9.212+

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#if LINUX_VERSION_CODE > KERNEL_VERSION(4, 14, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 212)
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -170,7 +170,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache() {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163)
+#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) || (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 212))
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163)
+#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) || (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 212))
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 212)))
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 212)))
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 212)))
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;
@@ -88,7 +88,7 @@ bool getenforce()
 #endif
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 212)
 /*
  * get the subjective security ID of the current task
  */


### PR DESCRIPTION
_selinux_state_ is backported to 4.9 kernel with the 4.9.212 release, use it to fix the build.
many thanks to @reallysnow for figuring this out.
inspired by https://github.com/ReallySnow/kernel_google_bluecross/commit/d7c2c5f02ad1ce89e746fa14f097ea71fdc4aadc