### PR TITLE
ksud: modules_update will be mounted to /data/adb/modules_update

### DIFF
--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -14,7 +14,7 @@ pub const MODULE_UPDATE_IMG: &str = concatcp!(WORKING_DIR, "modules_update.img")
 pub const MODULE_UPDATE_TMP_IMG: &str = concatcp!(WORKING_DIR, "update_tmp.img");
 
 // warning: this directory should not change, or you need to change the code in module_installer.sh!!!
-pub const MODULE_UPDATE_TMP_DIR: &str = concatcp!(WORKING_DIR, "modules_update/");
+pub const MODULE_UPDATE_TMP_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
 
 pub const DISABLE_FILE_NAME: &str = "disable";
 pub const UPDATE_FILE_NAME: &str = "update";

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -337,7 +337,7 @@ install_module() {
   [ ! -f $TMPDIR/module.prop ] && abort "! Unable to extract zip file!"
 
   local MODDIRNAME=modules
-  $BOOTMODE && MODDIRNAME=ksu/modules_update
+  $BOOTMODE && MODDIRNAME=modules_update
   local MODULEROOT=$NVBASE/$MODDIRNAME
   MODID=`grep_prop id $TMPDIR/module.prop`
   MODNAME=`grep_prop name $TMPDIR/module.prop`


### PR DESCRIPTION
https://github.com/tiann/KernelSU/commit/ee09b9f9f4c1b42da3af5cc4df96629e4f6c0745 and https://github.com/tiann/KernelSU/pull/327 have moved /data/adb/ksu/modules to /data/adb/modules,but modules_update has not to do it.Many modules hard-coded this directory.