### PR TITLE
templates: Update templates and try to get rid with `CAP_SYS_ADMIN`

### DIFF
--- a/website/docs/public/templates/kernelmanager.root
+++ b/website/docs/public/templates/kernelmanager.root
@@ -6,14 +6,14 @@
     "uid":0,
     "gid":0,
     "groups":[
-        "ROOT"
+        "ROOT",
+        "READPROC"
     ],
     "capabilities":[
         "CAP_SYS_MODULE",
         "CAP_SYS_NICE",
         "CAP_SYS_RESOURCE",
         "CAP_KILL",
-        "CAP_SYS_PTRACE",
         "CAP_SYSLOG",
         "CAP_PERFMON"
     ],

--- a/website/docs/public/templates/kernelmanager.root
+++ b/website/docs/public/templates/kernelmanager.root
@@ -9,10 +9,12 @@
         "ROOT"
     ],
     "capabilities":[
-        "CAP_SYS_ADMIN",
+        "CAP_SYS_MODULE",
         "CAP_SYS_NICE",
         "CAP_SYS_RESOURCE",
         "CAP_KILL",
+        "CAP_SYS_PTRACE",
+        "CAP_SYSLOG",
         "CAP_PERFMON"
     ],
     "context":"u:r:su:s0",

--- a/website/docs/public/templates/rootexploler.root
+++ b/website/docs/public/templates/rootexploler.root
@@ -9,8 +9,9 @@
         "ROOT"
     ],
     "capabilities":[
-        "CAP_SYS_ADMIN",
-        "CAP_DAC_OVERRIDE"
+        "CAP_DAC_READ_SEARCH",
+        "CAP_DAC_OVERRIDE",
+        "CAP_SYS_ADMIN"
     ],
     "context":"u:r:su:s0",
     "namespace":"INHERITED",


### PR DESCRIPTION
- The use of CAP_SYS_ADMIN can be avoided in Kernel Manager, but cannot be avoided in Root Explorer because it's needed for mounting RW/RO.
- Capabilities adjustment
- Fix template typo