### PR TITLE
fix #1559

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/SELinuxChecker.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/SELinuxChecker.kt
@@ -12,7 +12,9 @@ fun getSELinuxStatus(): String {
         .build("sh")
 
     val list = ArrayList<String>()
-    val result = shell.newJob().add("getenforce").to(list, list).exec()
+    val result = shell.use {
+        it.newJob().add("getenforce").to(list, list).exec()
+    }
     val output = result.out.joinToString("\n").trim()
 
     if (result.isSuccess) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/SuFilePathHandler.java
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/SuFilePathHandler.java
@@ -84,14 +84,14 @@ public final class SuFilePathHandler implements WebViewAssetLoader.PathHandler {
      *                  which files can be loaded.
      * @throws IllegalArgumentException if the directory is not allowed.
      */
-    public SuFilePathHandler(@NonNull Context context, @NonNull File directory) {
+    public SuFilePathHandler(@NonNull Context context, @NonNull File directory, Shell rootShell) {
         try {
             mDirectory = new File(getCanonicalDirPath(directory));
             if (!isAllowedInternalStorageDir(context)) {
                 throw new IllegalArgumentException("The given directory \"" + directory
                         + "\" doesn't exist under an allowed app internal storage directory");
             }
-            mShell = KsuCliKt.createRootShell(true);
+            mShell = rootShell;
         } catch (IOException e) {
             throw new IllegalArgumentException(
                     "Failed to resolve the canonical path for the given directory: "

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
@@ -10,11 +10,15 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
 import androidx.webkit.WebViewAssetLoader
+import com.topjohnwu.superuser.Shell
+import me.weishu.kernelsu.ui.util.createRootShell
 import java.io.File
 
 @SuppressLint("SetJavaScriptEnabled")
-class WebUIActivity : ComponentActivity()  {
+class WebUIActivity : ComponentActivity() {
     private lateinit var webviewInterface: WebViewInterface
+
+    private var rootShell: Shell? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,11 +30,12 @@ class WebUIActivity : ComponentActivity()  {
         WebView.setWebContentsDebuggingEnabled(prefs.getBoolean("enable_web_debugging", false))
 
         val webRoot = File("/data/adb/modules/${moduleId}/webroot")
+        val rootShell = createRootShell(true).also { this.rootShell = it }
         val webViewAssetLoader = WebViewAssetLoader.Builder()
             .setDomain("mui.kernelsu.org")
             .addPathHandler(
                 "/",
-                SuFilePathHandler(this, webRoot)
+                SuFilePathHandler(this, webRoot, rootShell)
             )
             .build()
 
@@ -54,5 +59,10 @@ class WebUIActivity : ComponentActivity()  {
         }
 
         setContentView(webView)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        runCatching { rootShell?.close() }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
@@ -15,6 +15,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.ShellUtils
 import me.weishu.kernelsu.ui.util.createRootShell
+import me.weishu.kernelsu.ui.util.withNewRootShell
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.CompletableFuture
@@ -23,7 +24,7 @@ class WebViewInterface(val context: Context, private val webView: WebView) {
 
     @JavascriptInterface
     fun exec(cmd: String): String {
-        return createRootShell(true).use { ShellUtils.fastCmd(it, cmd) }
+        return withNewRootShell(true) { ShellUtils.fastCmd(this, cmd) }
     }
 
     @JavascriptInterface
@@ -58,8 +59,8 @@ class WebViewInterface(val context: Context, private val webView: WebView) {
         processOptions(finalCommand, options)
         finalCommand.append(cmd)
 
-        val result = createRootShell(true).use {
-            it.newJob().add(finalCommand.toString()).to(ArrayList(), ArrayList()).exec()
+        val result = withNewRootShell(true) {
+            newJob().add(finalCommand.toString()).to(ArrayList(), ArrayList()).exec()
         }
         val stdout = result.out.joinToString(separator = "\n")
         val stderr = result.err.joinToString(separator = "\n")


### PR DESCRIPTION
这个问题早些天我就遇到过，不过没怎么细究，今天又遇到了，就花了点时间捣鼓了一下。

一开始有点懵，好好的为什么会突然获取root失败。直到我`ps -A | grep <kernelsu pid>`看到一连十几个`sh`子进程，但没有一个是root进程，接着又花了点时间找复现方法，最终

复现步骤:
- 首先打开KernelSU
- 在首页和其他页之间来回切
- 通过`ps -A | grep <kernelsu pid>`可以发现，会出现一堆子进程，其中会有两个是root进程
- 继续在首页和其他页之间来回切
- 再执行`ps -A | grep <kernelsu pid>`, root进程消失了，应该是被系统杀了
- KernelSU首页弹出获取root失败

我感觉这样处理有点粗糙，应该将shell获取规范一下，而不是哪哪都创建一个。术哥怎么看 :P
