### PR TITLE
throne_tracker: skip iterate if failed to open dir

### DIFF
--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -236,13 +236,13 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
 				file = ksu_filp_open_compat(pos->dirpath, O_RDONLY | O_NOFOLLOW, 0);
 				if (IS_ERR(file)) {
 					pr_err("Failed to open directory: %s, err: %ld\n", pos->dirpath, PTR_ERR(file));
-					return;
+					goto skip_iterate;
 				}
 
 				iterate_dir(file, &ctx.ctx);
 				filp_close(file, NULL);
 			}
-
+skip_iterate:
 			list_del(&pos->list);
 			if (pos != &data)
 				kfree(pos);


### PR DESCRIPTION
fix https://github.com/tiann/KernelSU/issues/1800