### PR TITLE
ci: Delete unused files for build to free disk space

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -98,9 +98,9 @@ jobs:
           echo "Free space:"
           df -h
           cd $GITHUB_WORKSPACE
-          git clone https://gerrit.googlesource.com/git-repo
+          sudo apt-get install repo -y
           mkdir android-kernel && cd android-kernel
-          ../git-repo/repo init --depth=1 --u https://android.googlesource.com/kernel/manifest -b common-${{ inputs.tag }} --repo-rev=v2.16
+          repo init --depth=1 --u https://android.googlesource.com/kernel/manifest -b common-${{ inputs.tag }} --repo-rev=v2.16
           REMOTE_BRANCH=$(git ls-remote https://android.googlesource.com/kernel/common ${{ inputs.tag }})
           DEFAULT_MANIFEST_PATH=.repo/manifests/default.xml
           if grep -q deprecated <<< $REMOTE_BRANCH; then
@@ -108,8 +108,8 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
             cat $DEFAULT_MANIFEST_PATH
           fi
-          ./.repo/repo/repo --version
-          ./.repo/repo/repo sync -c -j$(nproc --all) --no-tags
+          repo --version
+          repo sync -c -j$(nproc --all) --no-tags
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -96,8 +96,9 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' .repo/manifests/default.xml
             cat .repo/manifests/default.xml
           fi
+          sed -i '/prebuilts\/ndk-*/d' .repo/manifests/default.xml
+          sed -i '/prebuilts\/jdk/d' .repo/manifests/default.xml
           ../git-repo/repo sync -j$(nproc --all)
-          rm -rf prebuilts/ndk-*
           ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants) | xargs rm -rf
 
       - name: Setup KernelSU

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -70,15 +70,6 @@ jobs:
       CCACHE_NOHASHDIR: "true"
       CCACHE_HARDLINK: "true"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
       - uses: actions/checkout@v3
         with:
           path: KernelSU
@@ -95,6 +86,8 @@ jobs:
 
       - name: Setup kernel source
         run: |
+          echo "Free space:"
+          df -h
           cd $GITHUB_WORKSPACE
           git clone https://gerrit.googlesource.com/git-repo
           mkdir android-kernel && cd android-kernel
@@ -105,7 +98,7 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' .repo/manifests/default.xml
             cat .repo/manifests/default.xml
           fi
-          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 default.xml | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
+          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 .repo/manifests/default.xml | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
           if [ "$CLANG_REV" != "" ]; then
             echo "Fuck stupid Google clone whole clang!!!"
             wget -o clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -98,6 +98,7 @@ jobs:
           fi
           ../git-repo/repo sync -j$(nproc --all)
           rm -rf prebuilts/ndk-*
+          ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants) | xargs rm -rf
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -109,7 +109,7 @@ jobs:
             cat $DEFAULT_MANIFEST_PATH
           fi
           repo --version
-          repo sync -c -j$(nproc --all) --no-tags
+          repo --trace sync -q -c -j$(nproc --all) --no-tags
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -91,24 +91,13 @@ jobs:
           cd $GITHUB_WORKSPACE
           git clone https://gerrit.googlesource.com/git-repo
           mkdir android-kernel && cd android-kernel
-          ../git-repo/repo init --depth=1 --u https://android.googlesource.com/kernel/manifest -b common-${{ inputs.tag }}
+          ../git-repo/repo init --depth=1 --u https://android.googlesource.com/kernel/manifest -b common-${{ inputs.tag }} --repo-rev=v2.16
           REMOTE_BRANCH=$(git ls-remote https://android.googlesource.com/kernel/common ${{ inputs.tag }})
           DEFAULT_MANIFEST_PATH=.repo/manifests/default.xml
           if grep -q deprecated <<< $REMOTE_BRANCH; then
             echo "Found deprecated branch: ${{ inputs.tag }}"
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
             cat $DEFAULT_MANIFEST_PATH
-          fi
-          CLANG_REV=$(grep 'path="prebuilts/clang/host/linux-x86"' $DEFAULT_MANIFEST_PATH | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
-          if [ "$CLANG_REV" != "" ]; then
-            echo "Fuck stupid Google clone whole clang!!!"
-            wget -q -O clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
-            mkdir -p prebuilts/clang/host/linux-x86
-            ls -alh clang.tar.gz
-            tar -xzf clang.tar.gz -C prebuilts/clang/host/linux-x86
-            rm clang.tar.gz
-            sed -i '/prebuilts\/clang\/host\/linux-x86/d' $DEFAULT_MANIFEST_PATH
-            sed -i '/prebuilts\/jdk/d' $DEFAULT_MANIFEST_PATH
           fi
           ../git-repo/repo sync -c -j$(nproc --all)
 

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -97,6 +97,7 @@ jobs:
             cat .repo/manifests/default.xml
           fi
           ../git-repo/repo sync -j$(nproc --all)
+          rm -rf prebuilts/ndk-*
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -101,6 +101,9 @@ jobs:
           fi
           repo --version
           repo --trace sync -q -c -j$(nproc --all) --no-tags
+          ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants)
+          rm -rf .repo
+          df -h
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -95,8 +95,6 @@ jobs:
 
       - name: Setup kernel source
         run: |
-          echo "Free space:"
-          df -h
           cd $GITHUB_WORKSPACE
           git clone https://gerrit.googlesource.com/git-repo
           mkdir android-kernel && cd android-kernel
@@ -107,10 +105,17 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' .repo/manifests/default.xml
             cat .repo/manifests/default.xml
           fi
+          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 default.xml | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
+          if [ "$CLANG_REV" != "" ]; then
+            echo "Fuck stupid Google clone whole clang!!!"
+            wget -o clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
+            mkdir -p prebuilts/clang/host/linux-x86
+            tar -xvf clang.tar.gz -C prebuilts/clang/host/linux-x86
+            sed -i '/prebuilts\/clang\/host\/linux-x86/d' .repo/manifests/default.xml
+          fi
           sed -i '/prebuilts\/ndk-*/d' .repo/manifests/default.xml
           sed -i '/prebuilts\/jdk/d' .repo/manifests/default.xml
-          ../git-repo/repo sync -j$(nproc --all)
-          ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants) | xargs rm -rf
+          ../git-repo/repo sync -c -j$(nproc --all)
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -101,7 +101,9 @@ jobs:
           fi
           repo --version
           repo --trace sync -q -c -j$(nproc --all) --no-tags
-          ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants)
+          if [ -d prebuilts/clang/host/linux-x86 ] && [ -f common/build.config.constants ]; then
+            ls -d prebuilts/clang/host/linux-x86/clang-r* | grep -v $(sed -n 's/^CLANG_VERSION=//p' common/build.config.constants)
+          fi
           rm -rf .repo
           df -h
 

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -70,6 +70,15 @@ jobs:
       CCACHE_NOHASHDIR: "true"
       CCACHE_HARDLINK: "true"
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
       - uses: actions/checkout@v3
         with:
           path: KernelSU

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -102,12 +102,12 @@ jobs:
           CLANG_REV=$(grep prebuilts/clang/host/linux-x86 $DEFAULT_MANIFEST_PATH | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
           if [ "$CLANG_REV" != "" ]; then
             echo "Fuck stupid Google clone whole clang!!!"
-            wget -O clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
+            wget -q -O clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
             mkdir -p prebuilts/clang/host/linux-x86
+            ls -alh clang.tar.gz
             tar -xvf clang.tar.gz -C prebuilts/clang/host/linux-x86
             rm clang.tar.gz
             sed -i '/prebuilts\/clang\/host\/linux-x86/d' $DEFAULT_MANIFEST_PATH
-            sed -i '/prebuilts\/ndk-*/d' $DEFAULT_MANIFEST_PATH
             sed -i '/prebuilts\/jdk/d' $DEFAULT_MANIFEST_PATH
           fi
           ../git-repo/repo sync -c -j$(nproc --all)

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -70,6 +70,15 @@ jobs:
       CCACHE_NOHASHDIR: "true"
       CCACHE_HARDLINK: "true"
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
       - uses: actions/checkout@v3
         with:
           path: KernelSU
@@ -86,6 +95,8 @@ jobs:
 
       - name: Setup kernel source
         run: |
+          echo "Free space:"
+          df -h
           cd $GITHUB_WORKSPACE
           git clone https://gerrit.googlesource.com/git-repo
           mkdir android-kernel && cd android-kernel

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -108,7 +108,8 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
             cat $DEFAULT_MANIFEST_PATH
           fi
-          ../git-repo/repo sync -c -j$(nproc --all) --no-tags
+          ./.repo/repo/repo --version
+          ./.repo/repo/repo sync -c -j$(nproc --all) --no-tags
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -70,15 +70,6 @@ jobs:
       CCACHE_NOHASHDIR: "true"
       CCACHE_HARDLINK: "true"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-
       - uses: actions/checkout@v3
         with:
           path: KernelSU

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -99,13 +99,13 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
             cat $DEFAULT_MANIFEST_PATH
           fi
-          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 $DEFAULT_MANIFEST_PATH | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
+          CLANG_REV=$(grep 'path="prebuilts/clang/host/linux-x86"' $DEFAULT_MANIFEST_PATH | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
           if [ "$CLANG_REV" != "" ]; then
             echo "Fuck stupid Google clone whole clang!!!"
             wget -q -O clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
             mkdir -p prebuilts/clang/host/linux-x86
             ls -alh clang.tar.gz
-            tar -xvf clang.tar.gz -C prebuilts/clang/host/linux-x86
+            tar -xzf clang.tar.gz -C prebuilts/clang/host/linux-x86
             rm clang.tar.gz
             sed -i '/prebuilts\/clang\/host\/linux-x86/d' $DEFAULT_MANIFEST_PATH
             sed -i '/prebuilts\/jdk/d' $DEFAULT_MANIFEST_PATH

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -108,7 +108,7 @@ jobs:
             sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
             cat $DEFAULT_MANIFEST_PATH
           fi
-          ../git-repo/repo sync -c -j$(nproc --all)
+          ../git-repo/repo sync -c -j$(nproc --all) --no-tags
 
       - name: Setup KernelSU
         env:

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -93,21 +93,23 @@ jobs:
           mkdir android-kernel && cd android-kernel
           ../git-repo/repo init --depth=1 --u https://android.googlesource.com/kernel/manifest -b common-${{ inputs.tag }}
           REMOTE_BRANCH=$(git ls-remote https://android.googlesource.com/kernel/common ${{ inputs.tag }})
+          DEFAULT_MANIFEST_PATH=.repo/manifests/default.xml
           if grep -q deprecated <<< $REMOTE_BRANCH; then
             echo "Found deprecated branch: ${{ inputs.tag }}"
-            sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' .repo/manifests/default.xml
-            cat .repo/manifests/default.xml
+            sed -i 's/"${{ inputs.tag }}"/"deprecated\/${{ inputs.tag }}"/g' $DEFAULT_MANIFEST_PATH
+            cat $DEFAULT_MANIFEST_PATH
           fi
-          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 .repo/manifests/default.xml | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
+          CLANG_REV=$(grep prebuilts/clang/host/linux-x86 $DEFAULT_MANIFEST_PATH | sed -n 's/.*revision="\([^"]*\)".*/\1/p')
           if [ "$CLANG_REV" != "" ]; then
             echo "Fuck stupid Google clone whole clang!!!"
-            wget -o clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
+            wget -O clang.tar.gz https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+archive/$CLANG_REV.tar.gz
             mkdir -p prebuilts/clang/host/linux-x86
             tar -xvf clang.tar.gz -C prebuilts/clang/host/linux-x86
-            sed -i '/prebuilts\/clang\/host\/linux-x86/d' .repo/manifests/default.xml
+            rm clang.tar.gz
+            sed -i '/prebuilts\/clang\/host\/linux-x86/d' $DEFAULT_MANIFEST_PATH
+            sed -i '/prebuilts\/ndk-*/d' $DEFAULT_MANIFEST_PATH
+            sed -i '/prebuilts\/jdk/d' $DEFAULT_MANIFEST_PATH
           fi
-          sed -i '/prebuilts\/ndk-*/d' .repo/manifests/default.xml
-          sed -i '/prebuilts\/jdk/d' .repo/manifests/default.xml
           ../git-repo/repo sync -c -j$(nproc --all)
 
       - name: Setup KernelSU

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <sys/mman.h>
 
 #include "ksu.h"
 
@@ -34,32 +33,18 @@ static bool ksuctl(int cmd, void* arg1, void* arg2) {
     prctl(KERNEL_SU_OPTION, cmd, arg1, arg2, &result);
     return result == KERNEL_SU_OPTION;
 }
-#include <android/log.h>
-#define LOG_TAG "KernelSU"
-#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 
 bool become_manager(const char* pkg) {
-    char addr[128];
-//    uid_t uid = getuid();
-//    uint32_t userId = uid / 100000;
-//    if (userId == 0) {
-//        sprintf(param, "/data/data/%s", pkg);
-//    } else {
-//        snprintf(param, sizeof(param), "/data/user/%d/%s", userId, pkg);
-//    }
+    char param[128];
+    uid_t uid = getuid();
+    uint32_t userId = uid / 100000;
+    if (userId == 0) {
+        sprintf(param, "/data/data/%s", pkg);
+    } else {
+        snprintf(param, sizeof(param), "/data/user/%d/%s", userId, pkg);
+    }
 
-    int page = getpagesize();
-//    void *addr = mmap(nullptr, page, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
-    madvise(addr, page, MADV_PAGEOUT);
-
-    bool result = ksuctl(CMD_BECOME_MANAGER, addr, nullptr);
-    bool found = false;
-    mincore(addr, page, reinterpret_cast<unsigned char *>(&found));
-//    munmap(addr, page);
-    LOGD("found: %d\n", found);
-
-    return result;
+    return ksuctl(CMD_BECOME_MANAGER, param, nullptr);
 }
 
 int get_version() {


### PR DESCRIPTION
For android13 gki kernels, Google puts lots of unused file to kernel source tree, while the Github Action only has 14G disk size and the ci may fail because of "No space left on device". So we just delete unused files to make it build success.