### PR TITLE
kernel: print the current KernelSU version at build time

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -16,6 +16,10 @@ obj-y += selinux/
 ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
 KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git rev-list --count HEAD)
 ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)
+
+# KernelSU version
+$(eval ver=$(shell expr 10000 + $(KSU_GIT_VERSION) + 200))
+$(info - KernelSU version: $(ver))
 endif
 
 ifndef EXPECTED_SIZE


### PR DESCRIPTION
* For example:
   - KernelSU version: 11055

(cherry picked from commit 46aa8e7a32e9c84dcd9e7f1ba4e16109949e6bf1) Change-Id: Iaaf4cd4100c9e344a6df6ea73fa74a347b81297b