### PR TITLE
kernel: Kconfig: Remove KPROBES dependancy

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1,7 +1,6 @@
 config KSU
 	tristate "KernelSU module"
 	default y
-	depends on KPROBES
 	depends on OVERLAY_FS
 	help
 	This is the KSU privilege driver for android system.


### PR DESCRIPTION
For those who want to Implement KernelSU Manually with KPROBES disabled.

When KPROBES Broken and Still enabled, this will causing Loop at splash logo even Already Manually Imported because this https://github.com/tiann/KernelSU/blob/842c0b674feaa4f6522452c8dc2ad2837f99892c/kernel/ksu.c#L57. And when KPROBES is disabled, KSU also will not compiled (I Know it'll still build if obj-y is set for KSU, but it's better to remove, who knows if someone set as obj-$(CONFIG_KSU)).