### PR TITLE
Kernel: fix filp_open in kernel below 4.9

### DIFF
--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -77,12 +77,10 @@ void ksu_android_ns_fs_check()
 struct file *ksu_filp_open_compat(const char *filename, int flags, umode_t mode)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
-	static bool keyring_installed = false;
-	if (init_session_keyring != NULL && !keyring_installed &&
+	if (init_session_keyring != NULL && !current_cred()->session_keyring &&
 	    (current->flags & PF_WQ_WORKER)) {
 		pr_info("installing init session keyring for older kernel\n");
 		install_session_keyring(init_session_keyring);
-		keyring_installed = true;
 	}
 #endif
 	// switch mnt_ns even if current is not wq_worker, to ensure what we open is the correct file in android mnt_ns, rather than user created mnt_ns


### PR DESCRIPTION
Use current_cred()->session_keyring to check whether session_keyring installed or not.