### PR TITLE
[CI][A13] a13-5.10 patch level 2024-02

### DIFF
--- a/.github/workflows/build-kernel-a13.yml
+++ b/.github/workflows/build-kernel-a13.yml
@@ -37,6 +37,9 @@ jobs:
             sub_level: 177
             os_patch_level: 2023-07
           - version: "5.10"
+            sub_level: 177
+            os_patch_level: 2024-02
+          - version: "5.10"
             sub_level: 186
             os_patch_level: 2023-08
           - version: "5.10"


### PR DESCRIPTION
My Pixel 7a has a kernel version `5.10.177-android13-4-00003-ga7208022a7ea-ab1081582`, with a security patch of 2024-02, but the only available kernel build for that is security patch 2023-07 which causes a bootloop.