### PR TITLE
fixup pre-4.20 builds

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -1,6 +1,5 @@
 #include "asm/current.h"
 #include "linux/compat.h"
-#include "linux/compiler_attributes.h"
 #include "linux/cred.h"
 #include "linux/dcache.h"
 #include "linux/err.h"
@@ -20,6 +19,9 @@
 #include "linux/types.h"
 #include "linux/uaccess.h"
 #include "linux/version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#include "linux/compiler_attributes.h"
+#endif
 #include "linux/workqueue.h"
 
 #include "allowlist.h"

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -1,5 +1,4 @@
 #include "asm/current.h"
-#include "linux/compiler_attributes.h"
 #include "linux/cred.h"
 #include "linux/err.h"
 #include "linux/fs.h"
@@ -7,6 +6,9 @@
 #include "linux/types.h"
 #include "linux/uaccess.h"
 #include "linux/version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#include "linux/compiler_attributes.h"
+#endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include "linux/sched/task_stack.h"
 #else


### PR DESCRIPTION
../drivers/../KernelSU/kernel/sucompat.c:2:10: fatal error: 'linux/compiler_attributes.h' file not found
    2 | #include "linux/compiler_attributes.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CHK     kernel/config_data.h

../drivers/../KernelSU/kernel/ksud.c:3:10: fatal error: 'linux/compiler_attributes.h' file not found
    3 | #include "linux/compiler_attributes.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[3]: *** [../scripts/Makefile.build:364: drivers/../KernelSU/kernel/ksud.o] Error 1
