### PR TITLE
Add option to enable global namespace

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -1,5 +1,6 @@
 #include "linux/fs.h"
 #include "linux/module.h"
+#include "linux/moduleparam.h"
 #include "linux/workqueue.h"
 
 #include "allowlist.h"
@@ -8,6 +9,9 @@
 #include "klog.h" // IWYU pragma: keep
 #include "ksu.h"
 #include "uid_observer.h"
+
+int global_namespace_enable;
+module_param(global_namespace_enable, int, S_IRUSR | S_IWUSR);
 
 static struct workqueue_struct *ksu_workqueue;
 

--- a/userspace/ksud/src/ksu.rs
+++ b/userspace/ksud/src/ksu.rs
@@ -229,7 +229,10 @@ pub fn root_shell() -> Result<()> {
 
             // switch to global mount namespace
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            if mount_master {
+            let global_namespace_enable =
+                std::fs::read_to_string("/sys/module/ksu/parameters/global_namespace_enable")
+                    .unwrap_or("0".to_string());
+            if global_namespace_enable.trim() == "1" || mount_master {
                 let _ = utils::switch_mnt_ns(1);
                 let _ = utils::unshare_mnt_ns();
             }


### PR DESCRIPTION
Disabled by default.
To enable/disable use terminal with root.

To enable:
echo 1 > /sys/module/ksu/parameters/global_namespace_enable

To disable:
echo 0 > /sys/module/ksu/parameters/global_namespace_enable

Value will be reset to 0 (disabled) on reboot.