### PR TITLE
kernel: fix search git in path

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -14,7 +14,7 @@ obj-y += kernel_compat.o
 obj-y += selinux/
 # .git is a text file while the module is imported by 'git submodule add'.
 ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
-KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH=$$PATH:/usr/bin:/usr/local/bin git rev-list --count HEAD)
+KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git rev-list --count HEAD)
 ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)
 endif
 


### PR DESCRIPTION
Prevent failing to get KSU_GIT_VERSION when PATH contains space.

[Details](https://github.com/5ec1cff/my-notes/blob/master/mi-kernel.md#%E4%B8%80%E4%B8%AA%E7%BC%BA%E5%B0%91%E5%BC%95%E5%8F%B7%E5%BC%95%E5%8F%91%E7%9A%84%E8%A1%80%E6%A1%88)