### PR TITLE
Fixup: build under linux 4.14

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -1,6 +1,5 @@
 #include "ksu.h"
 #include "linux/compiler.h"
-#include "linux/compiler_types.h"
 #include "linux/fs.h"
 #include "linux/gfp.h"
 #include "linux/kernel.h"
@@ -8,6 +7,10 @@
 #include "linux/printk.h"
 #include "linux/slab.h"
 #include "linux/version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
+#include "linux/compiler_types.h"
+#endif
+
 #include "klog.h" // IWYU pragma: keep
 #include "selinux/selinux.h"
 #include "kernel_compat.h"


### PR DESCRIPTION
Split compiler_types.h from compiler.h only available for linux 4.14