### PR TITLE
kernel: Modify and adjust KernelSU Kconfig

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1,13 +1,17 @@
+menu "KernelSU"
+
 config KSU
 	tristate "KernelSU module"
+	select OVERLAY_FS
 	default y
-	depends on OVERLAY_FS
 	help
 	This is the KSU privilege driver for android system.
 
 config KSU_DEBUG
-	tristate "KernelSU module debug mode"
-	default n
+	bool "KernelSU module debug mode"
 	depends on KSU
+	default n
 	help
 	This enables debug mode for KSU
+
+endmenu


### PR DESCRIPTION
1. List KSU as a "KernelSU" menu
2. Overlayfs[1] may be disabled for some early kernels(4.4.y), so choosing depends on OVERLAY_FS here is useless.
3. KSU_DEBUG is a bool option, it is not a module, fixed from tristate to bool.
4. Adjust the config order

[1]: github.com/LineageOS/android_kernel_xiaomi_msm8998/commit/dcc27641

Change-Id: I49c77ba30f0a8ed00efc44afef8a12f9ad039d7e