### PR TITLE
manager: a small fix in InstallScreen

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Install.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Install.kt
@@ -46,7 +46,7 @@ import java.util.*
 fun InstallScreen(navigator: DestinationsNavigator, uri: Uri) {
 
     var text by rememberSaveable { mutableStateOf("") }
-    val logContent = StringBuilder()
+    val logContent = rememberSaveable { StringBuilder() }
     var showFloatAction by rememberSaveable { mutableStateOf(false) }
 
     val snackBarHost = LocalSnackbarHost.current
@@ -64,9 +64,6 @@ fun InstallScreen(navigator: DestinationsNavigator, uri: Uri) {
                 }
             }, onStdout = {
                 text += "$it\n"
-                scope.launch {
-                    scrollState.animateScrollTo(scrollState.maxValue)
-                }
                 logContent.append(it).append("\n")
             }, onStderr = {
                 logContent.append(it).append("\n")
@@ -121,6 +118,9 @@ fun InstallScreen(navigator: DestinationsNavigator, uri: Uri) {
                 .padding(innerPadding)
                 .verticalScroll(scrollState),
         ) {
+            LaunchedEffect(text) {
+                scrollState.animateScrollTo(scrollState.maxValue)
+            }
             Text(
                 modifier = Modifier.padding(8.dp),
                 text = text,


### PR DESCRIPTION
今天刷一个模块，刷入时要配置一些内容，然后发现每次输出我都得手动滑动一下才能看全内容，就很难受。气得我直接翻源码，就有了这个PR   :P

- 防止logContent在重组时丢失。
- 修复输出内容总是自动滚动到上次内容的最底部，而不是最新内容的最底部的f问题。