### PR TITLE
kernel: fix throne_tracker uncompile-able on 4.4 kernel (issue #1771)

### DIFF
--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -170,8 +170,11 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 	} else {
 		if ((namelen == 8) && (strncmp(name, "base.apk", namelen) == 0)) {
 			struct apk_path_hash *pos, *n;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
+			unsigned int hash = full_name_hash(dirpath, strlen(dirpath));
+#else
 			unsigned int hash = full_name_hash(NULL, dirpath, strlen(dirpath));
-
+#endif
 			list_for_each_entry(pos, &apk_path_hash_list, list) {
 				if (hash == pos->hash) {
 					pos->exists = true;


### PR DESCRIPTION
in kernel v4.7.10:
extern unsigned int __pure full_name_hash(const char *, unsigned int);

in kernel v4.8.0:
extern unsigned int __pure full_name_hash(const void *salt, const char *, unsigned int);