### PR TITLE
setup.sh:change obj-y > obj-$(CONFIG_KSU)

### DIFF
--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -45,5 +45,6 @@ echo '[+] Add kernel su driver to Makefile'
 DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
 grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
-grep -q "kernelsu" "$DRIVER_KCONFIG" || printf printf "source \"drivers/kernelsu/Kconfig\"\n" >> "$DRIVER_KCONFIG"
+KSU_CONFIG=$(printf "source \"drivers/kernelsu/Kconfig\"\n")
+grep -q "kernelsu" "$DRIVER_KCONFIG" || sed  "4i\\$text" "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -46,5 +46,5 @@ DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
 grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
 KSU_CONFIG=$(printf "source \"drivers/kernelsu/Kconfig\"\n")
-grep -q "kernelsu" "$DRIVER_KCONFIG" || sed  "4i\\$text" "$DRIVER_KCONFIG"
+grep -q "kernelsu" "$DRIVER_KCONFIG" || sed  "4i\\$KSU_CONFIG" "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -43,7 +43,7 @@ cd "$GKI_ROOT"
 echo '[+] Add kernel su driver to Makefile'
 
 DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
-grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
+grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
 grep -q "kernelsu" "$DRIVER_KCONFIG" || printf "\nsource drivers/kernelsu/Kconfig\n" >> "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -45,6 +45,6 @@ echo '[+] Add kernel su driver to Makefile'
 DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
 grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
-KSU_CONFIG=$(printf "source \"drivers/kernelsu/Kconfig\"\n")
+KSU_CONFIG=$(printf 'source "%s"\n' "drivers/kernelsu/Kconfig")
 grep -q "kernelsu" "$DRIVER_KCONFIG" || sed -i  "4i\\$KSU_CONFIG" "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -45,5 +45,5 @@ echo '[+] Add kernel su driver to Makefile'
 DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
 grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
-grep -q "kernelsu" "$DRIVER_KCONFIG" || printf "\nsource drivers/kernelsu/Kconfig\n" >> "$DRIVER_KCONFIG"
+grep -q "kernelsu" "$DRIVER_KCONFIG" || printf printf "source \"drivers/kernelsu/Kconfig\"\n" >> "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -43,6 +43,7 @@ cd "$GKI_ROOT"
 echo '[+] Add kernel su driver to Makefile'
 
 DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
-grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-y += kernelsu/\n" >> "$DRIVER_MAKEFILE"
-
+grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
+DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
+grep -q "kernelsu" "$DRIVER_KCONFIG" || printf "\nsource drivers/kernelsu/Kconfig\n" >> "$DRIVER_KCONFIG"
 echo '[+] Done.'

--- a/kernel/setup.sh
+++ b/kernel/setup.sh
@@ -46,5 +46,5 @@ DRIVER_MAKEFILE=$DRIVER_DIR/Makefile
 grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
 DRIVER_KCONFIG=$DRIVER_DIR/Kconfig
 KSU_CONFIG=$(printf "source \"drivers/kernelsu/Kconfig\"\n")
-grep -q "kernelsu" "$DRIVER_KCONFIG" || sed  "4i\\$KSU_CONFIG" "$DRIVER_KCONFIG"
+grep -q "kernelsu" "$DRIVER_KCONFIG" || sed -i  "4i\\$KSU_CONFIG" "$DRIVER_KCONFIG"
 echo '[+] Done.'


### PR DESCRIPTION
In my opinion, change "obj-y" to "obj-$(CONFIG_KSU)". I feel that this can decide whether to compile KernelSU instead of the previous forced compilation based on whether the "CONFIG_KSU" option is enabled or not. The source kconfig option has also been added. This allows you to see the KernelSU option in the "Device Drivers" option in menuconfig.