### PR TITLE
[非官方支持设备]修正K-Nel-M1721内核的仓库网址

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -584,7 +584,7 @@
         "maintainer": "KJ-Network",
         "maintainer_link": "https://github.com/KJ-Network",
         "kernel_name": "K-Nel-M1721",
-        "kernel_link": "https://https://github.com/KJ-Network/K-Nel-M1721/",
+        "kernel_link": "https://github.com/KJ-Network/K-Nel-M1721/",
         "devices": "Meizu M6 Note (M1721)"
     }    
 ]


### PR DESCRIPTION
合并之前没发现偏偏合并以后发现多了个https://
之前的合并请求关闭了，只能再开一个（）