### PR TITLE
[RFC] kernel: try umount /system/etc/hosts

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -613,6 +613,9 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	try_umount("/debug_ramdisk", false, MNT_DETACH);
 	try_umount("/sbin", false, MNT_DETACH);
 
+	// try umount /system/etc/hosts (hosts module)
+	try_umount("/system/etc/hosts", false, MNT_DETACH);
+
 	return 0;
 }
 


### PR DESCRIPTION
Modding hosts file is a common thing to have on rooted android devices.
But this is easy to detect, either by reading the file, checking modified time and checking its filesize.
Unmounting it as needed for non-root processes solves this issue.

This is a PR requesting for comments for this change. 
Use it with this module https://github.com/backslashxx/bindhosts/

