### PR TITLE
kernel:Compatible with devices based on Huawei EMUI10

### DIFF
--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -14,8 +14,10 @@
  * Huawei Hisi Kernel EBITMAP Enable or Disable Flag ,
  * From ss/ebitmap.h
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) &&                           \
-	LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0) || \
+    LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0) && \
+    LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 #ifdef HISI_SELINUX_EBITMAP_RO
 #define CONFIG_IS_HW_HISI
 #endif


### PR DESCRIPTION
EMUI 10 kernel version is 4.14.xxx.  
The SELinux of Huawei's modified EMUI10 kernel is still similar to the EMUI 9 version.   This commit not support HarmonyOS 2 based EMUI 10.