### PR TITLE
ksud(feat): Parse KMI from boot or kernel

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -574,7 +574,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6dc8c8ff84895b051f07a0e65f975cf225131742531338752abfb324e4449ff"
 dependencies = [
  "log",
- "regex",
 ]
 
 [[package]]

--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -899,7 +899,7 @@ dependencies = [
  "loopdev",
  "nom",
  "procfs",
- "regex",
+ "regex-lite",
  "retry",
  "rust-embed",
  "rustix 0.38.34 (git+https://github.com/Kernel-SU/rustix.git?branch=main)",
@@ -1250,6 +1250,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"

--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -47,15 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,12 +828,11 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 [[package]]
 name = "java-properties"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf6f484471c451f2b51eabd9e66b3fa7274550c5ec4b6c3d6070840945117f"
+source = "git+https://github.com/Kernel-SU/java-properties.git?branch=master#42a4aa941b70ded2dd3be9e9f892471023e70229"
 dependencies = [
  "encoding_rs",
  "lazy_static",
- "regex",
+ "regex-lite",
 ]
 
 [[package]]
@@ -1228,39 +1218,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "remove_dir_all"

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -20,7 +20,7 @@ zip = { version = "2.1.5", features = [
     "xz",
 ], default-features = false }
 zip-extensions = "0.8"
-java-properties = "2"
+java-properties = { git = "https://github.com/Kernel-SU/java-properties.git", branch = "master", default-features = false }
 log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde = { version = "1" }

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -57,7 +57,7 @@ procfs = "0.16"
 loopdev = { git = "https://github.com/Kernel-SU/loopdev" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.14"
+android_logger = { version = "0.14", default-features = false }
 
 [profile.release]
 strip = true

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -25,7 +25,6 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde = { version = "1" }
 serde_json = "1"
-regex = "1"
 encoding_rs = "0.8"
 retry = "2"
 humansize = "2"
@@ -46,6 +45,7 @@ sha1 = "0.10"
 tempdir = "0.3"
 chrono = "0.4"
 hole-punch = { git = "https://github.com/tiann/hole-punch" }
+regex-lite = "0.1.6"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 rustix = { git = "https://github.com/Kernel-SU/rustix.git", branch = "main", features = [

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -100,7 +100,7 @@ fn parse_kmi_from_kernel(kernel: &PathBuf, workdir: &Path) -> Result<String> {
     use std::fs::{copy, File};
     use std::io::{BufReader, Read};
     let kernel_path = workdir.join("kernel");
-    copy(&kernel, &kernel_path).context("Failed to copy kernel")?;
+    copy(kernel, &kernel_path).context("Failed to copy kernel")?;
 
     let file = File::open(&kernel_path).context("Failed to open kernel file")?;
     let mut reader = BufReader::new(file);
@@ -132,7 +132,7 @@ fn parse_kmi_from_kernel(kernel: &PathBuf, workdir: &Path) -> Result<String> {
 fn parse_kmi_from_boot(magiskboot: &Path, image: &PathBuf, workdir: &Path) -> Result<String> {
     let image_path = workdir.join("image");
 
-    std::fs::copy(&image, &image_path).context("Failed to copy image")?;
+    std::fs::copy(image, &image_path).context("Failed to copy image")?;
 
     let status = Command::new(magiskboot)
         .current_dir(workdir)
@@ -375,7 +375,7 @@ fn do_patch(
     let kmi = if let Some(kmi) = kmi {
         kmi
     } else {
-        let kmi = match get_current_kmi() {
+        match get_current_kmi() {
             Ok(value) => value,
             Err(e) => {
                 println!("- {}", e);
@@ -395,8 +395,7 @@ fn do_patch(
                     "".to_string()
                 }
             }
-        };
-        kmi
+        }
     };
 
     let skip_init = kmi.starts_with("android12-");

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -10,6 +10,7 @@ use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
+use regex_lite::Regex;
 use which::which;
 
 use crate::defs;
@@ -27,7 +28,6 @@ fn ensure_gki_kernel() -> Result<()> {
 
 #[cfg(target_os = "android")]
 pub fn get_kernel_version() -> Result<(i32, i32, i32)> {
-    use regex::Regex;
     let uname = rustix::system::uname();
     let version = uname.release().to_string_lossy();
     let re = Regex::new(r"(\d+)\.(\d+)\.(\d+)")?;
@@ -52,7 +52,6 @@ pub fn get_kernel_version() -> Result<(i32, i32, i32)> {
 
 #[cfg(target_os = "android")]
 fn parse_kmi(version: &str) -> Result<String> {
-    use regex::Regex;
     let re = Regex::new(r"(.* )?(\d+\.\d+)(\S+)?(android\d+)(.*)")?;
     let cap = re
         .captures(version)
@@ -98,7 +97,6 @@ pub fn get_current_kmi() -> Result<String> {
 }
 
 fn parse_kmi_from_kernel(kernel: &PathBuf, workdir: &Path) -> Result<String> {
-    use regex::Regex;
     use std::fs::{copy, File};
     use std::io::{BufReader, Read};
     let kernel_path = workdir.join("kernel");
@@ -146,7 +144,10 @@ fn parse_kmi_from_boot(magiskboot: &Path, image: &PathBuf, workdir: &Path) -> Re
         .context("Failed to execute magiskboot command")?;
 
     if !status.success() {
-        bail!("magiskboot unpack failed with status: {:?}", status.code().unwrap());
+        bail!(
+            "magiskboot unpack failed with status: {:?}",
+            status.code().unwrap()
+        );
     }
 
     parse_kmi_from_kernel(&image_path, workdir)


### PR DESCRIPTION
```console
  _  __                    _ ____  _   _ 
 | |/ /___ _ __ _ __   ___| / ___|| | | |
 | ' // _ \ '__| '_ \ / _ \ \___ \| | | |
 | . \  __/ |  | | | |  __/ |___) | |_| |
 |_|\_\___|_|  |_| |_|\___|_|____/ \___/ 

- Unsupported platform
- Trying to auto detect KMI version for ./image.img
- Preparing assets
- KMI: android12-5.10
- Unpacking boot image
- Adding KernelSU LKM
- Repacking boot image
- Output file is written to
- /tmp/tmp.dzLsDK6iyj/kernelsu_patched_20240726_012936.img
- Done!
```
It can only auto-detect when the kernel name is `r"(?:.* )?(\d+\.\d+)(?:\S+)?(android\d+)"`, otherwise you should use `--kmi` flag to specified your KMI version.
