### PR TITLE
manager: Add key to LazyColumn's items to prevent incorrect allow sta…

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
@@ -100,7 +100,7 @@ fun SuperUserScreen() {
                 .fillMaxSize()
         ) {
             LazyColumn {
-                items(viewModel.appList) { app ->
+                items(viewModel.appList, key = { it.packageName }) { app ->
                     var isChecked by rememberSaveable(app) { mutableStateOf(app.onAllowList) }
                     AppItem(app, isChecked) { checked ->
                         val success = Natives.allowRoot(app.uid, checked)


### PR DESCRIPTION
在超级用户页面，当用户通过搜索结果修改了授权状态，退出搜索后显示的应用列表会出现授权状态显示不正确，需要刷新应用列表才能正确显示。