### PR TITLE
feat(kernel): Add Kernel 5.10.187

### DIFF
--- a/.github/workflows/build-debug-kernel.yml
+++ b/.github/workflows/build-debug-kernel.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         include:
           - version: "5.10"
-            sub_level: 177
-            os_patch_level: 2023-06
+            sub_level: 187
+            os_patch_level: 2023-08
           - version: "5.15"
             sub_level: 119
             os_patch_level: 2023-09

--- a/.github/workflows/build-kernel-a13.yml
+++ b/.github/workflows/build-kernel-a13.yml
@@ -36,6 +36,9 @@ jobs:
           - version: "5.10"
             sub_level: 177
             os_patch_level: 2023-06
+          - version: "5.10"
+            sub_level: 187
+            os_patch_level: 2023-08
           - version: "5.15"
             sub_level: 41
             os_patch_level: 2022-11
@@ -135,8 +138,8 @@ jobs:
       matrix:
         include:
           - version: "5.10"
-            sub_level: 177
-            os_patch_level: 2023-06
+            sub_level: 187
+            os_patch_level: 2023-08
           - version: "5.15"
             sub_level: 119
             os_patch_level: 2023-07


### PR DESCRIPTION
- Bluejay running GrapheneOS is on Kernel version `5.10.187`.  
- Tried to flash other versions `5.10.xxx` and all went into bootloop. Unsure how this version would go