### PR TITLE
kernel: Adapt to low version Android init process

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -97,7 +97,7 @@ void ksu_show_allow_list(void)
 {
 	struct perm_data *p = NULL;
 	struct list_head *pos = NULL;
-	pr_info("ksu_show_allow_list");
+	pr_info("ksu_show_allow_list\n");
 	list_for_each (pos, &allow_list) {
 		p = list_entry(pos, struct perm_data, list);
 		pr_info("uid :%d, allow: %d\n", p->profile.current_uid,

--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -18,7 +18,7 @@ check_v2_signature(char *path, unsigned expected_size, unsigned expected_hash)
 	int i;
 	struct file *fp = ksu_filp_open_compat(path, O_RDONLY, 0);
 	if (IS_ERR(fp)) {
-		pr_err("open %s error.", path);
+		pr_err("open %s error.\n", path);
 		return PTR_ERR(fp);
 	}
 
@@ -138,7 +138,7 @@ static int set_expected_size(const char *val, const struct kernel_param *kp)
 {
 	int rv = param_set_uint(val, kp);
 	ksu_invalidate_manager_uid();
-	pr_info("ksu_expected_size set to %x", ksu_expected_size);
+	pr_info("ksu_expected_size set to %x\n", ksu_expected_size);
 	return rv;
 }
 
@@ -146,7 +146,7 @@ static int set_expected_hash(const char *val, const struct kernel_param *kp)
 {
 	int rv = param_set_uint(val, kp);
 	ksu_invalidate_manager_uid();
-	pr_info("ksu_expected_hash set to %x", ksu_expected_hash);
+	pr_info("ksu_expected_hash set to %x\n", ksu_expected_hash);
 	return rv;
 }
 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -184,7 +184,7 @@ int ksu_handle_rename(struct dentry *old_dentry, struct dentry *new_dentry)
 	if (strcmp(buf, "/system/packages.list")) {
 		return 0;
 	}
-	pr_info("renameat: %s -> %s, new path: %s", old_dentry->d_iname,
+	pr_info("renameat: %s -> %s, new path: %s\n", old_dentry->d_iname,
 		new_dentry->d_iname, buf);
 
 	update_uid();
@@ -313,7 +313,7 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			static bool post_fs_data_lock = false;
 			if (!post_fs_data_lock) {
 				post_fs_data_lock = true;
-				pr_info("post-fs-data triggered");
+				pr_info("post-fs-data triggered\n");
 				on_post_fs_data();
 			}
 			break;
@@ -322,7 +322,7 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			static bool boot_complete_lock = false;
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
-				pr_info("boot_complete triggered");
+				pr_info("boot_complete triggered\n");
 			}
 			break;
 		}
@@ -641,7 +641,7 @@ static int ksu_key_permission(key_ref_t key_ref, const struct cred *cred,
 		return 0;
 	}
 	init_session_keyring = cred->session_keyring;
-	pr_info("kernel_compat: got init_session_keyring");
+	pr_info("kernel_compat: got init_session_keyring\n");
 	return 0;
 }
 #endif

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -59,11 +59,11 @@ void on_post_fs_data(void)
 {
 	static bool done = false;
 	if (done) {
-		pr_info("on_post_fs_data already done");
+		pr_info("on_post_fs_data already done\n");
 		return;
 	}
 	done = true;
-	pr_info("on_post_fs_data!");
+	pr_info("on_post_fs_data!\n");
 	ksu_load_allow_list();
 	// sanity check, this may influence the performance
 	stop_input_hook();
@@ -262,7 +262,7 @@ static ssize_t read_proxy(struct file *file, char __user *buf, size_t count,
 	bool first_read = file->f_pos == 0;
 	ssize_t ret = orig_read(file, buf, count, pos);
 	if (first_read) {
-		pr_info("read_proxy append %ld + %ld", ret, read_count_append);
+		pr_info("read_proxy append %ld + %ld\n", ret, read_count_append);
 		ret += read_count_append;
 	}
 	return ret;
@@ -273,7 +273,7 @@ static ssize_t read_iter_proxy(struct kiocb *iocb, struct iov_iter *to)
 	bool first_read = iocb->ki_pos == 0;
 	ssize_t ret = orig_read_iter(iocb, to);
 	if (first_read) {
-		pr_info("read_iter_proxy append %ld + %ld", ret,
+		pr_info("read_iter_proxy append %ld + %ld\n", ret,
 			read_count_append);
 		ret += read_count_append;
 	}
@@ -342,7 +342,7 @@ int ksu_handle_vfs_read(struct file **file_ptr, char __user **buf_ptr,
 		current->comm, count, rc_count);
 
 	if (count < rc_count) {
-		pr_err("count: %d < rc_count: %d", count, rc_count);
+		pr_err("count: %d < rc_count: %d\n", count, rc_count);
 		return 0;
 	}
 

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -103,6 +103,44 @@ static const char __user *get_user_arg_ptr(struct user_arg_ptr argv, int nr)
 	return native;
 }
 
+static const bool get_env_bool(struct user_arg_ptr envp, const char *name) {
+	const char __user *const __user *env;
+
+	// Traverse the list of environment variables
+    for (env = envp.ptr.native; *env != NULL; env++) {
+        const char __user *entry = *env;
+        char buf[256];
+        
+        // Reading environment variable strings from user space
+        if (ksu_strncpy_from_user_nofault(buf, entry, sizeof(buf)) < 0)
+            continue;
+        
+        // Parsing environment variable names and values
+        char *env_name = buf;
+        char *env_value = strchr(buf, '=');
+        if (env_value == NULL)
+            continue;
+        
+        // Replace equal sign with string terminator
+        *env_value = '\0';
+        env_value++;
+        
+        // pr_info("env %s=%s\n", env_name, env_value);
+        // Check if the environment variable names are matching
+        if (strcmp(env_name, name) == 0) {
+            // If matched, returns a Boolean value based on the environment variable's value
+            if (strcmp(env_value, "1") == 0 || strcmp(env_value, "true") == 0)
+                return true;
+            else
+                return false;
+        }
+    }
+    
+    // If the specified environment variable is not found, return the default value
+	pr_info("not found env %s\n", name);
+    return false;
+}
+
 /*
  * count() counts the number of strings in array ARGV.
  */
@@ -140,7 +178,7 @@ static int __maybe_unused count(struct user_arg_ptr argv, int max)
 
 // the call from execve_handler_pre won't provided correct value for __never_use_argument, use them after fix execve_handler_pre, keeping them for consistence for manually patched code
 int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
-			     struct user_arg_ptr *argv, void *__never_use_envp, int *__never_use_flags)
+			     struct user_arg_ptr *argv, struct user_arg_ptr *envp, int *__never_use_flags)
 {
 #ifndef CONFIG_KPROBES
 	if (!ksu_execveat_hook) {
@@ -151,7 +189,11 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 
 	static const char app_process[] = "/system/bin/app_process";
 	static bool first_app_process = true;
+
+	/* This applies to Android 10 and above versions */
 	static const char system_bin_init[] = "/system/bin/init";
+	/* This applies to versions between Android 6 and Android 9  */
+	static const char old_system_init[] = "/init";
 	static bool init_second_stage_executed = false;
 
 	if (!filename_ptr)
@@ -163,24 +205,37 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 	}
 
 	if (unlikely(!memcmp(filename->name, system_bin_init,
-		    sizeof(system_bin_init) - 1))) {
-		// /system/bin/init executed
+		    sizeof(system_bin_init) - 1)) || 
+			unlikely(!memcmp(filename->name, old_system_init,
+			sizeof(old_system_init) - 1))) {
+		// init executed
 		int argc = count(*argv, MAX_ARG_STRINGS);
-		pr_info("/system/bin/init argc: %d\n", argc);
+		pr_info("init argc: %d\n", argc);
 		if (argc > 1 && !init_second_stage_executed) {
 			const char __user *p = get_user_arg_ptr(*argv, 1);
+			/* This applies to versions Android 6 ~ 7 and Android 10+  */
 			if (p && !IS_ERR(p)) {
 				char first_arg[16];
-                                ksu_strncpy_from_user_nofault(first_arg, p, sizeof(first_arg));
-				pr_info("first arg: %s\n", first_arg);
-				if (!strcmp(first_arg, "second_stage")) {
-					pr_info("/system/bin/init second_stage executed\n");
+                ksu_strncpy_from_user_nofault(first_arg, p, sizeof(first_arg));
+				pr_info("init first arg: %s\n", first_arg);
+				if (!strcmp(first_arg, "second_stage") || !strcmp(first_arg, "--second-stage")) {
+					pr_info("init second_stage executed\n");
 					apply_kernelsu_rules();
 					init_second_stage_executed = true;
 					ksu_android_ns_fs_check();
 				}
 			} else {
-				pr_err("/system/bin/init parse args err!\n");
+				pr_err("init parse args err!\n");
+			}
+		} else if (argc == 1 && !init_second_stage_executed) {
+			/* This applies to versions between Android 8 and Android 9  */
+			const bool init_second_stage = get_env_bool(*envp, "INIT_SECOND_STAGE");
+			pr_info("init env INIT_SECOND_STAGE = %s\n", init_second_stage ? "true" : "false");
+			if (init_second_stage) {
+				pr_info("init second_stage executed\n");
+				apply_kernelsu_rules();
+				init_second_stage_executed = true;
+				ksu_android_ns_fs_check();
 			}
 		}
 	}
@@ -457,6 +512,7 @@ static void stop_vfs_read_hook()
 	pr_info("unregister vfs_read kprobe: %d!\n", ret);
 #else
 	ksu_vfs_read_hook = false;
+	pr_info("stop vfs_read_hook\n");
 #endif
 }
 
@@ -467,6 +523,7 @@ static void stop_execve_hook()
 	pr_info("unregister execve kprobe: %d!\n", ret);
 #else
 	ksu_execveat_hook = false;
+	pr_info("stop execve_hook\n");
 #endif
 }
 
@@ -482,6 +539,7 @@ static void stop_input_hook()
 	pr_info("unregister input kprobe: %d!\n", ret);
 #else
 	ksu_input_hook = false;
+	pr_info("stop input_hook\n");
 #endif
 }
 

--- a/kernel/manager.c
+++ b/kernel/manager.c
@@ -52,7 +52,7 @@ bool become_manager(char *pkg)
 			continue;
 		}
 		// we have found the apk!
-		pr_info("found apk: %s", cwd);
+		pr_info("found apk: %s\n", cwd);
 		char *pkg_index = strstr(cwd, pkg);
 		if (!pkg_index) {
 			pr_info("apk path not match package name!\n");
@@ -80,7 +80,7 @@ bool become_manager(char *pkg)
 			result = true;
 			goto clean;
 		} else {
-			pr_info("manager signature invalid!");
+			pr_info("manager signature invalid!\n");
 		}
 
 		break;

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -39,7 +39,7 @@ static struct policydb *get_policydb(void)
 void apply_kernelsu_rules()
 {
 	if (!getenforce()) {
-		pr_info("SELinux permissive or disabled, apply rules!");
+		pr_info("SELinux permissive or disabled, apply rules!\n");
 	}
 
 	rcu_read_lock();
@@ -249,7 +249,7 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 		} else if (subcmd == 4) {
 			success = ksu_dontaudit(db, s, t, c, p);
 		} else {
-			pr_err("sepol: unknown subcmd: %d", subcmd);
+			pr_err("sepol: unknown subcmd: %d\n", subcmd);
 		}
 		ret = success ? 0 : -1;
 
@@ -294,7 +294,7 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 		} else if (subcmd == 3) {
 			success = ksu_dontauditxperm(db, s, t, c, perm_set);
 		} else {
-			pr_err("sepol: unknown subcmd: %d", subcmd);
+			pr_err("sepol: unknown subcmd: %d\n", subcmd);
 		}
 		ret = success ? 0 : -1;
 	} else if (cmd == CMD_TYPE_STATE) {
@@ -311,7 +311,7 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 		} else if (subcmd == 2) {
 			success = ksu_enforce(db, src);
 		} else {
-			pr_err("sepol: unknown subcmd: %d", subcmd);
+			pr_err("sepol: unknown subcmd: %d\n", subcmd);
 		}
 		if (success)
 			ret = 0;
@@ -426,7 +426,7 @@ int handle_sepolicy(unsigned long arg3, void __user *arg4)
 			success = ksu_type_member(db, src, tgt, cls,
 						  default_type);
 		} else {
-			pr_err("sepol: unknown subcmd: %d", subcmd);
+			pr_err("sepol: unknown subcmd: %d\n", subcmd);
 		}
 		if (success)
 			ret = 0;

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -44,7 +44,7 @@ static int transive_to_domain(const char *domain)
 void setup_selinux(const char *domain)
 {
 	if (transive_to_domain(domain)) {
-		pr_err("transive domain failed.");
+		pr_err("transive domain failed.\n");
 		return;
 	}
 

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -592,14 +592,14 @@ static bool add_filename_trans(struct policydb *db, const char *s,
 		trans = (struct filename_trans_datum *)kcalloc(sizeof(*trans),
 							       1, GFP_ATOMIC);
 		if (!trans) {
-			pr_err("add_filename_trans: Failed to alloc datum");
+			pr_err("add_filename_trans: Failed to alloc datum\n");
 			return false;
 		}
 		struct filename_trans *new_key =
 			(struct filename_trans *)kmalloc(sizeof(*new_key),
 							 GFP_ATOMIC);
 		if (!new_key) {
-			pr_err("add_filename_trans: Failed to alloc new_key");
+			pr_err("add_filename_trans: Failed to alloc new_key\n");
 			return false;
 		}
 		*new_key = key;


### PR DESCRIPTION
1. Adapt to low version Android init process
2. Add stop hook output
3. Fix output with missing line breaks