### PR TITLE
kernel: Fix commit `7bdb8858` in Linux 4.9.y and Linux 4.4.y builds

### DIFF
--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -4,6 +4,9 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
 #include "linux/sched/task.h"
 #include "linux/uaccess.h"
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
+#include "linux/uaccess.h"
+#include "linux/sched.h"
 #else
 #include "linux/sched.h"
 #endif


### PR DESCRIPTION
* linux/uaccess.h is also required on 4.4 and 4.9

-- KernelSU version: 11184
-- KernelSU Manager signature size: 0x033b
-- KernelSU Manager signature hash: 0xb0b91415
  CC      drivers/kernelsu/kernel_compat.o
../drivers/kernelsu/kernel_compat.c:159:9: error: use of undeclared identifier 'USER_DS'
        set_fs(USER_DS);
               ^
1 error generated.
make[4]: *** [../scripts/Makefile.build:314：drivers/kernelsu/kernel_compat.o] 错误 1
make[3]: *** [../scripts/Makefile.build:599：drivers/kernelsu] 错误 2

Change-Id: I19598c62a3ae901049ea99ef878fa5c1a15201fd