### PR TITLE
讓artifact可以正確導出

### DIFF
--- a/.github/workflows/build-kernel-a14.yml
+++ b/.github/workflows/build-kernel-a14.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Upload images artifact
         uses: actions/upload-artifact@v3
         with:
-          name: boot-images-android13
-          path: Image-android13*/*.img.gz
+          name: boot-images-android14
+          path: Image-android14*/*.img.gz
 
   check-build-kernel:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
修正artifact無法被導出的問題
[action](https://github.com/tiann/KernelSU/actions/runs/6597355879)
Annotations
1 warning
upload-artifacts
No files were found with the provided path: Image-android13*/*.img.gz. No artifacts will be uploaded.