### PR TITLE
从非官方支持设备中移除K-Nel-M1721

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -609,13 +609,6 @@
         "devices": "Samsung Galaxy A34 5G (a34x)"
     },
     {
-        "maintainer": "KJ-Network",
-        "maintainer_link": "https://github.com/KJ-Network",
-        "kernel_name": "K-Nel-M1721",
-        "kernel_link": "https://github.com/KJ-Network/K-Nel-M1721/",
-        "devices": "Meizu M6 Note (M1721)"
-    },
-    {
         "maintainer": "SnowWolf725    ",
         "maintainer_link": "https://github.com/snowwolf725",
         "kernel_name": "android_kernel_oneplus_sm8150",


### PR DESCRIPTION
* 随着KernelSU的快速发展，非 GKI 和 GKI 1.0的设备早晚是要被放弃的
* 可以说，KernelSU已经开始这么做了
* 所以，我决定移除K-Nel M1721中的KernelSU