### PR TITLE
js: add getModuleId method

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -109,3 +109,12 @@ Show a toast message.
 import { toast } from 'kernelsu';
 toast('Hello, world!');
 ```
+
+### getModuleId
+
+Get Module Id.
+```javascript
+import { getModuleId } from 'kernelsu';
+// print moduleId in console
+console.log(getModuleId());
+```

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -37,9 +37,12 @@ declare function fullScreen(isFullScreen: boolean);
 
 declare function toast(message: string);
 
+declare function getModuleId(): string;
+
 export {
     exec,
     spawn,
     fullScreen,
-    toast
+    toast,
+    getModuleId
 }

--- a/js/index.js
+++ b/js/index.js
@@ -113,3 +113,7 @@ export function fullScreen(isFullScreen) {
 export function toast(message) {
   ksu.toast(message);
 }
+
+export function getModuleId() {
+  return ksu.getModuleId();
+}

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kernelsu",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Library for KernelSU's module WebUI",
   "main": "index.js",
   "types": "index.d.ts",

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
@@ -52,7 +52,7 @@ class WebUIActivity : ComponentActivity() {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.allowFileAccess = false
-            webviewInterface = WebViewInterface(this@WebUIActivity, this)
+            webviewInterface = WebViewInterface(this@WebUIActivity, this, moduleId)
             addJavascriptInterface(webviewInterface, "ksu")
             setWebViewClient(webViewClient)
             loadUrl("https://mui.kernelsu.org/index.html")

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
@@ -20,7 +20,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.CompletableFuture
 
-class WebViewInterface(val context: Context, private val webView: WebView) {
+class WebViewInterface(val context: Context, private val webView: WebView, private val moduleId: String) {
 
     @JavascriptInterface
     fun exec(cmd: String): String {
@@ -168,6 +168,11 @@ class WebViewInterface(val context: Context, private val webView: WebView) {
                 }
             }
         }
+    }
+
+    @JavascriptInterface
+    fun getModuleId(): String {
+        return moduleId;
     }
 
 }


### PR DESCRIPTION
Add a method to get module ID in JS.
resolves https://github.com/tiann/KernelSU/issues/1571

test module's index.html
![image](https://github.com/user-attachments/assets/017be053-aaad-4e45-9216-df6d28e58d97)

The test module:
[moduleId_test.zip](https://github.com/user-attachments/files/16552451/moduleId_test.zip)

test module's result:
![image](https://github.com/user-attachments/assets/b9885271-93bd-468f-8776-e96b5fcae799)

