### PR TITLE
[Experimental] Release magiskboot binaries to /data/adb

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
@@ -61,7 +61,7 @@ fun HomeScreen(navigator: DestinationsNavigator) {
         ) {
             val isManager = Natives.becomeManager(ksuApp.packageName)
             SideEffect {
-                if (isManager) install()
+                if (isManager) install(File(ksuApp.applicationInfo.nativeLibraryDir, "libmagiskboot.so"))
             }
             val ksuVersion = if (isManager) Natives.version else null
             val lkmMode = ksuVersion?.let {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
@@ -61,7 +61,7 @@ fun HomeScreen(navigator: DestinationsNavigator) {
         ) {
             val isManager = Natives.becomeManager(ksuApp.packageName)
             SideEffect {
-                if (isManager) install(File(ksuApp.applicationInfo.nativeLibraryDir, "libmagiskboot.so"))
+                if (isManager) install()
             }
             val ksuVersion = if (isManager) Natives.version else null
             val lkmMode = ksuVersion?.let {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -82,9 +82,9 @@ fun execKsud(args: String, newShell: Boolean = false): Boolean {
     }
 }
 
-fun install() {
+fun install(magiskboot_path: String) {
     val start = SystemClock.elapsedRealtime()
-    val result = execKsud("install", true)
+    val result = execKsud("install --magiskboot $magiskboot_path", true)
     Log.w(TAG, "install result: $result, cost: ${SystemClock.elapsedRealtime() - start}ms")
 }
 

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -307,7 +307,7 @@ pub fn run() -> Result<()> {
                 Module::Shrink => module::shrink_ksu_images(),
             }
         }
-        Commands::Install => utils::install(),
+        Commands::Install { magiskboot } => utils::install(magiskboot),
         Commands::Uninstall { magiskboot } => utils::uninstall(magiskboot),
         Commands::Sepolicy { command } => match command {
             Sepolicy::Patch { sepolicy } => crate::sepolicy::live_patch(&sepolicy),

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -12,9 +12,11 @@ pub const PROFILE_TEMPLATE_DIR: &str = concatcp!(PROFILE_DIR, "templates/");
 pub const KSURC_PATH: &str = concatcp!(WORKING_DIR, ".ksurc");
 pub const KSU_OVERLAY_SOURCE: &str = "KSU";
 pub const DAEMON_PATH: &str = concatcp!(ADB_DIR, "ksud");
+pub const MAGISKBOOT_PATH: &str = concatcp!(ADB_DIR, "magisk");
 
 #[cfg(target_os = "android")]
 pub const DAEMON_LINK_PATH: &str = concatcp!(BINARY_DIR, "ksud");
+pub const MAGISKBOOT_LINK_PATH: &str = concatcp!(BINARY_DIR, "magiskboot");
 
 pub const MODULE_DIR: &str = concatcp!(ADB_DIR, "modules/");
 pub const MODULE_IMG: &str = concatcp!(WORKING_DIR, "modules.img");

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -199,24 +199,31 @@ pub fn get_tmp_path() -> &'static str {
 }
 
 #[cfg(target_os = "android")]
-fn link_ksud_to_bin() -> Result<()> {
+fn link_to_bin() -> Result<()> {
     let ksu_bin = PathBuf::from(defs::DAEMON_PATH);
     let ksu_bin_link = PathBuf::from(defs::DAEMON_LINK_PATH);
     if ksu_bin.exists() && !ksu_bin_link.exists() {
         std::os::unix::fs::symlink(&ksu_bin, &ksu_bin_link)?;
     }
+    let magiskboot_bin = PathBuf::from(defs:: MAGISKBOOT_PATH);
+    let magiskboot_bin_link = PathBuf::from(defs:: MAGISKBOOT_LINK_PATH);
+    if magiskboot_bin.exists() && ! magiskboot_bin_link.exists() {
+        std::os::unix::fs::symlink(&magiskboot_bin, &magiskboot_bin_link)?;
+    }
     Ok(())
 }
 
-pub fn install() -> Result<()> {
+pub fn install(magiskboot: Option<PathBuf>) -> Result<()> {
     ensure_dir_exists(defs::ADB_DIR)?;
     std::fs::copy("/proc/self/exe", defs::DAEMON_PATH)?;
+    std::fs::copy(magiskboot, defs::MAGISKBOOT_PATH)?;
     restorecon::lsetfilecon(defs::DAEMON_PATH, restorecon::ADB_CON)?;
+    restorecon::lsetfilecon(defs::MAGISKBOOT_PATH, restorecon::ADB_CON)?;
     // install binary assets
     assets::ensure_binaries(false).with_context(|| "Failed to extract assets")?;
 
     #[cfg(target_os = "android")]
-    link_ksud_to_bin()?;
+    link_to_bin()?;
 
     Ok(())
 }


### PR DESCRIPTION
Experimental!
 Added the release of magiskboot to /data/adb during the process of ksu manager releasing ksud to /data/adb