### PR TITLE
Exclude minidump.gz when collecting xiaomi logs

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/LogEvent.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/LogEvent.kt
@@ -45,7 +45,7 @@ fun getBugreportFile(context: Context): File {
     shell.newJob().add("tar -czf ${tombstonesFile.absolutePath} -C /data/tombstones .").exec()
     shell.newJob().add("tar -czf ${dropboxFile.absolutePath} -C /data/system/dropbox .").exec()
     shell.newJob().add("tar -czf ${pstoreFile.absolutePath} -C /sys/fs/pstore .").exec()
-    shell.newJob().add("tar -czf ${diagFile.absolutePath} -C /data/vendor/diag .").exec()
+    shell.newJob().add("tar -czf ${diagFile.absolutePath} -C /data/vendor/diag . --exclude=./minidump.gz").exec()
     shell.newJob().add("tar -czf ${opulsFile.absolutePath} -C /mnt/oplus/op2/media/log/boot_log/ .").exec()
     shell.newJob().add("tar -czf ${bootlogFile.absolutePath} -C /data/adb/ksu/log .").exec()
 


### PR DESCRIPTION
Saves about ~80MB space.