### PR TITLE
[CI] Update Android 12 5.10 sublevel and patch level

### DIFF
--- a/.github/workflows/build-debug-kernel.yml
+++ b/.github/workflows/build-debug-kernel.yml
@@ -7,9 +7,9 @@ jobs:
     uses: ./.github/workflows/gki-kernel.yml
     with:
       version: android12-5.10
-      version_name: android12-5.10.177
-      tag: android12-5.10-2023-06
-      os_patch_level: 2023-06
+      version_name: android12-5.10.185
+      tag: android12-5.10-2023-09
+      os_patch_level: 2023-09
       patch_path: "5.10"
       debug: true
   build-debug-kernel-a13:

--- a/.github/workflows/build-kernel-a12.yml
+++ b/.github/workflows/build-kernel-a12.yml
@@ -40,7 +40,9 @@ jobs:
           - sub_level: 168
             os_patch_level: 2023-05
           - sub_level: 177
-            os_patch_level: 2023-06
+            os_patch_level: 2023-07
+          - sub_level: 185
+            os_patch_level: 2023-09
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:


### PR DESCRIPTION
For patch level 2023-07, sublevel is 177 https://android.googlesource.com/kernel/common/+/refs/heads/android12-5.10-2023-07/Makefile 

For patch level 2023-09, sublevel is 185 https://android.googlesource.com/kernel/common/+/refs/heads/android12-5.10-2023-09/Makefile