### PR TITLE
Convert devpts domain to ksu_file

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -116,7 +116,7 @@ bool is_zygote(void *sec)
 	return result;
 }
 
-#define DEVPTS_DOMAIN "u:object_r:devpts:s0"
+#define DEVPTS_DOMAIN "u:object_r:ksu_file:s0"
 
 u32 ksu_get_devpts_sid()
 {


### PR DESCRIPTION
AOSP sepolicy does not allow appdomain to open pts. Hence, convert devpts domain to ksu_file to allow any access.