### PR TITLE
repos.json:Update repo info

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -177,7 +177,7 @@
     {
         "maintainer": "rxuglr",
         "maintainer_link": "https://github.com/rxuglr",
-        "kernel_name": "android_kernel_xiaomi_surya",
+        "kernel_name": "kernel_xiaomi_surya",
         "kernel_link": "https://github.com/rxuglr/kernel_xiaomi_surya",
         "devices": "Xiaomi POCO X3 / NFC (surya)"
     },

--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -178,7 +178,7 @@
         "maintainer": "rxuglr",
         "maintainer_link": "https://github.com/rxuglr",
         "kernel_name": "android_kernel_xiaomi_surya",
-        "kernel_link": "https://github.com/rxuglr/android_kernel_xiaomi_surya",
+        "kernel_link": "https://github.com/rxuglr/kernel_xiaomi_surya",
         "devices": "Xiaomi POCO X3 / NFC (surya)"
     },
     {
@@ -278,13 +278,6 @@
         "kernel_name": "kernel_xiaomi_raphael",
         "kernel_link": "https://github.com/SOVIET-ANDROID/kernel_xiaomi_raphael",
         "devices": "XK20 Pro Raphael  DSP & A only SAR support "
-    },
-    {
-        "maintainer": "AkariOficial",
-        "maintainer_link": "https://github.com/AkariOficial",
-        "kernel_name": "kernel_Moe_ginkgo",
-        "kernel_link": "https://github.com/AkariOficial/kernel_Moe_ginkgo",
-        "devices": "Xiaomi Redmi Note 8 (Ginkgo)"
     },
     {
         "maintainer": "Coconutat",


### PR DESCRIPTION
Some changes to repos.json:
- Redirect android_kernel_xiaomi_surya to kernel_xiaomi_surya: Because the original warehouse has changed android_kernel_xiaomi_surya to kernel_xiaomi_surya, this time the original address is 404
- Removed kernel repository information maintained by AkariOficial #754 