### PR TITLE
setup: Soft link through relative path

### DIFF
--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -17,13 +17,13 @@ fi
 
 test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/tiann/KernelSU
 cd "$GKI_ROOT/KernelSU"
-git stash && git pull
+git stash && git pull --allow-unrelated-histories
 cd "$GKI_ROOT"
 
 echo "[+] GKI_ROOT: $GKI_ROOT"
 echo "[+] Copy kernel su driver to $DRIVER_DIR"
 
-test -e "$DRIVER_DIR/kernelsu" || ln -sf "$GKI_ROOT/KernelSU/kernel" "$DRIVER_DIR/kernelsu"
+test -e "$DRIVER_DIR/kernelsu" || ln -r -sf "$GKI_ROOT/KernelSU/kernel" "$DRIVER_DIR/kernelsu"
 
 echo '[+] Add kernel su driver to Makefile'
 


### PR DESCRIPTION
In the process of using Github Actions, source code synchronization will generate some errors, and the absolute path method of soft links will cause the folders under the submodule to be unreadable, so this part has been updated to better adapt to Github Actions