### PR TITLE
Revert da46dfb

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -391,7 +391,7 @@ static void try_umount(const char *mnt)
 	}
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
-	err = path_umount(&path, MNT_DETACH);
+	err = path_umount(&path, 0);
 	if (err) {
 		pr_info("umount %s failed: %d\n", mnt, err);
 	}


### PR DESCRIPTION
确实会导致卡住问题，一旦卡住，其他程序就无法正确卸载。
可能是，卸载目录那里一直在等待前面的空闲后再卸载，然后把后面的事件全部阻塞了？