### PR TITLE
kernel: Relax dentry_path_raw compare in core_hook

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -15,6 +15,7 @@
 #include <linux/sched.h>
 #include <linux/security.h>
 #include <linux/stddef.h>
+#include <linux/string.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
 #include <linux/uidgid.h>
@@ -193,7 +194,7 @@ int ksu_handle_rename(struct dentry *old_dentry, struct dentry *new_dentry)
 		return 0;
 	}
 
-	if (strcmp(buf, "/system/packages.list")) {
+	if (!strstr(buf, "/system/packages.list")) {
 		return 0;
 	}
 	pr_info("renameat: %s -> %s, new path: %s\n", old_dentry->d_iname,


### PR DESCRIPTION
On Android-x86 (or BlissOS) it initialize Android by using switch_root or chroot, when checking a path with dentry_path_raw() it will show the whole real path instead of the path that we want.

Relax the checking requirement by using strstr to look for "/system/packages.list" in the string instead of requiring the path to be "/system/packages.list"

This fixes #1783 