### PR TITLE
更新中文+其他语言的Wiki

### DIFF
--- a/website/docs/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/guide/how-to-integrate-for-non-gki.md
@@ -55,21 +55,9 @@ If kprobe does not work in your kernel (may be an upstream or kernel bug below 4
 
 First, add KernelSU to your kernel source tree:
 
-::: code-group
-
-```sh[Latest tag(stable)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+```sh
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
-
-```sh[ main branch(dev)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-```sh[Select tag(Such as v0.5.2)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
-
-:::
 
 Keep in mind that on some devices, your defconfig may be in `arch/arm64/configs` or in other cases `arch/arm64/configs/vendor/your_defconfig`. For whichever defconfig you're using, make sure to enable `CONFIG_KSU` with `y` to enable or `n` to disable it. For example, in case you chose to enable it, you defconfig should contain the following string:
 

--- a/website/docs/id_ID/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/id_ID/guide/how-to-integrate-for-non-gki.md
@@ -17,23 +17,13 @@ KernelSU menggunakan kprobe untuk melakukan hook kernel, jika *kprobe* berjalan 
 
 Pertama, tambahkan KernelSU ke dalam berkas kernel source tree:
 
-- Latest tag(stable)
-
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
-- main branch(dev)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-- Select tag(Such as v0.5.2)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
+:::info
+[KernelSU 1.0 dan versi yang lebih baru tidak lagi mendukung kernel non-GKI](https://github.com/tiann/KernelSU/issues/1705). Versi terakhir yang didukung adalah `v0.9.5`, pastikan untuk menggunakan versi yang benar.
+:::
 
 Kemudian, Anda harus memeriksa apakah *kprobe* diaktifkan dalam konfigurasi kernel Anda, jika tidak, tambahkan konfigurasi ini ke dalamnya:
 

--- a/website/docs/id_ID/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/id_ID/guide/how-to-integrate-for-non-gki.md
@@ -46,7 +46,7 @@ Jika kprobe tidak dapat bekerja pada kernel Anda (mungkin karena bug di upstream
 Pertama, tambahkan KernelSU ke dalam direktori kernel source tree:
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
 Kemudian, tambahkan panggilan KernelSU ke source kernel, berikut ini adalah patch yang dapat dirujuk:

--- a/website/docs/ja_JP/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/ja_JP/guide/how-to-integrate-for-non-gki.md
@@ -18,8 +18,12 @@ KernelSU は kprobe を使ってカーネルフックを行います。もし *k
 まず、KernelSU をカーネルソースツリーに追加してください：
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
+
+:::info
+[KernelSU 1.0 およびそれ以降のバージョンでは、非 GKI カーネルがサポートされなくなりました](https://github.com/tiann/KernelSU/issues/1705). 最終サポートバージョンは`v0.9.5`です, 正しいバージョンをお使いください。
+:::
 
 次に、*kprobe* がカーネル設定で有効になっているか確認してください。もし有効でなければ、これらの設定を追加してください：
 

--- a/website/docs/ja_JP/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/ja_JP/guide/how-to-integrate-for-non-gki.md
@@ -55,24 +55,9 @@ KPROBES がまだ有効化されていない場合は、CONFIG_MODULES を有効
 
 まず、KernelSU をカーネルソースツリーに追加してください：
 
-::: code-group
-
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
-
-[ main branch(dev)]
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-[Select tag(Such as v0.5.2)]
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
-
-
-:::
 
 いくつかのデバイスでは、あなたの defconfig が `arch/arm64/configs` にあったり、または他のケースでは `arch/arm64/configs/vendor/your_defconfig` にあることを念頭に置いてください。例えばあなたの defconfig で、`CONFIG_KSU` を y で有効に、または n で無効に設定します。あなたのパスは次のようになるでしょう：
 `arch/arm64/configs/...`

--- a/website/docs/pt_BR/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/pt_BR/guide/how-to-integrate-for-non-gki.md
@@ -55,21 +55,9 @@ Se o kprobe não funcionar no seu kernel (pode ser um bug do upstream ou do kern
 
 Primeiro, adicione o KernelSU à árvore de origem do kernel:
 
-::: code-group
-
-```sh[Tag mais recente (estável)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+```sh
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
-
-```sh[Branch principal (dev)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-```sh[Selecionar tag (como v0.5.2)]
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
-
-:::
 
 Tenha em mente que em alguns dispositivos, seu defconfig pode estar em `arch/arm64/configs` ou em outros casos `arch/arm64/configs/vendor/your_defconfig`. Para qualquer defconfig que você estiver usando, certifique-se de ativar `CONFIG_KSU` com `y` para ativa-lo ou `n` para desativa-lo. Por exemplo, caso você opte por ativa-lo, seu defconfig deverá conter a seguinte string:
 

--- a/website/docs/ru_RU/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/ru_RU/guide/how-to-integrate-for-non-gki.md
@@ -18,8 +18,12 @@ KernelSU использует kprobe для выполнения хуков яд
 Сначала добавьте KernelSU в дерево исходных текстов ядра:
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash - v0.9.5
 ```
+
+:::info
+[KernelSU 1.0 и более поздние версии больше не поддерживают ядра, отличные от GKI](https://github.com/tiann/KernelSU/issues/1705). Последняя поддерживаемая версия - `v0.9.5`, пожалуйста, убедитесь, что вы используете правильную версию.
+:::
 
 Затем необходимо проверить, включена ли функция *kprobe* в конфигурации ядра, если нет, то добавьте в нее эти настройки:
 

--- a/website/docs/ru_RU/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/ru_RU/guide/how-to-integrate-for-non-gki.md
@@ -53,19 +53,7 @@ CONFIG_KPROBE_EVENTS=y
 - Последний тэг(стабильный)
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
-```
-
-- Основная ветвь(разработка)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-- Выбранный тэг(Например, версия v0.5.2)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
 Затем добавьте вызовы KernelSU в исходный код ядра, вот патч, на который можно сослаться:

--- a/website/docs/vi_VN/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/vi_VN/guide/how-to-integrate-for-non-gki.md
@@ -21,20 +21,12 @@ KernelSU sử dụng kprobe để thực hiện hook kernel, nếu *kprobe* ch�
 - Thẻ mới nhất (ổn định)
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
-- Nhánh chính (dev)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-- Chọn thẻ (chẳng hạn như v0.5.2)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
+:::info
+[KernelSU 1.0 and later versions no longer support non-GKI kernels](https://github.com/tiann/KernelSU/issues/1705). The last supported version is `v0.9.5`, please make sure to use the correct version.
+:::
 
 Sau đó, bạn nên kiểm tra xem *kprobe* có được bật trong config của bạn hay không, nếu không, vui lòng thêm các cấu hình sau vào:
 

--- a/website/docs/vi_VN/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/vi_VN/guide/how-to-integrate-for-non-gki.md
@@ -49,7 +49,7 @@ Nếu kprobe không thể hoạt động trong kernel của bạn (có thể là
 Đầu tiên, thêm KernelSU vào mã nguồn kernel của bạn:
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
 Sau đó, thêm lệnh gọi KernelSU vào mã nguồn kernel, đây là một patch bạn có thể tham khảo:

--- a/website/docs/zh_CN/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/zh_CN/guide/how-to-integrate-for-non-gki.md
@@ -51,7 +51,7 @@ CONFIG_KPROBE_EVENTS=y
 首先，把 KernelSU 添加到你的内核源码树，在内核的根目录执行以下命令：
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
 请注意，某些设备的defconfig文件可能在`arch/arm64/configs/设备代号_defconfig`或位于`arch/arm64/configs/vendor/设备代号_defconfig`。在您的defconfig文件中,将 `CONFIG_KSU`设置为`y`以启用KernelSU,或设置为`n`以禁用。比如在某个defconfig中:

--- a/website/docs/zh_TW/guide/how-to-integrate-for-non-gki.md
+++ b/website/docs/zh_TW/guide/how-to-integrate-for-non-gki.md
@@ -17,23 +17,13 @@ KernelSU 使用 kprobe 機制來處理核心的相關 hook，如果 *kprobe* 可
 
 首先，把 KernelSU 新增至您的核心來源樹狀結構，再核心的根目錄執行以下命令：
 
-- 最新 tag (稳定版本)
-
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
-- main 分支(開發版本)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s main
-```
-
-- 選取 tag (例如 v0.5.2)
-
-```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.5.2
-```
+:::info
+[KernelSU 1.0 及其後的版本不再支援非 GKI 核心](https://github.com/tiann/KernelSU/issues/1705)，最後支援的版本是 `v0.9.5`，請務必使用正確的版本。
+:::
 
 然後，您需要檢查您的核心是否啟用 *kprobe* 相關組態，如果未啟用，則需要新增以下組態：
 
@@ -66,7 +56,7 @@ CONFIG_KPROBE_EVENTS=y
 首先，將 KernelSU 新增至您的原始碼樹狀結構，再核心的根目錄執行以下命令：
 
 ```sh
-curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -
+curl -LSs "https://raw.githubusercontent.com/tiann/KernelSU/main/kernel/setup.sh" | bash -s v0.9.5
 ```
 
 然後，手動修改核心原始碼，您可以參閱下方的 patch：


### PR DESCRIPTION
昨天查给Non-GKI内核手动移植时发现命令并不是使用v0.9.5，恰好其他语言也没更新到v0.9.5，~~就改了改开PR，虽然有些语言是机翻~~