### PR TITLE
kernel: Use a better way to link submodule directory

### DIFF
--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -32,7 +32,13 @@ cd "$GKI_ROOT"
 echo "[+] GKI_ROOT: $GKI_ROOT"
 echo "[+] Copy kernel su driver to $DRIVER_DIR"
 
-test -e "$DRIVER_DIR/kernelsu" || ln -sf "$GKI_ROOT/KernelSU/kernel" "$DRIVER_DIR/kernelsu"
+cd "$DRIVER_DIR"
+if test -d "$GKI_ROOT/common/drivers"; then
+     ln -sf "../../KernelSU/kernel" "kernelsu"
+elif test -d "$GKI_ROOT/drivers"; then
+     ln -sf "../KernelSU/kernel" "kernelsu"
+fi
+cd "$GKI_ROOT"
 
 echo '[+] Add kernel su driver to Makefile'
 


### PR DESCRIPTION
Use ../ instead of absolute path