### PR TITLE
Add nethunter.root template

### DIFF
--- a/website/docs/public/templates/nethunter.root
+++ b/website/docs/public/templates/nethunter.root
@@ -15,6 +15,7 @@
         "CAP_SYS_CHROOT",
         "CAP_SYS_PTRACE",
         "CAP_SYS_ADMIN"
+        "CAP_SETGID",
     ],
     "context":"u:r:su:s0",
     "rules":[""]

--- a/website/docs/public/templates/nethunter.root
+++ b/website/docs/public/templates/nethunter.root
@@ -1,0 +1,21 @@
+{
+    "id":"nethunter.root",
+    "name":"Kali NetHunter",
+    "author":"cachiusa",
+    "description":"Required permissions for Kali NetHunter app to chroot",
+    "namespace":"INHERITED",
+    "uid":0,
+    "gid":0,
+    "groups":[
+        "ROOT"
+    ],
+    "capabilities":[
+        "CAP_DAC_OVERRIDE",
+        "CAP_DAC_READ_SEARCH",
+        "CAP_SYS_CHROOT",
+        "CAP_SYS_PTRACE",
+        "CAP_SYS_ADMIN"
+    ],
+    "context":"u:r:su:s0",
+    "rules":[""]
+}


### PR DESCRIPTION
This app requires DAC_OVERRIDE, DAC_READ_SEARCH, SYS_PTRACE, SYS_ADMIN (for /data/local r/w) and SYS_CHROOT, SETGID (to run chroot and run it's processes)

Devices with NetHunter installed is already considered compromised due to lack of security features(like SELinux), therefore users are advised not to store private data

It's not really worth restricting more capabilities of the app.