### PR TITLE
Remove fontFamily from the Unsupported Warning

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
@@ -216,7 +216,6 @@ private fun StatusCard(kernelVersion: KernelVersion, ksuVersion: Int?) {
                     Column(Modifier.padding(start = 20.dp)) {
                         Text(
                             text = stringResource(R.string.home_unsupported),
-                            fontFamily = FontFamily.Serif,
                             style = MaterialTheme.typography.titleMedium
                         )
                         Spacer(Modifier.height(4.dp))


### PR DESCRIPTION
Just a small design fix, to make the Unsupported Warning text have the same font as the Working text.

## Before
![before](https://github.com/tiann/KernelSU/assets/77107077/7e3f2382-446a-4039-8bec-d72c7e4471b3)

## After
![after](https://github.com/tiann/KernelSU/assets/77107077/31905aa3-a274-4289-b51b-0c45bbeee90e)

