### PR TITLE
manager: detect init_boot with Android version in uname

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -4,16 +4,15 @@ import android.content.ContentResolver
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
 import android.os.Parcelable
 import android.os.SystemClock
 import android.provider.OpenableColumns
+import android.system.Os
 import android.util.Log
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
 import com.topjohnwu.superuser.ShellUtils
-import com.topjohnwu.superuser.io.SuFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -312,18 +311,7 @@ fun isAbDevice(): Boolean {
 }
 
 fun isInitBoot(): Boolean {
-    val shell = getRootShell()
-    if (shell.isRoot) {
-        // if we have root, use /dev/block/by-name/init_boot to check
-        val abDevice = isAbDevice()
-        val initBootBlock = "/dev/block/by-name/init_boot${if (abDevice) "_a" else ""}"
-        val file = SuFile(initBootBlock)
-        file.shell = shell
-        return file.exists()
-    }
-    // https://source.android.com/docs/core/architecture/partitions/generic-boot
-    return ShellUtils.fastCmd(shell, "getprop ro.product.first_api_level").trim()
-        .toInt() >= Build.VERSION_CODES.TIRAMISU
+    return !Os.uname().release.contains("android12-")
 }
 
 suspend fun getCurrentKmi(): String = withContext(Dispatchers.IO) {


### PR DESCRIPTION
Redmi Note 12 Turbo (marble) comes shipped with Android 13, but the baseline/kernel target version is Android 12.

```
# getprop | grep api_level
[ro.board.api_level]: [31]
[ro.board.first_api_level]: [31]
[ro.product.first_api_level]: [33]
[ro.vendor.api_level]: [31]
# uname -a
Linux localhost 5.10.198-android12-9-00085-g226a9632f13d-ab11136126 #1 SMP PREEMPT Wed Nov 22 14:16:37 UTC 2023 aarch64 Toybox
```

Maybe we should use `ro.board.first_api_level` instead of `ro.product.first_api_level`, or the minimum value. But anyway, it's better to be consistent with ksud.
https://github.com/tiann/KernelSU/blob/2f9210b2e79338e7e7b1eb91878cada2b9a37ed6/userspace/ksud/src/boot_patch.rs#L407