### PR TITLE
KernelSU: selinux: fix Modules install stuck on kernel 4.4

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -63,6 +63,7 @@ void apply_kernelsu_rules()
 		ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "blk_file", ALL);
 		ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "fifo_file", ALL);
 		ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "chr_file", ALL);
+		ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "file", ALL);
 	}
 
 	// we need to save allowlist in /data/adb/ksu


### PR DESCRIPTION
This fixes that the Module Installer is stuck when installing any Modules on Kernel 4.4