### PR TITLE
[CI][A14] a14-5.15 patch level 2024-01 and 2024-02

### DIFF
--- a/.github/workflows/build-kernel-a14.yml
+++ b/.github/workflows/build-kernel-a14.yml
@@ -27,6 +27,12 @@ jobs:
           - version: "5.15"
             sub_level: 131
             os_patch_level: 2023-11
+          - version: "5.15"
+            sub_level: 137
+            os_patch_level: 2024-01
+          - version: "5.15"
+            sub_level: 144
+            os_patch_level: 2024-02
           - version: "6.1"
             sub_level: 25
             os_patch_level: 2023-10


### PR DESCRIPTION
Since android14 5.15.137 (2024-01) was released with QPR3 Beta2 on Pixel 8(Pro)