### PR TITLE
selinux: clamp 4.9 SUBLEVEL to 255

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 337)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 255)
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -172,7 +172,7 @@ static void reset_avc_cache()
 {
 #if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) &&                       \
      (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) ||                     \
-	(LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337))
+	(LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 255))
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) || (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337))
+#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) || (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 255))
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || (LINUX_VERSION_CODE == KERNEL_VERSION(4, 9, 255))
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || (LINUX_VERSION_CODE == KERNEL_VERSION(4, 9, 255))
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || (LINUX_VERSION_CODE == KERNEL_VERSION(4, 9, 255))
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;
@@ -88,7 +88,7 @@ bool getenforce()
 #endif
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 255)
 /*
  * get the subjective security ID of the current task
  */


### PR DESCRIPTION
#324 is making the checks too strict that it is not requiring 4.9.337 but an updated `KERNEL_VERSION`. The official [4.9.337 Makefile](https://github.com/aosp-mirror/kernel_common/blob/f9b8314c64640cd10c7b14ce9d2a11a0dc02a941/Makefile#L1238) and even the latest [4.14](https://github.com/aosp-mirror/kernel_common/blob/3bfa20247ddad0861bd900b40e9c25e6f22c59dc/Makefile#L1337) and [4.19](https://github.com/aosp-mirror/kernel_common/blob/9b68392a2b5860995364db295d0d869b413fdfdf/Makefile#L1280) ones do not have a correct `KERNEL_VERSION` that clamps the subversion to 255 like their `LINUX_VERSION_CODE` do. The earliest kernel with a correct `KERNEL_VERSION` is 5.4 by [this commit](https://github.com/aosp-mirror/kernel_common/commit/e9be5518af2c1cd110824bd8b3327aedd9a80104). Comparing the 5.x commit with the 4.x ones (e.g. [this](https://github.com/aosp-mirror/kernel_common/commit/42efb098c75f9d4b95f7cf35d3d52e80cc2fde82)), it feels like an AOSP oversight but whatever we should adapt to it.

Fixes #400.