### PR TITLE
Remove non-GKI kernel(Huawei P10) that are no longer maintained

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -287,13 +287,6 @@
         "devices": "XK20 Pro Raphael  DSP & A only SAR support "
     },
     {
-        "maintainer": "Coconutat",
-        "maintainer_link": "https://github.com/Coconutat",
-        "kernel_name": "android_kernel_huawei_vtr_emui9_KernelSU",
-        "kernel_link": "https://github.com/Coconutat/android_kernel_huawei_vtr_emui9_KernelSU",
-        "devices": "Huawei P10,P10 Plus,Mate9,Mate9 Pro(Kirin960 Series),Stable For GSI"
-    },
-    {
         "maintainer": "dabao1955",
         "maintainer_link": "https://github.com/dabao1955",
         "kernel_name": "android_kernel_OPPO_PEQM00",


### PR DESCRIPTION
Due to job changes, I no longer maintain this kernel. Therefore, I will delete this repo website link.