### PR TITLE
[add device]: Oneplus8/8T/8P/9R (opkona)

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -404,5 +404,12 @@
         "kernel_name": "android_kernel_xiaomi_sm8250",
         "kernel_link": "https://github.com/vyrine/android_kernel_xiaomi_sm8250/tree/lineage-20-kernelsu",
         "devices": "POCO F3/Redmi K40/Mi 11X (alioth)"
+    },
+    {
+        "maintainer": "DawfukFR",
+        "maintainer_link": "https://github.com/DawfukFR",
+        "kernel_name": "kernel_oneplus_sm8250 (Stellaris-Kernel)",
+        "kernel_link": "https://github.com/DawfukFR/kernel_oneplus_sm8250",
+        "devices": "Oneplus 8 (Instantnoodle), Oneplus 8T (Kebab), Oneplus 8 Pro (Instantnoodlep), Oneplus 9R (lemonades) [msm-4.19]"
     }
 ]


### PR DESCRIPTION
Custom kernel for Oneplus SM8250 devices with support of KernelSU (using the command : curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -)

Precompiled kernel can be found here : 
https://t.me/StellarisRelease (stable)
https://t.me/DawfukSpace (testing)

I have tested the KernelSU feature on this kernel, everything works fine.
Current version used : 11165
KernelSU Manager signature size: 0x033b
KernelSU Manager signature hash: 0xb0b91415