### PR TITLE
kernel: Add input hook to ksu_hooks.h

### DIFF
--- a/kernel/include/ksu_hook.h
+++ b/kernel/include/ksu_hook.h
@@ -21,4 +21,8 @@ int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 int ksu_handle_execveat(int *fd, struct filename **filename_ptr, void *argv,
 			void *envp, int *flags);
 
+// For volume button
+int ksu_handle_input_handle_event(unsigned int *type, unsigned int *code, 
+				  int *value);
+
 #endif


### PR DESCRIPTION
Then we don't have to do extern input_hook(...) ; input_hook(..) and just include header file and use input_hook(...) only
Like https://github.com/hac4us06/kernel_xiaomi_chime/commit/f39f4823a196c1cb66df10e96c93dfb97872a4c4
Not
https://github.com/hac4us06/kernel_xiaomi_chime/commit/0c491aca8a7c41c5d0b11616dccec6ab54e41082