### PR TITLE
promotion: KernelSU integrated Bool-X kernel for raphael

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -194,5 +194,12 @@
         "kernel_name": "kernel_oneplus_msm8998",
         "kernel_link": "https://github.com/TheNoFace/kernel_oneplus_msm8998",
         "devices": "OnePlus 5/5T"
+    },
+    {
+        "maintainer": "Evans Mike",
+        "maintainer_link": "https://github.com/etnperlong",
+        "kernel_name": "kernel_xiaomi_raphael_bool-x",
+        "kernel_link": "https://github.com/etnperlong/kernel_xiaomi_raphael_bool-x",
+        "devices": "Xiaomi Redmi K20 Pro / Mi 9T Pro (raphael)"
     }
 ]


### PR DESCRIPTION
Hi, I have made yet another KernelSU integrated kernel for Redmi #K20Pro (#Raphael), based on a popular custom & optimized kernel called Bool-X in the community.

Forked source code: https://github.com/etnperlong/kernel_xiaomi_raphael_bool-x/tree/13.0-ksu
upstream source: https://github.com/onettboots/bool-x_xiaomi_raphael (thanks to @onettboots)

I have tested the KernelSU feature on this kernel, everything works fine.