### PR TITLE
[add device]: Huawei nova 2 (pic)

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -551,5 +551,12 @@
         "kernel_name": "liquid_kernel_realme_even",
         "kernel_link": "https://github.com/liquidprjkt/liquid_kernel_realme_even",
         "devices": "Realme C25/s and Narzo50A (even)"
+    },
+    {
+        "maintainer": "CoolestEnoch",
+        "maintainer_link": "https://github.com/CoolestEnoch",
+        "kernel_name": "kernel-su-huawei-nova2",
+        "kernel_link": "https://github.com/CoolestEnoch/kernel-su-huawei-nova2",
+        "devices": "Huawei nova 2 (pic)"
     }
 ]


### PR DESCRIPTION
Add Huawei nova 2 (pic) device that is a non-GKI kernel (Linux 4.4), regularly build with Github Actions weekly. This kernel is based on LineageOS kernel.