### PR TITLE
kernel/selinux: Need to force include errno.h sometimes

### DIFF
--- a/kernel/selinux/Makefile
+++ b/kernel/selinux/Makefile
@@ -13,4 +13,4 @@ endif
 ccflags-y += -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-int-conversion
 ccflags-y += -Wno-declaration-after-statement -Wno-unused-function
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
-ccflags-y += -I$(objtree)/security/selinux
+ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h


### PR DESCRIPTION
- Seen with Linux 4.14 kernel with error message:

In file included from ../drivers/android/kernelsu/selinux/sepolicy.c:1: In file included from ../drivers/android/kernelsu/selinux/sepolicy.h:6: In file included from ../security/selinux/ss/policydb.h:30: In file included from ../security/selinux/ss/avtab.h:26: ../security/selinux/include/security.h:240:10: error: use of undeclared identifier 'EIDRM'
        return -EIDRM;
                ^
  CC      drivers/base/transport_class.o
  CC      kernel/rcu/update.o
../security/selinux/include/security.h:246:10: error: use of undeclared identifier 'ENOENT'
        return -ENOENT;
                ^