### PR TITLE
[add device] pixel 3a

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -558,5 +558,12 @@
         "kernel_name": "android_kernel_google_redbull",
         "kernel_link": "https://github.com/QKIvan/android_kernel_google_redbull",
         "devices": "Google Pixel 4a 5G & 5 (bramble & redfin)"
+    },
+    {
+        "maintainer": "josedelinux",
+        "maintainer_link": "https://github.com/josedelinux",
+        "kernel_name": "kernel_google_msm-4.9",
+        "kernel_link": "https://github.com/josedelinux/kernel_google_msm-4.9",
+        "devices": "Google Pixel 3a & 3a XL (sargo & bonito)"
     }
 ]


### PR DESCRIPTION
[add device] pixel 3a

There is a usable ksu image for Pixel 3a, but it's obsolete and doesn't work with latest ksu manager
here is my fork with latest ksu