### PR TITLE
ksud.c:Fix the issue of incompatible __maybe_unused in the GCC compiler kernel used in versions 4.4. x to 4.9. x.

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -114,8 +114,6 @@ static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
  * Test passed in 4.4.x ~ 4.9.x when use GCC.
  */
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) &&                           \
-	LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
 static int __maybe_unused count(struct user_arg_ptr argv, int max)
 {
 	int i = 0;
@@ -141,33 +139,6 @@ static int __maybe_unused count(struct user_arg_ptr argv, int max)
 	}
 	return i;
 }
-#else
-static int count(struct user_arg_ptr argv, int max) __maybe_unused
-{
-	int i = 0;
-
-	if (argv.ptr.native != NULL) {
-		for (;;) {
-			const char __user *p = get_user_arg_ptr(argv, i);
-
-			if (!p)
-				break;
-
-			if (IS_ERR(p))
-				return -EFAULT;
-
-			if (i >= max)
-				return -E2BIG;
-			++i;
-
-			if (fatal_signal_pending(current))
-				return -ERESTARTNOHAND;
-			cond_resched();
-		}
-	}
-	return i;
-}
-#endif
 
 int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 			     void *argv, void *envp, int *flags)

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -110,13 +110,13 @@ static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
  */
 
  /*
- * Not all kernel support __maybe_unused,
- * Test in 4.4.x ~ 4.9.x when use GCC.
+ * Make sure old GCC compiler can use __maybe_unused,
+ * Test passed in 4.4.x ~ 4.9.x when use GCC.
  */
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) &&                           \
 	LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
-static int count(struct user_arg_ptr argv, int max)
+static int __maybe_unused count(struct user_arg_ptr argv, int max)
 {
 	int i = 0;
 


### PR DESCRIPTION
Not all use GCC compiler kernel support __maybe_unused.Use __maybe_unused will cost compile error.  
Tested different versions of the kernel from versions 4.4 to 4.9.  
Test list:
4.4.x:Xiaomi 6 stock kernel and Huawei hi3660 Proto kernel
4.9.x:OnePlus 6/6T kernel(GCC vsrsion can't use  __maybe_unused,Clang Version can use  __maybe_unused),Huawei Pangu hi3660 Kernel and Xiaomi 8(Clang Version can use __maybe_unused) .