### PR TITLE
kernel: Modify KERNEL_SU_VERSION logic and behavior

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,7 +15,13 @@ obj-y += selinux/
 # .git is a text file while the module is imported by 'git submodule add'.
 ifeq ($(shell test -e $(srctree)/$(src)/../.git; echo $$?),0)
 KSU_GIT_VERSION := $(shell cd $(srctree)/$(src); /usr/bin/env PATH="$$PATH":/usr/bin:/usr/local/bin git rev-list --count HEAD)
-ccflags-y += -DKSU_GIT_VERSION=$(KSU_GIT_VERSION)
+# ksu_version: major * 10000 + git version + 200 for historical reasons
+$(eval KSU_VERSION=$(shell expr 10000 + $(KSU_GIT_VERSION) + 200))
+$(info -- KernelSU version: $(KSU_VERSION))
+ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
+else # If there is no .git file, the default version will be passed.
+$(warning "KSU_GIT_VERSION not defined! It is better to make KernelSU a git submodule!")
+ccflags-y += -DKSU_VERSION=16
 endif
 
 ifndef EXPECTED_SIZE

--- a/kernel/ksu.h
+++ b/kernel/ksu.h
@@ -4,16 +4,7 @@
 #include "linux/types.h"
 #include "linux/workqueue.h"
 
-#ifndef KSU_GIT_VERSION
-#warning                                                                       \
-	"KSU_GIT_VERSION not defined! It is better to make KernelSU a git submodule!"
-#define KERNEL_SU_VERSION (16)
-#else
-#define KERNEL_SU_VERSION                                                      \
-	(10000 + KSU_GIT_VERSION +                                             \
-	 200) // major * 10000 + git version + 200 for historical reasons
-#endif
-
+#define KERNEL_SU_VERSION KSU_VERSION
 #define KERNEL_SU_OPTION 0xDEADBEEF
 
 #define CMD_GRANT_ROOT 0


### PR DESCRIPTION
This patch modifies the following:
- Move the version addition logic in ksu.h to Makefile processing
- Print the current version number of KernelSU during make build

build test (normal):
 buildlog:
  HOSTCC  scripts/basic/bin2c Using .. as source for kernel -- KernelSU version: 11055
  CHK     include/generated/utsrelease.h
  UPD     include/generated/utsrelease.h

 KernelSU software:
  KernelSU Working Version: 11055 (v) Superusers: 0 Modules: 0

![11055](https://github.com/tiann/KernelSU/assets/47409494/10506289-04d2-41c0-bd48-bad9f0dbdec5)

build test (missing .git file):
 buildlog:
  HOSTCC  scripts/basic/bin2c Using .. as source for kernel ../drivers/kernelsu/Makefile:23: "KSU_GIT_VERSION not defined! It is better to make KernelSU a git submodule!"
  CHK     include/generated/utsrelease.h
  CHK     scripts/mod/devicetable-offsets.h

 KernelSU software:
  KernelSU Working Version: 16 (v) Superusers: 0 Modules: 0

  The current kernel version 16 is too low for the manager to function properly. Please upgrade to version 10977 or higher!

![16](https://github.com/tiann/KernelSU/assets/47409494/9ea877a7-7b91-4a27-b6ab-58ce6e1b386f)

(cherry picked from commit 0c38a1614a77d80de752aba20908e3f9d21660a8) Change-Id: I570f2ee33db224e1a36770f847137f290ba9bcfd