### PR TITLE
Ensure the stability of use

### DIFF
--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -18,7 +18,7 @@ fi
 test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/tiann/KernelSU
 cd "$GKI_ROOT/KernelSU"
 git stash && git pull
-git checkout $(git describe --abbrev=0 --tags)
+git checkout "$(git describe --abbrev=0 --tags)"
 cd "$GKI_ROOT"
 
 echo "[+] GKI_ROOT: $GKI_ROOT"

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -18,6 +18,7 @@ fi
 test -d "$GKI_ROOT/KernelSU" || git clone https://github.com/tiann/KernelSU
 cd "$GKI_ROOT/KernelSU"
 git stash && git pull
+git checkout $(git describe --abbrev=0 --tags)
 cd "$GKI_ROOT"
 
 echo "[+] GKI_ROOT: $GKI_ROOT"


### PR DESCRIPTION
I think we can add tag selection commands in the setup.sh script, such as git checkout v0.5.1, to ensure the stability of use #379 