### PR TITLE
website/docs: add N0Kernel and NOVA kernels

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -698,5 +698,19 @@
         "kernel_name": "android_kernel_motorola_sdm632",
         "kernel_link": "https://github.com/Fede2782/android_kernel_motorola_sdm632",
         "devices": "Motorola Moto G7 (river)"
+    },
+    {
+        "maintainer": "EmanuelCN",
+        "maintainer_link": "https://github.com/EmanuelCN",
+        "kernel_name": "N0Kernel",
+        "kernel_link": "https://github.com/EmanuelCN/kernel_xiaomi_sm8250",
+        "devices": "Poco F3 (alioth) | Mi 10T/Pro (apollo) | Poco F4 (munch)"
+    },
+    {
+        "maintainer": "kvsnr113",
+        "maintainer_link": "https://github.com/kvsnr113",
+        "kernel_name": "NOVA Kernel",
+        "kernel_link": "https://github.com/kvsnr113/xiaomi_sm8250_kernel",
+        "devices": "Poco F3 (alioth) | Mi 10T/Pro (apollo) | Poco F4 (munch)"
     }
 ]


### PR DESCRIPTION
Add N0kernel and NOVA kernels to the unofficially supported devices section in the KernelSU website.
KernelSU isn't added in the [source of NOVA kernel](https://github.com/kvsnr113/xiaomi_sm8250_kernel), however his builds include KernelSU ones as it can be seen in his [releases repo](https://github.com/kvsnr113/nova_kernel_releases/releases).