### PR TITLE
templates/kernelmanager.root: add `CAP_SYS_BOOT` capability

### DIFF
--- a/website/docs/public/templates/kernelmanager.root
+++ b/website/docs/public/templates/kernelmanager.root
@@ -15,7 +15,8 @@
         "CAP_SYS_RESOURCE",
         "CAP_KILL",
         "CAP_SYSLOG",
-        "CAP_PERFMON"
+        "CAP_PERFMON",
+        "CAP_SYS_BOOT"
     ],
     "context":"u:r:su:s0",
     "namespace":"INHERITED",


### PR DESCRIPTION
* Needed for kernel flasher