### PR TITLE
[add device]: POCO F3/Redmi K40/Mi 11X (alioth)

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -397,5 +397,12 @@
         "kernel_name": "android_kernel_google_wahoo",
         "kernel_link": "https://github.com/Google-Pixel2-2XL/kernel_google_wahoo",
         "devices": "Google Pixel 2/2XL"
+    },
+    {
+        "maintainer": "Flame",
+        "maintainer_link": "https://github.com/flame-0",
+        "kernel_name": "android_kernel_xiaomi_sm8250",
+        "kernel_link": "https://github.com/vyrine/android_kernel_xiaomi_sm8250/tree/lineage-20-kernelsu",
+        "devices": "POCO F3/Redmi K40/Mi 11X (alioth)"
     }
 ]


### PR DESCRIPTION
This pull request includes a modified LineageOS kernel with the implementation of KernelSU for POCO F3/Redmi K40/Mi 11X (alioth), adding them to the list of unofficially supported devices.