### PR TITLE
templates/kernelmanager.root: Adjust capabilities

### DIFF
--- a/website/docs/public/templates/kernelmanager.root
+++ b/website/docs/public/templates/kernelmanager.root
@@ -10,13 +10,10 @@
         "READPROC"
     ],
     "capabilities":[
-        "CAP_SYS_MODULE",
-        "CAP_SYS_NICE",
-        "CAP_SYS_RESOURCE",
         "CAP_KILL",
         "CAP_SYSLOG",
-        "CAP_PERFMON",
-        "CAP_SYS_BOOT"
+        "CAP_SYS_BOOT",
+        "CAP_DAC_OVERRIDE"
     ],
     "context":"u:r:su:s0",
     "namespace":"INHERITED",


### PR DESCRIPTION
* Following capabilities are removed as not commonly used on Kernel Managers:
 - CAP_SYS_NICE
 - CAP_PERFMON
 - CAP_SYS_MODULE
 - CAP_SYS_RESOURCE

* Added CAP_DAC_OVERRIDE to prevent read/write permission issues