### PR TITLE
manager: Corrected "Kernel version" and "KernelSU version" string

### DIFF
--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -65,7 +65,7 @@
     <string name="profile_selinux_context">SELinux</string>
     <string name="profile_umount_modules">卸载模块</string>
     <string name="failed_to_update_app_profile">为 %s 更新 App Profile 失败</string>
-    <string name="require_kernel_version">当前内核版本 %d 过低，管理器无法正常工作，请升级内核版本至 %d 或以上！</string>
+    <string name="require_kernel_version">当前 KernelSU 版本 %d 过低，管理器无法正常工作，请升级内核 KernelSU 版本至 %d 或以上！</string>
     <string name="settings_umount_modules_default">默认卸载模块</string>
     <string name="settings_umount_modules_default_summary">App Profile 中\"卸载模块\"的全局默认值，如果启用，将会为没有设置 Profile 的应用移除所有模块针对系统的修改。</string>
     <string name="profile_umount_modules_summary">启用后将允许 KernelSU 为本应用还原被模块修改过的文件。</string>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -61,7 +61,7 @@
     <string name="profile_umount_modules">卸載模組</string>
     <string name="failed_to_update_app_profile">無法更新 %s 應用程式設定檔</string>
     <string name="profile_selinux_rules">規則</string>
-    <string name="require_kernel_version">目前核心版本 %d 過低，管理員無法正常運作。請升級至 %d 或更高版本！</string>
+    <string name="require_kernel_version">目前 KernelSU 版本 %d 過低，管理員無法正常運作。請升級至 %d 或更高版本！</string>
     <string name="settings_umount_modules_default_summary">應用程式設定檔中「卸載模組」的全域預設值。如果啟用，將會為沒有設定檔的應用程式移除所有模組對系統的修改。</string>
     <string name="profile_umount_modules_summary">啟用此選項將允許 KernelSU 為這個應用程式還原任何被模組修改過的檔案。</string>
     <string name="profile_selinux_domain">網域</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -54,7 +54,7 @@
     <string name="about_source_code"><![CDATA[在 %1$s 中檢視原始碼<br/>加入我們的 %2$s 頻道]]></string>
     <string name="profile_umount_modules">解除安裝模組</string>
     <string name="failed_to_update_app_profile">無法更新 %s 應用程式設定檔</string>
-    <string name="require_kernel_version">目前安裝的核心版本 %d 過低，管理器無法正常工作，請升級核心版本至 %d 或以上！</string>
+    <string name="require_kernel_version">目前安裝的 KernelSU 版本 %d 過低，管理器無法正常工作，請升級核心 KernelSU 版本至 %d 或以上！</string>
     <string name="settings_umount_modules_default">預設解除安裝模組</string>
     <string name="settings_umount_modules_default_summary">應用程式設定檔中「解除安裝模組」的全域預設值，如果啟用，將會為沒有設定檔的應用程式移除所有模組針對系統的修改。</string>
     <string name="profile_umount_modules_summary">啟用後將允許 KernelSU 為本應用程式還原被模組修改過的檔案。</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="profile_selinux_context">SELinux context</string>
     <string name="profile_umount_modules">Umount modules</string>
     <string name="failed_to_update_app_profile">Failed to update App Profile for %s</string>
-    <string name="require_kernel_version">The current kernel version %d is too low for the manager to function properly. Please upgrade to version %d or higher!</string>
+    <string name="require_kernel_version">The current KernelSU version %d is too low for the manager to function properly. Please upgrade to version %d or higher!</string>
     <string name="settings_umount_modules_default">Umount modules by default</string>
     <string name="settings_umount_modules_default_summary">The global default value for \"Umount modules\" in App Profiles. If enabled, it will remove all module modifications to the system for applications that do not have a Profile set.</string>
     <string name="profile_umount_modules_summary">Enabling this option will allow KernelSU to restore any modified files by the modules for this application.</string>


### PR DESCRIPTION
* Avoid misunderstanding "The current kernel version %d is too low" Many people misunderstand that the version of the Linux kernel is too low, so the version of KernelSU is low and they go looking for a kernel with an upgraded version of the Linux kernel.

 Correct the string of require_kernel_version to avoid misunderstanding,
 Now let them look for the updated KernelSU version of the kernel.

(cherry picked from commit dcc4ad10f81b1531b551b2b44a3b9cbdc0e489e9) Change-Id: I4373b006d45ed98e02effa4556e8a9e8c0b70f14