### PR TITLE
support umount modules for 4.4 or higher Non-GKI kernel

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -33,7 +33,7 @@
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
 
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 extern inline bool may_mount(void);
 extern inline int check_mnt(struct mount *mnt);
 extern void mntput_no_expire(struct mount *mnt);
@@ -538,7 +538,7 @@ static void ksu_umount_mnt(struct path *path, int flags)
 	if (err) {
 		pr_info("umount %s failed: %d\n", path->dentry->d_iname, err);
 	}
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 	int err = ksu_path_umount(path, flags);
 	if (err) {
 		pr_info("umount %s failed: %d\n", path->dentry->d_iname, err);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -542,8 +542,6 @@ static void ksu_umount_mnt(struct path *path, int flags)
 	int err = ksu_path_umount(path, flags);
 	if (err) {
 		pr_info("umount %s failed: %d\n", path->dentry->d_iname, err);
-	}else{
-		pr_info("umount %s successful: %d\n", path->dentry->d_iname, err);
 	}
 #else
 	//not tested


### PR DESCRIPTION
4.4内核及以上模块卸载。

只试过4.9，手上没设备了

To do:为了使用fs/namespace.c里面某些static函数，我把他们的static删了，参考这个[commit](https://github.com/wxt1221/android_kernel_oneplus_sdm845/commit/70ace81f14c97cf7896eb09c1f5a3c02a5f012ea)（只关注fs/namespace.c）的更改，在我的一加6t内核中没有问题，有没有更优雅的方式呢