### PR TITLE
Update Magisk Version

### DIFF
--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -442,5 +442,5 @@ POSTFSDATAD=$NVBASE/post-fs-data.d
 SERVICED=$NVBASE/service.d
 
 # Some modules dependents on this
-export MAGISK_VER=25.2
-export MAGISK_VER_CODE=25200
+export MAGISK_VER=27.0
+export MAGISK_VER_CODE=27000


### PR DESCRIPTION
Some modules demand Magisk 26+ from users, updated to latest.

Not tested.