### PR TITLE
selinux: use grep to check api supports

### DIFF
--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -2,12 +2,13 @@ obj-y += selinux.o
 obj-y += sepolicy.o
 obj-y += rules.o
 
-ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
-ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
-endif
-
-ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
-ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
+ifeq ($(shell [ $(VERSION) -lt 5 -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -lt 10 \) ]; echo $$?), 0)
+  ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
+  ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
+  endif
+  ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
+  ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
+  endif
 endif
 
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -2,7 +2,7 @@ obj-y += selinux.o
 obj-y += sepolicy.o
 obj-y += rules.o
 
-ifeq ($(shell [ $(VERSION) -lt 5 -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -lt 10 \) ]; echo $$?), 0)
+ifeq ($(shell [ $(VERSION) -lt 5 -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -lt 10 \) ]; echo $$?),0)
   ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
   ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
   endif

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -7,7 +7,7 @@ ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
 endif
 
 ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
-ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
+ccflags-y += -DKSU_COMPAT_HAS_SELINUX_STATE
 endif
 
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -2,6 +2,13 @@ obj-y += selinux.o
 obj-y += sepolicy.o
 obj-y += rules.o
 
+ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
+ccflags-y += -DHAS_CURRENT_SID
+endif
+
+ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
+ccflags-y += -DUSE_SELINUX_STATE
+endif
 
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion
 ccflags-y += -Wno-macro-redefined -Wno-declaration-after-statement -Wno-unused-function

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -3,11 +3,11 @@ obj-y += sepolicy.o
 obj-y += rules.o
 
 ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
-ccflags-y += -DHAS_CURRENT_SID
+ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
 endif
 
 ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
-ccflags-y += -DUSE_SELINUX_STATE
+ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
 endif
 
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion

--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -2,13 +2,12 @@ obj-y += selinux.o
 obj-y += sepolicy.o
 obj-y += rules.o
 
-ifeq ($(shell [ $(VERSION) -lt 5 -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -lt 10 \) ]; echo $$?),0)
-  ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
-  ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
-  endif
-  ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
-  ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
-  endif
+ifeq ($(shell grep -q " current_sid(void)" $(srctree)/security/selinux/include/objsec.h; echo $$?),0)
+ccflags-y += -DKSU_COMPAT_HAS_CURRENT_SID
+endif
+
+ifeq ($(shell grep -q "struct selinux_state " $(srctree)/security/selinux/include/security.h; echo $$?),0)
+ccflags-y += -DKSU_COMPAT_USE_SELINUX_STATE
 endif
 
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#ifdef USE_SELINUX_STATE
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -170,7 +170,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache()
 {
-#ifndef USE_SELINUX_STATE
+#ifndef KSU_COMPAT_USE_SELINUX_STATE
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#ifdef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -170,7 +170,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache()
 {
-#ifndef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)) && !defined(KSU_COMPAT_USE_SELINUX_STATE)
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -170,7 +170,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache()
 {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)) && !defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifndef KSU_COMPAT_USE_SELINUX_STATE
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -22,7 +22,7 @@ static struct policydb *get_policydb(void)
 {
 	struct policydb *db;
 // selinux_state does not exists before 4.19
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 337)
+#ifdef USE_SELINUX_STATE
 #ifdef SELINUX_POLICY_INSTEAD_SELINUX_SS
 	struct selinux_policy *policy = rcu_dereference(selinux_state.policy);
 	db = &policy->policydb;
@@ -170,9 +170,7 @@ static int get_object(char *buf, char __user *user_object, size_t buf_sz,
 // reset avc cache table, otherwise the new rules will not take effect if already denied
 static void reset_avc_cache()
 {
-#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) &&                       \
-     (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) ||                     \
-	(LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337))
+#ifndef USE_SELINUX_STATE
 	avc_ss_reset(0);
 	selnl_notify_policyload(0);
 	selinux_status_update_policyload(0);

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if ((KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 163))) || (LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337))
+#ifndef USE_SELINUX_STATE
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#ifdef USE_SELINUX_STATE
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#ifdef USE_SELINUX_STATE
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 163)) || ((KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE) && (LINUX_VERSION_CODE  >= KERNEL_VERSION(4, 9, 337)))
+#ifdef USE_SELINUX_STATE
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;
@@ -88,7 +88,7 @@ bool getenforce()
 #endif
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 337)
+#ifndef HAS_CURRENT_SID
 /*
  * get the subjective security ID of the current task
  */

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#ifndef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)) && !defined(KSU_COMPAT_USE_SELINUX_STATE)
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#ifdef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#ifdef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#ifdef KSU_COMPAT_USE_SELINUX_STATE
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;
@@ -88,7 +88,7 @@ bool getenforce()
 #endif
 }
 
-#ifndef KSU_COMPAT_HAS_CURRENT_SID
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)) && !defined(KSU_COMPAT_HAS_CURRENT_SID)
 /*
  * get the subjective security ID of the current task
  */

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#ifndef USE_SELINUX_STATE
+#ifndef KSU_COMPAT_USE_SELINUX_STATE
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#ifdef USE_SELINUX_STATE
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#ifdef USE_SELINUX_STATE
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#ifdef USE_SELINUX_STATE
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;
@@ -88,7 +88,7 @@ bool getenforce()
 #endif
 }
 
-#ifndef HAS_CURRENT_SID
+#ifndef KSU_COMPAT_HAS_CURRENT_SID
 /*
  * get the subjective security ID of the current task
  */

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -2,7 +2,7 @@
 #include "objsec.h"
 #include "linux/version.h"
 #include "../klog.h" // IWYU pragma: keep
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0)) && !defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifndef KSU_COMPAT_USE_SELINUX_STATE
 #include "avc.h"
 #endif
 
@@ -57,7 +57,7 @@ if (!is_domain_permissive) {
 void setenforce(bool enforce)
 {
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	selinux_state.enforcing = enforce;
 #else
 	selinux_enforcing = enforce;
@@ -68,7 +68,7 @@ void setenforce(bool enforce)
 bool getenforce()
 {
 #ifdef CONFIG_SECURITY_SELINUX_DISABLE
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	if (selinux_state.disabled) {
 #else
 	if (selinux_disabled) {
@@ -78,7 +78,7 @@ bool getenforce()
 #endif
 
 #ifdef CONFIG_SECURITY_SELINUX_DEVELOP
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_USE_SELINUX_STATE)
+#ifdef KSU_COMPAT_USE_SELINUX_STATE
 	return selinux_state.enforcing;
 #else
 	return selinux_enforcing;

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -2,6 +2,11 @@
 #define __KSU_H_SELINUX
 
 #include "linux/types.h"
+#include "linux/version.h"
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)) || defined(KSU_COMPAT_HAS_SELINUX_STATE)
+#define KSU_COMPAT_USE_SELINUX_STATE
+#endif
 
 void setup_selinux();
 


### PR DESCRIPTION
This checks `selinux_state` and `current_sid` supports in a raw way. Feels more reliable than the version checks.

Supersedes #401, fixes #280, fixes #400.