### PR TITLE
Add android12-5.10-2023-11 (sublevel: 198) to CI build flow.

### DIFF
--- a/.github/workflows/build-kernel-a12.yml
+++ b/.github/workflows/build-kernel-a12.yml
@@ -43,6 +43,8 @@ jobs:
             os_patch_level: 2023-07
           - sub_level: 185
             os_patch_level: 2023-09
+          - sub_level: 198
+            os_patch_level: 2023-11
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Add this kernel from https://source.android.com/docs/core/architecture/kernel/gki-android12-5_10-release-builds#november-2023-releases to CI