### PR TITLE
ksud: symlink by relative path when handle partitions

### DIFF
--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -313,7 +313,7 @@ handle_partition() {
         ui_print "- Handle partition /$1"
         # we create a symlink if module want to access $MODPATH/system/$1
         # but it doesn't always work(ie. write it in post-fs-data.sh would fail because it is readonly)
-        mv -f $MODPATH/system/$1 $MODPATH/$1 && ln -sf /$1 $MODPATH/system/$1
+        mv -f $MODPATH/system/$1 $MODPATH/$1 && ln -sf ../$1 $MODPATH/system/$1
     fi
 }
 


### PR DESCRIPTION
This allows the Magisk design-compliant module boot script to access `$MODDIR/system/$part` while the mounted overlay still points to `/$part`
Fix https://github.com/tiann/KernelSU/issues/726