### PR TITLE
kernel: use git from PATH

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,8 +14,7 @@ obj-y += kernel_compat.o
 obj-y += selinux/
 # .git is a text file while the module is imported by 'git submodule add'.
 ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
-# We must use the absolute path to git, otherwise the build will fail if git is not in the PATH
-KSU_GIT_VERSION := $(shell cd $(srctree)/$(src);/usr/bin/git rev-list --count HEAD)
+KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); git rev-list --count HEAD)
 ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)
 endif
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,7 +14,7 @@ obj-y += kernel_compat.o
 obj-y += selinux/
 # .git is a text file while the module is imported by 'git submodule add'.
 ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
-KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); git rev-list --count HEAD)
+KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH=$$PATH:/usr/bin:/usr/local/bin git rev-list --count HEAD)
 ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)
 endif
 


### PR DESCRIPTION
One should have git in PATH in order to build Android kernel.
Also it's weird that git is used in `setup.sh` without absolute path.