### PR TITLE
manager: Use AM instead of Monkey to start the app.

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -366,7 +366,7 @@ fun launchApp(packageName: String) {
 
     val shell = getRootShell()
     val result =
-        shell.newJob().add("cmd activity start -n $(cmd package resolve-activity --brief $packageName | tail -n 1)").exec()
+        shell.newJob().add("cmd package resolve-activity --brief $packageName | tail -n 1 | xargs cmd activity start-activity -n").exec()
     Log.i(TAG, "launch $packageName result: $result")
 }
 


### PR DESCRIPTION
Using Monkey will unlock the rotation, and possibly more unintended behavior.
link: [ADB shell monkey command changing device orientation lock](https://stackoverflow.com/q/56684778)