### PR TITLE
change warning about disable kprobes

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -57,7 +57,7 @@ int __init kernelsu_init(void)
 	ksu_enable_sucompat();
 	ksu_enable_ksud();
 #else
-#warning("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html")
+	pr_alert("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html");
 #endif
 
 	return 0;


### PR DESCRIPTION
According to the instructions in #479, integrating kernelSU can not require enabling kprobes, but when manually integrating KernelSU in android kernel 4.4-4.9, the following error may appear:


In file included from /home/synaptic/android_kernel_oppo_sdm660/drivers/
/home/synaptic/android_kernel_oppo_sdm660/drivers/kernelsu/uid_observer.c:12:0:
/drivers/kernelsu/ksu.c:60:2: warning: #warning"KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html"
 [-Wcpp]
error, forbidden warning: ksu.c:60
make[3]: *** [/home/synaptic/android_kernel_oppo_sdm660/scripts/Makefile.build:282: drivers/kernelsu/uid_observer.o] Error 1