### PR TITLE
kernel: guard "umount for uid" logprint with CONFIG_KSU_DEBUG

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -517,9 +517,11 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 			current->pid);
 		return 0;
 	}
+#ifdef CONFIG_KSU_DEBUG
 	// umount the target mnt
 	pr_info("handle umount for uid: %d, pid: %d\n", new_uid.val,
 		current->pid);
+#endif
 
 	// fixme: use `collect_mounts` and `iterate_mount` to iterate all mountpoint and
 	// filter the mountpoint whose target is `/data/adb`


### PR DESCRIPTION
Its too spammy to be on non-debug mode.