### PR TITLE
Fix WSA kernels

### DIFF
--- a/.github/workflows/build-kernel-wsa.yml
+++ b/.github/workflows/build-kernel-wsa.yml
@@ -18,19 +18,28 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, arm64]
-        version: ["5.15.104.3"]
+        version: ["5.15.104.2", "5.15.104.3"]
         include:
           - arch: x86_64
             file_name: "bzImage"
           - arch: arm64
             file_name: "Image"
             cross_compile: "aarch64-linux-gnu"
+          - version: "5.15.104.2"
+            arch: x86_64
+            make_config: config-wsa-x64
+          - version: "5.15.104.2"
+            arch: arm64
+            make_config: config-wsa-arm64
           - version: "5.15.104.3"
             arch: x86_64
             make_config: config-wsa-x64
           - version: "5.15.104.3"
             arch: arm64
             make_config: config-wsa-arm64
+          - version: "5.15.104.2"
+            device_code: latte-2
+            kernel_version: "5.15"
           - version: "5.15.104.3"
             device_code: latte-2
             kernel_version: "5.15"

--- a/.github/workflows/build-kernel-wsa.yml
+++ b/.github/workflows/build-kernel-wsa.yml
@@ -18,38 +18,20 @@ jobs:
     strategy:
       matrix:
         arch: [x86_64, arm64]
-        version: ["5.15.94.4", "5.15.104.1", "5.15.104.2"]
+        version: ["5.15.104.3"]
         include:
           - arch: x86_64
             file_name: "bzImage"
           - arch: arm64
             file_name: "Image"
             cross_compile: "aarch64-linux-gnu"
-          - version: "5.15.94.4"
+          - version: "5.15.104.3"
             arch: x86_64
             make_config: config-wsa-x64
-          - version: "5.15.94.4"
+          - version: "5.15.104.3"
             arch: arm64
             make_config: config-wsa-arm64
-          - version: "5.15.104.1"
-            arch: x86_64
-            make_config: config-wsa-x64
-          - version: "5.15.104.1"
-            arch: arm64
-            make_config: config-wsa-arm64
-          - version: "5.15.104.2"
-            arch: x86_64
-            make_config: config-wsa-x64
-          - version: "5.15.104.2"
-            arch: arm64
-            make_config: config-wsa-arm64
-          - version: "5.15.94.4"
-            device_code: latte-2
-            kernel_version: "5.15"
-          - version: "5.15.104.1"
-            device_code: latte-2
-            kernel_version: "5.15"
-          - version: "5.15.104.2"
+          - version: "5.15.104.3"
             device_code: latte-2
             kernel_version: "5.15"
 


### PR DESCRIPTION
- WSA latest version: `2307.40000.6.0`
  -> Kernel version: `5.15.104.2`

- Next kernel version: `5.15.104.3`
  -> We haven't yet confirmed the release of this kernel.