### PR TITLE
js: add moduleInfo method

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -109,3 +109,12 @@ Show a toast message.
 import { toast } from 'kernelsu';
 toast('Hello, world!');
 ```
+
+### moduleInfo
+
+Get Module info.
+```javascript
+import { moduleInfo } from 'kernelsu';
+// print moduleId in console
+console.log(moduleInfo());
+```

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -37,9 +37,12 @@ declare function fullScreen(isFullScreen: boolean);
 
 declare function toast(message: string);
 
+declare function moduleInfo(): string;
+
 export {
     exec,
     spawn,
     fullScreen,
-    toast
+    toast,
+    moduleInfo
 }

--- a/js/index.js
+++ b/js/index.js
@@ -113,3 +113,7 @@ export function fullScreen(isFullScreen) {
 export function toast(message) {
   ksu.toast(message);
 }
+
+export function moduleInfo() {
+  return ksu.moduleInfo();
+}

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kernelsu",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Library for KernelSU's module WebUI",
   "main": "index.js",
   "types": "index.d.ts",

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
@@ -29,7 +29,8 @@ class WebUIActivity : ComponentActivity() {
         val prefs = getSharedPreferences("settings", Context.MODE_PRIVATE)
         WebView.setWebContentsDebuggingEnabled(prefs.getBoolean("enable_web_debugging", false))
 
-        val webRoot = File("/data/adb/modules/${moduleId}/webroot")
+        val moduleDir = "/data/adb/modules/${moduleId}"
+        val webRoot = File("${moduleDir}/webroot")
         val rootShell = createRootShell(true).also { this.rootShell = it }
         val webViewAssetLoader = WebViewAssetLoader.Builder()
             .setDomain("mui.kernelsu.org")
@@ -52,7 +53,7 @@ class WebUIActivity : ComponentActivity() {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.allowFileAccess = false
-            webviewInterface = WebViewInterface(this@WebUIActivity, this)
+            webviewInterface = WebViewInterface(this@WebUIActivity, this, moduleDir)
             addJavascriptInterface(webviewInterface, "ksu")
             setWebViewClient(webViewClient)
             loadUrl("https://mui.kernelsu.org/index.html")

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
@@ -14,13 +14,15 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.ShellUtils
+import me.weishu.kernelsu.ui.util.listModules
 import me.weishu.kernelsu.ui.util.createRootShell
 import me.weishu.kernelsu.ui.util.withNewRootShell
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.CompletableFuture
+import java.io.File
 
-class WebViewInterface(val context: Context, private val webView: WebView) {
+class WebViewInterface(val context: Context, private val webView: WebView, private val modDir: String) {
 
     @JavascriptInterface
     fun exec(cmd: String): String {
@@ -170,6 +172,27 @@ class WebViewInterface(val context: Context, private val webView: WebView) {
         }
     }
 
+    @JavascriptInterface
+    fun moduleInfo(): String {
+        val moduleInfos = JSONArray(listModules())
+        var currentModuleInfo = JSONObject()
+        currentModuleInfo.put("moduleDir", modDir)
+        val moduleId = File(modDir).getName()
+        for (i in 0 until moduleInfos.length()) {
+            val currentInfo = moduleInfos.getJSONObject(i)
+
+            if (currentInfo.getString("id") != moduleId) {
+                continue
+            }
+
+            var keys = currentInfo.keys()
+            for(key in keys) {
+                currentModuleInfo.put(key, currentInfo.get(key));
+            }
+            break;
+        }
+        return currentModuleInfo.toString();
+    }
 }
 
 fun hideSystemUI(window: Window) {


### PR DESCRIPTION
Add a `ksu.moduleInfo()` in JS.
resolves https://github.com/tiann/KernelSU/issues/1571

test module's index.html
![image](https://github.com/user-attachments/assets/39920606-452c-4b19-abca-967c25146d6a)

The test module:
[moduleInfo_test.zip](https://github.com/user-attachments/files/17001977/moduleInfo_test.zip)

test module's result:
![image](https://github.com/user-attachments/assets/9dbbd2e8-f7ea-418f-b545-66d33ce1b3ae)

