### PR TITLE
change AkariOficial to whyakari

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -281,9 +281,9 @@
     },
     {
         "maintainer": "AkariOficial",
-        "maintainer_link": "https://github.com/AkariOficial",
+        "maintainer_link": "https://github.com/whyakari",
         "kernel_name": "kernel_Moe_ginkgo",
-        "kernel_link": "https://github.com/AkariOficial/kernel_Moe_ginkgo",
+        "kernel_link": "https://github.com/whyakari/kernel_Moe_ginkgo",
         "devices": "Xiaomi Redmi Note 8 (Ginkgo)"
     },
     {


### PR DESCRIPTION
AkariOficial has been renamed to whyakari. Entering https://github.com/AkariOficial directly will result in 404.