### PR TITLE
Fix the directory pathname while moving directories

### DIFF
--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -301,6 +301,20 @@ is_legacy_script() {
   return $?
 }
 
+# find_mv [source_directory] [destination_directory]
+find_mv() {
+    for file in $(find "$1" -type f); do
+        # Get the sub directory of the file.
+        sub_dir=$(echo "${file%/*}" | sed "s|$1||")
+        # Create the new directory, if it doesn't already exist.
+        mkdir -p "$2$sub_dir"
+        # Move the file to the new directory.
+        mv -f "$file" "$2$sub_dir"
+    done
+    # Clean old directory.
+    rm -r "$1"
+}
+
 handle_partition() {
     # if /system/vendor is a symlink, we need to move it out of $MODPATH/system, otherwise it will be overlayed
     # if /system/vendor is a normal directory, it is ok to overlay it and we don't need to overlay it separately.
@@ -313,7 +327,7 @@ handle_partition() {
         ui_print "- Handle partition /$1"
         # we create a symlink if module want to access $MODPATH/system/$1
         # but it doesn't always work(ie. write it in post-fs-data.sh would fail because it is readonly)
-        mv -f $MODPATH/system/$1 $MODPATH/$1 && ln -sf ../$1 $MODPATH/system/$1
+        find_mv $MODPATH/system/$1 $MODPATH/$1 && ln -sf ../$1 $MODPATH/system/$1
     fi
 }
 


### PR DESCRIPTION
Fix the duplicate directory name error that occurs when the destination directory already exists while moving folders.