### PR TITLE
ci: remove a14 6.1 2024-01

### DIFF
--- a/.github/workflows/build-kernel-a14.yml
+++ b/.github/workflows/build-kernel-a14.yml
@@ -36,9 +36,6 @@ jobs:
           - version: "6.1"
             sub_level: 57
             os_patch_level: 2023-12
-          - version: "6.1"
-            sub_level: 68
-            os_patch_level: 2024-01
     uses: ./.github/workflows/gki-kernel.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Not released
https://android.googlesource.com/kernel/common/+/refs/heads/android14-6.1-2024-01