### PR TITLE
ksud: Fix installer.sh modules path

### DIFF
--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -434,7 +434,7 @@ install_module() {
 [ -z $BOOTMODE ] && ps -A 2>/dev/null | grep zygote | grep -qv grep && BOOTMODE=true
 [ -z $BOOTMODE ] && BOOTMODE=false
 
-NVBASE=/data/adb/ksu
+NVBASE=/data/adb
 TMPDIR=/dev/tmp
 
 # Some modules dependents on this

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -337,7 +337,7 @@ install_module() {
   [ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
 
   local MODDIRNAME=modules
-  $BOOTMODE && MODDIRNAME=modules_update
+  $BOOTMODE && MODDIRNAME=ksu/modules_update
   local MODULEROOT=$NVBASE/$MODDIRNAME
   MODID=`grep_prop id $TMPDIR/module.prop`
   MODNAME=`grep_prop name $TMPDIR/module.prop`


### PR DESCRIPTION
https://github.com/tiann/KernelSU/commit/ee09b9f9f4c1b42da3af5cc4df96629e4f6c0745 修改了模块路径，installer.sh 没有修改，导致管理器无法刷新模块(安装/更新/卸载)状态