### PR TITLE
kernel:fix save_allow_list create file failed: -126 on kernel 4.9 and below 

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -349,7 +349,8 @@ void do_save_allow_list(struct work_struct *work)
 	struct perm_data *p = NULL;
 	struct list_head *pos = NULL;
 	loff_t off = 0;
-
+        
+	KWORKER_INSTALL_KEYRING();
 	struct file *fp =
 		ksu_filp_open_compat(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT, 0644);
 	if (IS_ERR(fp)) {
@@ -391,6 +392,7 @@ void do_load_allow_list(struct work_struct *work)
 	struct file *fp = NULL;
 	u32 magic;
 	u32 version;
+        KWORKER_INSTALL_KEYRING();
 
 #ifdef CONFIG_KSU_DEBUG
 	// always allow adb shell by default

--- a/kernel/kernel_compat.h
+++ b/kernel/kernel_compat.h
@@ -23,4 +23,33 @@ extern struct file *ksu_filp_open_compat(const char *filename, int flags, umode_
 extern ssize_t ksu_kernel_read_compat(struct file *p, void *buf, size_t count, loff_t *pos);
 extern ssize_t ksu_kernel_write_compat(struct file *p, const void *buf, size_t count, loff_t *pos);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+static inline int install_session_keyring(struct key *keyring)
+{
+	struct cred *new;
+	int ret;
+
+	new = prepare_creds();
+	if (!new)
+		return -ENOMEM;
+
+	ret = install_session_keyring_to_cred(new, keyring);
+	if (ret < 0) {
+		abort_creds(new);
+		return ret;
+	}
+
+	return commit_creds(new);
+}
+#define KWORKER_INSTALL_KEYRING()                           \
+	static bool keyring_installed = false;                  \
+	if (init_session_keyring != NULL && !keyring_installed) \
+	{                                                       \
+		install_session_keyring(init_session_keyring);      \
+		keyring_installed = true;                           \
+	}
+#else
+#define KWORKER_INSTALL_KEYRING()
+#endif
+
 #endif

--- a/kernel/uid_observer.c
+++ b/kernel/uid_observer.c
@@ -39,6 +39,7 @@ static bool is_uid_exist(uid_t uid, void *data)
 
 static void do_update_uid(struct work_struct *work)
 {
+	KWORKER_INSTALL_KEYRING();
 	struct file *fp = ksu_filp_open_compat(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
 		pr_err("do_update_uid, open " SYSTEM_PACKAGES_LIST_PATH


### PR DESCRIPTION
这个commit c0066b6 删除了一些 b008b1d 的代码，这导致4.9及以下的内核无法保存.allowlist 文件。
将这些代码恢复后问题被修复