### PR TITLE
Add types in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "Library for KernelSU's module WebUI",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "npm run test"
   },


### PR DESCRIPTION
The package can not be imported into TS project without this option. [docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)