### PR TITLE
api: spawn CallbackList use UiThreadHandler::runAndWait executor

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
@@ -14,6 +14,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.ShellUtils
+import com.topjohnwu.superuser.internal.UiThreadHandler
 import me.weishu.kernelsu.ui.util.listModules
 import me.weishu.kernelsu.ui.util.createRootShell
 import me.weishu.kernelsu.ui.util.withNewRootShell
@@ -110,13 +111,13 @@ class WebViewInterface(val context: Context, private val webView: WebView, priva
             }
         }
 
-        val stdout = object : CallbackList<String>() {
+        val stdout = object : CallbackList<String>(UiThreadHandler::runAndWait) {
             override fun onAddElement(s: String) {
                 emitData("stdout", s)
             }
         }
 
-        val stderr = object : CallbackList<String>() {
+        val stderr = object : CallbackList<String>(UiThreadHandler::runAndWait) {
             override fun onAddElement(s: String) {
                 emitData("stderr", s)
             }


### PR DESCRIPTION
![jsexception](https://github.com/user-attachments/assets/e8a4744d-bd0a-40bf-869c-def915b66075)

Because the exit callback in js cleans up the ChildProcess, when the last callback of stdout is executed after the exit callback, an error like “emitData ReferenceError: spawn_callback_1727358276092_68 is not defined” will occur.