### PR TITLE
kernel/ksu.c:Fix word mistakes when enabling CONFIG_KSU_DEBUG

### DIFF
--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -39,7 +39,7 @@ int __init kernelsu_init(void)
 	pr_alert("*************************************************************");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("**                                                         **");
-	pr_alert("**         You are running KernelSU in Debug Mode!         **");
+	pr_alert("**         You are running KernelSU in Debug Mode          **");
 	pr_alert("**                                                         **");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("*************************************************************");

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -39,7 +39,7 @@ int __init kernelsu_init(void)
 	pr_alert("*************************************************************");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("**                                                         **");
-	pr_alert("**         You are running KernelSU in Debug Mode          **");
+	pr_alert("**         You are running KernelSU in DEBUG mode          **");
 	pr_alert("**                                                         **");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("*************************************************************");

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -39,7 +39,7 @@ int __init kernelsu_init(void)
 	pr_alert("*************************************************************");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("**                                                         **");
-	pr_alert("**         You are running DEBUG version of KernelSU       **");
+	pr_alert("**         You are running KernelSU in Debug Mode!         **");
 	pr_alert("**                                                         **");
 	pr_alert("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE    **");
 	pr_alert("*************************************************************");


### PR DESCRIPTION
According to the instructions in Kconfig, when the `CONFIG_KSU_DEBUG` option is turned on, KernelSU will run in `debug mode` instead of the `debug version` mentioned in kernel/ksu.c.