### PR TITLE
Hook syscalls and stable symbols

### DIFF
--- a/kernel/arch.h
+++ b/kernel/arch.h
@@ -24,18 +24,12 @@
 #define SYS_NEWFSTATAT_SYMBOL "__arm64_sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "__arm64_sys_faccessat"
 #define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
-#define SYS_EXECVEAT_SYMBOL "__arm64_sys_execveat"
-#define COMPAT_SYS_EXECVE_SYMBOL "__arm64_compat_sys_execve"
-#define COMPAT_SYS_EXECVEAT_SYMBOL "__arm64_compat_sys_execveat"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_NEWFSTATAT_SYMBOL "sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "sys_faccessat"
 #define SYS_EXECVE_SYMBOL "sys_execve"
-#define SYS_EXECVEAT_SYMBOL "sys_execveat"
-#define COMPAT_SYS_EXECVE_SYMBOL "compat_sys_execve"
-#define COMPAT_SYS_EXECVEAT_SYMBOL "compat_sys_execveat"
 #endif
 
 #elif defined(__x86_64__)
@@ -58,11 +52,13 @@
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_NEWFSTATAT_SYMBOL "__x64_sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "__x64_sys_faccessat"
+#define SYS_EXECVE_SYMBOL "__x64_sys_execve"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_NEWFSTATAT_SYMBOL "sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "sys_faccessat"
+#define SYS_EXECVE_SYMBOL "sys_execve"
 #endif
 
 #else

--- a/kernel/arch.h
+++ b/kernel/arch.h
@@ -23,11 +23,19 @@
 #define SYS_READ_SYMBOL "__arm64_sys_read"
 #define SYS_NEWFSTATAT_SYMBOL "__arm64_sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "__arm64_sys_faccessat"
+#define SYS_EXECVE_SYMBOL "__arm64_sys_execve"
+#define SYS_EXECVEAT_SYMBOL "__arm64_sys_execveat"
+#define COMPAT_SYS_EXECVE_SYMBOL "__arm64_compat_sys_execve"
+#define COMPAT_SYS_EXECVEAT_SYMBOL "__arm64_compat_sys_execveat"
 #else
 #define PRCTL_SYMBOL "sys_prctl"
 #define SYS_READ_SYMBOL "sys_read"
 #define SYS_NEWFSTATAT_SYMBOL "sys_newfstatat"
 #define SYS_FACCESSAT_SYMBOL "sys_faccessat"
+#define SYS_EXECVE_SYMBOL "sys_execve"
+#define SYS_EXECVEAT_SYMBOL "sys_execveat"
+#define COMPAT_SYS_EXECVE_SYMBOL "compat_sys_execve"
+#define COMPAT_SYS_EXECVEAT_SYMBOL "compat_sys_execveat"
 #endif
 
 #elif defined(__x86_64__)

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -743,7 +743,7 @@ void ksu_ksud_exit() {
 	unregister_kprobes(execve_kps, 4);
 #else
 	unregister_kprobe(&execve_kp);
-#endif	
+#endif
 	// this should be done before unregister vfs_read_kp
 	// unregister_kprobe(&vfs_read_kp);
 	unregister_kprobe(&input_event_kp);

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -650,6 +650,6 @@ void ksu_ksud_exit() {
 	unregister_kprobe(&execve_kp);
 	// this should be done before unregister vfs_read_kp
 	// unregister_kprobe(&vfs_read_kp);
-	unregister_kprobe(&input_event_kp);
+	unregister_kprobes(input_event_kps, 2);
 #endif
 }

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -5,7 +5,6 @@
 #include "linux/err.h"
 #include "linux/file.h"
 #include "linux/fs.h"
-#include "linux/namei.h"
 #include "linux/version.h"
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 #include "linux/input-event-codes.h"
@@ -177,7 +176,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 		return 0;
 	}
 
-	if (unlikely(!memcmp(filename->name, system_bin_init, 
+	if (unlikely(!memcmp(filename->name, system_bin_init,
 				sizeof(system_bin_init) - 1) && argv)) {
 		// /system/bin/init executed
 		int argc = count(*argv, MAX_ARG_STRINGS);
@@ -255,6 +254,119 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
 
 	if (unlikely(first_app_process &&
 		!memcmp(filename->name, app_process, sizeof(app_process) - 1))) {
+		first_app_process = false;
+		pr_info("exec app_process, /data prepared, second_stage: %d\n", init_second_stage_executed);
+		on_post_fs_data(); // we keep this for old ksud
+		stop_execve_hook();
+	}
+
+	return 0;
+}
+
+int ksu_handle_execve_ksud(int *fd, const char **filename_ptr,
+				struct user_arg_ptr *argv, struct user_arg_ptr *envp, int *flags)
+{
+	static const char app_process[] = "/system/bin/app_process";
+	static bool first_app_process = true;
+
+	/* This applies to versions Android 10+ */
+	static const char system_bin_init[] = "/system/bin/init";
+	/* This applies to versions between Android 6 ~ 9  */
+	static const char old_system_init[] = "/init";
+	static bool init_second_stage_executed = false;
+
+	char filename[sizeof(app_process) + 1];
+
+#ifndef CONFIG_KPROBES
+	if (!ksu_execveat_hook) {
+		return 0;
+	}
+#endif
+
+	if (!filename_ptr)
+		return 0;
+
+	memset(filename, 0, sizeof(filename));
+	ksu_strncpy_from_user_nofault(filename, *filename_ptr, sizeof(filename));
+
+	if (unlikely(!memcmp(filename, system_bin_init, 
+				sizeof(system_bin_init) - 1) && argv)) {
+		// /system/bin/init executed
+		int argc = count(*argv, MAX_ARG_STRINGS);
+		pr_info("/system/bin/init argc: %d\n", argc);
+		if (argc > 1 && !init_second_stage_executed) {
+			const char __user *p = get_user_arg_ptr(*argv, 1);
+			if (p && !IS_ERR(p)) {
+				char first_arg[16];
+				ksu_strncpy_from_user_nofault(first_arg, p, sizeof(first_arg));
+				pr_info("/system/bin/init first arg: %s\n", first_arg);
+				if (!strcmp(first_arg, "second_stage")) {
+					pr_info("/system/bin/init second_stage executed\n");
+					apply_kernelsu_rules();
+					init_second_stage_executed = true;
+					ksu_android_ns_fs_check();
+				}
+			} else {
+				pr_err("/system/bin/init parse args err!\n");
+			}
+		}
+	} else if (unlikely(!memcmp(filename, old_system_init,
+				sizeof(old_system_init) - 1) && argv)) {
+		// /init executed
+		int argc = count(*argv, MAX_ARG_STRINGS);
+		pr_info("/init argc: %d\n", argc);
+		if (argc > 1 && !init_second_stage_executed) {
+			/* This applies to versions between Android 6 ~ 7 */
+			const char __user *p = get_user_arg_ptr(*argv, 1);
+			if (p && !IS_ERR(p)) {
+				char first_arg[16];
+				ksu_strncpy_from_user_nofault(first_arg, p, sizeof(first_arg));
+				pr_info("/init first arg: %s\n", first_arg);
+				if (!strcmp(first_arg, "--second-stage")) {
+					pr_info("/init second_stage executed\n");
+					apply_kernelsu_rules();
+					init_second_stage_executed = true;
+					ksu_android_ns_fs_check();
+				}
+			} else {
+				pr_err("/init parse args err!\n");
+			}
+		} else if (argc == 1 && !init_second_stage_executed && envp) {
+			/* This applies to versions between Android 8 ~ 9  */
+			int envc = count(*envp, MAX_ARG_STRINGS);
+			if (envc > 0) {
+				int n;
+				for (n = 1; n <= envc; n++) {
+					const char __user *p = get_user_arg_ptr(*envp, n);
+					if (!p || IS_ERR(p)) {
+						continue;
+					}
+					char env[256];
+					// Reading environment variable strings from user space
+					if (ksu_strncpy_from_user_nofault(env, p, sizeof(env)) < 0)
+						continue;
+					// Parsing environment variable names and values
+					char *env_name = env;
+					char *env_value = strchr(env, '=');
+					if (env_value == NULL)
+						continue;
+					// Replace equal sign with string terminator
+					*env_value = '\0';
+					env_value++;
+					// Check if the environment variable name and value are matching
+					if (!strcmp(env_name, "INIT_SECOND_STAGE") && (!strcmp(env_value, "1") || !strcmp(env_value, "true"))) {
+						pr_info("/init second_stage executed\n");
+						apply_kernelsu_rules();
+						init_second_stage_executed = true;
+						ksu_android_ns_fs_check();
+					}
+				}
+			}
+		}
+	}
+
+	if (unlikely(first_app_process &&
+		!memcmp(filename, app_process, sizeof(app_process) - 1))) {
 		first_app_process = false;
 		pr_info("exec app_process, /data prepared, second_stage: %d\n", init_second_stage_executed);
 		on_post_fs_data(); // we keep this for old ksud
@@ -480,15 +592,12 @@ static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
 #else
 	struct pt_regs *real_regs = regs;
 #endif
-	const char __user *filename_user =
-		(const char *)PT_REGS_PARM1(real_regs);
-	struct filename *filename_mid = getname(filename_user);
-	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const char __user **filename_user = (const char **)&PT_REGS_PARM1(real_regs);
 	const char __user *const __user *__argv =
 		(const char __user *const __user *)PT_REGS_PARM2(real_regs);
 	struct user_arg_ptr argv = { .ptr.native = __argv };
 
-	return ksu_handle_execveat_ksud(AT_FDCWD, filename_ptr, &argv, NULL,
+	return ksu_handle_execve_ksud(AT_FDCWD, filename_user, &argv, NULL,
 					NULL);
 }
 

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -5,6 +5,7 @@
 #include "linux/err.h"
 #include "linux/file.h"
 #include "linux/fs.h"
+#include "linux/namei.h"
 #include "linux/version.h"
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 #include "linux/input-event-codes.h"
@@ -472,6 +473,89 @@ static int execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
 	return ksu_handle_execveat_ksud(fd, filename_ptr, &argv, NULL, NULL);
 }
 
+static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
+	struct pt_regs *real_regs = (struct pt_regs *)PT_REGS_PARM1(regs);
+#else
+	struct pt_regs *real_regs = regs;
+#endif
+	const char __user *filename_user =
+		(const char *)PT_REGS_PARM1(real_regs);
+	struct filename *filename_mid = getname(filename_user);
+	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const char __user *const __user *__argv =
+		(const char __user *const __user *)PT_REGS_PARM2(real_regs);
+	struct user_arg_ptr argv = { .ptr.native = __argv };
+
+	return ksu_handle_execveat_ksud(AT_FDCWD, filename_ptr, &argv, NULL,
+					NULL);
+}
+
+static int sys_execveat_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
+	struct pt_regs *real_regs = (struct pt_regs *)PT_REGS_PARM1(regs);
+#else
+	struct pt_regs *real_regs = regs;
+#endif
+	int *fd = (int *)&PT_REGS_PARM1(real_regs);
+	const char __user *filename_user =
+		(const char *)PT_REGS_PARM2(real_regs);
+	int flags = PT_REGS_PARM5(real_regs);
+	int lookup_flags = (flags & AT_EMPTY_PATH) ? LOOKUP_EMPTY : 0;
+	struct filename *filename_mid =
+		getname_flags(filename_user, lookup_flags, NULL);
+	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const char __user *const __user *__argv =
+		(const char __user *const __user *)PT_REGS_PARM3(real_regs);
+	struct user_arg_ptr argv = { .ptr.native = __argv };
+
+	return ksu_handle_execveat_ksud(fd, filename_ptr, &argv, NULL, NULL);
+}
+
+static int compat_sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
+	struct pt_regs *real_regs = (struct pt_regs *)PT_REGS_PARM1(regs);
+#else
+	struct pt_regs *real_regs = regs;
+#endif
+	const char __user *filename_user =
+		(const char *)PT_REGS_PARM1(real_regs);
+	struct filename *filename_mid = getname(filename_user);
+	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const compat_uptr_t __user *__argv =
+		(const compat_uptr_t *)PT_REGS_PARM2(real_regs);
+	struct user_arg_ptr argv = { .ptr.compat = __argv, .is_compat = true };
+
+	return ksu_handle_execveat_ksud(AT_FDCWD, filename_ptr, &argv, NULL,
+					NULL);
+}
+
+static int compat_sys_execveat_handler_pre(struct kprobe *p,
+					   struct pt_regs *regs)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0)
+	struct pt_regs *real_regs = (struct pt_regs *)PT_REGS_PARM1(regs);
+#else
+	struct pt_regs *real_regs = regs;
+#endif
+	int *fd = (int *)&PT_REGS_PARM1(real_regs);
+	const char __user *filename_user =
+		(const char *)PT_REGS_PARM2(real_regs);
+	int flags = PT_REGS_PARM5(real_regs);
+	int lookup_flags = (flags & AT_EMPTY_PATH) ? LOOKUP_EMPTY : 0;
+	struct filename *filename_mid =
+		getname_flags(filename_user, lookup_flags, NULL);
+	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const compat_uptr_t __user *__argv =
+		(const compat_uptr_t *)PT_REGS_PARM3(real_regs);
+	struct user_arg_ptr argv = { .ptr.compat = __argv, .is_compat = true };
+
+	return ksu_handle_execveat_ksud(fd, filename_ptr, &argv, NULL, NULL);
+}
+
 // remove this later!
 __maybe_unused static int vfs_read_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
@@ -506,6 +590,32 @@ static int input_handle_event_handler_pre(struct kprobe *p,
 	return ksu_handle_input_handle_event(type, code, value);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+static struct kprobe execve_syscall_kp = {
+	.symbol_name = SYS_EXECVE_SYMBOL,
+	.pre_handler = sys_execve_handler_pre,
+};
+
+static struct kprobe execveat_syscall_kp = {
+	.symbol_name = SYS_EXECVEAT_SYMBOL,
+	.pre_handler = sys_execveat_handler_pre,
+};
+
+static struct kprobe compat_execve_syscall_kp = {
+	.symbol_name = COMPAT_SYS_EXECVE_SYMBOL,
+	.pre_handler = compat_sys_execve_handler_pre,
+};
+
+static struct kprobe compat_execveat_syscall_kp = {
+	.symbol_name = COMPAT_SYS_EXECVEAT_SYMBOL,
+	.pre_handler = compat_sys_execveat_handler_pre,
+};
+
+static struct kprobe *execve_kps[] = {
+	&execve_syscall_kp, &compat_execve_syscall_kp,
+	&execveat_syscall_kp, &compat_execveat_syscall_kp
+};
+#else
 static struct kprobe execve_kp = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
 	.symbol_name = "do_execveat_common",
@@ -516,6 +626,7 @@ static struct kprobe execve_kp = {
 #endif
 	.pre_handler = execve_handler_pre,
 };
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
 static struct kprobe vfs_read_kp = {
@@ -529,9 +640,18 @@ static struct kprobe vfs_read_kp = {
 };
 #endif
 
-static struct kprobe input_handle_event_kp = {
-	.symbol_name = "input_handle_event",
+static struct kprobe input_event_kp = {
+	.symbol_name = "input_event",
 	.pre_handler = input_handle_event_handler_pre,
+};
+
+static struct kprobe input_inject_event_kp = {
+	.symbol_name = "input_inject_event",
+	.pre_handler = input_handle_event_handler_pre,
+};
+
+static struct kprobe *input_event_kps[] = {
+	&input_event_kp, &input_inject_event_kp
 };
 
 static void do_stop_vfs_read_hook(struct work_struct *work)
@@ -541,12 +661,16 @@ static void do_stop_vfs_read_hook(struct work_struct *work)
 
 static void do_stop_execve_hook(struct work_struct *work)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+	unregister_kprobes(execve_kps, 4);
+#else
 	unregister_kprobe(&execve_kp);
+#endif
 }
 
 static void do_stop_input_hook(struct work_struct *work)
 {
-	unregister_kprobe(&input_handle_event_kp);
+	unregister_kprobes(input_event_kps, 2);
 }
 #endif
 
@@ -594,13 +718,17 @@ void ksu_ksud_init()
 #ifdef CONFIG_KPROBES
 	int ret;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+	ret = register_kprobes(execve_kps, 4);
+#else
 	ret = register_kprobe(&execve_kp);
+#endif
 	pr_info("ksud: execve_kp: %d\n", ret);
 
 	ret = register_kprobe(&vfs_read_kp);
 	pr_info("ksud: vfs_read_kp: %d\n", ret);
 
-	ret = register_kprobe(&input_handle_event_kp);
+	ret = register_kprobes(input_event_kps, 2);
 	pr_info("ksud: input_handle_event_kp: %d\n", ret);
 
 	INIT_WORK(&stop_vfs_read_work, do_stop_vfs_read_hook);
@@ -611,9 +739,13 @@ void ksu_ksud_init()
 
 void ksu_ksud_exit() {
 #ifdef CONFIG_KPROBES
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
+	unregister_kprobes(execve_kps, 4);
+#else
 	unregister_kprobe(&execve_kp);
+#endif	
 	// this should be done before unregister vfs_read_kp
 	// unregister_kprobe(&vfs_read_kp);
-	unregister_kprobe(&input_handle_event_kp);
+	unregister_kprobe(&input_event_kp);
 #endif
 }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -6,7 +6,6 @@
 #include "linux/types.h"
 #include "linux/uaccess.h"
 #include "linux/version.h"
-#include "linux/namei.h"
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
 #include "linux/sched/task_stack.h"
 #else
@@ -38,6 +37,13 @@ static char __user *sh_user_path(void)
 	static const char sh_path[] = "/system/bin/sh";
 
 	return userspace_stack_buffer(sh_path, sizeof(sh_path));
+}
+
+static char __user *ksud_user_path(void)
+{
+	static const char ksud_path[] = KSUD_PATH;
+
+	return userspace_stack_buffer(ksud_path, sizeof(ksud_path));
 }
 
 int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
@@ -131,6 +137,32 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	return 0;
 }
 
+int ksu_handle_execve_sucompat(int *fd, const char __user **filename_user,
+				 void *__never_use_argv, void *__never_use_envp, int *__never_use_flags)
+{
+	const char su[] = SU_PATH;
+	char path[sizeof(su) + 1];
+
+	if (unlikely(!filename_user))
+		return 0;
+
+	memset(path, 0, sizeof(path));
+	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+
+	if (likely(memcmp(path, su, sizeof(su))))
+		return 0;
+
+	if (!ksu_is_allow_uid(current_uid().val))
+		return 0;
+
+	pr_info("sys_execve su found\n");
+	*filename_user = ksud_user_path();
+
+	escape_to_root();
+
+	return 0;
+}
+
 #ifdef CONFIG_KPROBES
 
 __maybe_unused static int faccessat_handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -204,12 +236,9 @@ static int sys_execve_handler_pre(struct kprobe *p, struct pt_regs *regs)
 #else
 	struct pt_regs *real_regs = regs;
 #endif
-	const char __user *filename_user =
-		(const char *)PT_REGS_PARM1(real_regs);
-	struct filename *filename_mid = getname(filename_user);
-	struct filename **filename_ptr = (struct filename **)&filename_mid;
+	const char __user **filename_user = (const char **)&PT_REGS_PARM1(real_regs);
 
-	return ksu_handle_execveat_sucompat(AT_FDCWD, filename_ptr, NULL, NULL, NULL);
+	return ksu_handle_execve_sucompat(AT_FDCWD, filename_user, NULL, NULL, NULL);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)


### PR DESCRIPTION
1. Replace `do_execveat_common` with `sys_execve` and `sys_execveat`
2. Replace `input_handle_event` with `input_event` and `input_inject_event`

Tested on android12-5.10-2024-04, android13-5.15-2024-04. android14-6.1-2024-04