### PR TITLE
kernel: Make it compile on 3.18 (maybe older) kernels

### DIFF
--- a/kernel/kernel_compat.c
+++ b/kernel/kernel_compat.c
@@ -3,13 +3,10 @@
 #include "linux/nsproxy.h"
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 10, 0)
 #include "linux/sched/task.h"
-#include "linux/uaccess.h"
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
-#include "linux/uaccess.h"
-#include "linux/sched.h"
 #else
 #include "linux/sched.h"
 #endif
+#include "linux/uaccess.h"
 #include "klog.h" // IWYU pragma: keep
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -3,7 +3,15 @@
 #include "linux/dcache.h"
 #include "linux/err.h"
 #include "linux/fs.h"
+#include "linux/version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 #include "linux/input-event-codes.h"
+#else
+#include "uapi/linux/input.h"
+#endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
+#include "linux/aio.h"
+#endif
 #include "linux/kprobes.h"
 #include "linux/printk.h"
 #include "linux/types.h"


### PR DESCRIPTION
input-event-codes.h:

Input: add input-event-codes header file (https://github.com/torvalds/linux/commit/f902dd893427eade90f7eaf858e5ff8b150a5a12) This was in 4.4-rc, so 4.4.0 or above has it else no.

aio.h:
fs: move struct kiocb to fs.h (https://github.com/torvalds/linux/commit/e2e40f2c1ed433c5e224525c8c862fd32e5d3df2)

Below this version, we need to explicitly include aio.h for struct kiocb This was in 4.1-rc, so 4.0 or below should do the include

uaccess.h, sched.h was present for long times, but 4.10 splited out to include/sched/ but the current ifdef is not including uaccess.h for lower versions than 4.4. Fix it.