### PR TITLE
readme: fix credits link title of genuine project

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -37,6 +37,6 @@ WSA 和运行在容器上的 Android 也可以与 KernelSU 一起工作。
 ## 鸣谢
 
 - [kernel-assisted-superuser](https://git.zx2c4.com/kernel-assisted-superuser/about/)：KernelSU 的灵感。
-- [true](https://github.com/brevent/genuine/)：apk v2 签名验证。
+- [genuine](https://github.com/brevent/genuine/)：apk v2 签名验证。
 - [Diamorphine](https://github.com/m0nad/Diamorphine)：一些 rootkit 技巧。
 - [Magisk](https://github.com/topjohnwu/Magisk)：sepolicy 的实现。

--- a/README_TW.md
+++ b/README_TW.md
@@ -37,6 +37,6 @@ WSA 和執行在容器中的 Android 也可以與 KernelSU 一同運作。
 ## 致謝
 
 - [kernel-assisted-superuser](https://git.zx2c4.com/kernel-assisted-superuser/about/)：KernelSU 的靈感。
-- [true](https://github.com/brevent/genuine/)：apk v2 簽章驗證。
+- [genuine](https://github.com/brevent/genuine/)：apk v2 簽章驗證。
 - [Diamorphine](https://github.com/m0nad/Diamorphine)：一些 rootkit 技巧。
 - [Magisk](https://github.com/topjohnwu/Magisk)：sepolicy 實作。


### PR DESCRIPTION
The credit link title of [genuine](https://github.com/brevent/genuine) in `README_CN.md` and `README_TW.md` is `true`.