### PR TITLE
throne_tracker: Fix Manager sometimes not detecting KSU and optimize it

### DIFF
--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -159,8 +159,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 		iterate_dir(file, &sub_ctx.ctx);
 		filp_close(file, NULL);
 	} else {
-		if ((strlen(name) == strlen("base.apk")) &&
-		    (strncmp(name, "base.apk", strlen("base.apk")) == 0)) {
+		if ((namelen == 8) && (strncmp(name, "base.apk", namelen) == 0)) {
 			bool is_manager = is_manager_apk(dirpath);
 			pr_info("Found base.apk at path: %s, is_manager: %d\n",
 				dirpath, is_manager);


### PR DESCRIPTION
The original logic was wrong and used 3 strlen()s for every file found, wasting cpu.

Optimize it by first comparing only the filename length, given we already know it,
and then strncmp() to compare with "base.apk"

Tested successfully on my Bandido Kernel (4.19)
