### PR TITLE
manager: Reset search filter after moving from SuperUser destination

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/SuperUser.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
@@ -40,10 +41,18 @@ fun SuperUserScreen(navigator: DestinationsNavigator) {
     val viewModel = viewModel<SuperUserViewModel>()
     val scope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val listState = rememberLazyListState()
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(key1 = navigator) {
+        viewModel.search = ""
         if (viewModel.appList.isEmpty()) {
             viewModel.fetchAppList()
+        }
+    }
+
+    LaunchedEffect(viewModel.search) {
+        if (viewModel.search.isEmpty()) {
+            listState.scrollToItem(0)
         }
     }
 
@@ -104,6 +113,7 @@ fun SuperUserScreen(navigator: DestinationsNavigator) {
             isRefreshing = viewModel.isRefreshing
         ) {
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .nestedScroll(scrollBehavior.nestedScrollConnection)


### PR DESCRIPTION
By default there's an annoying behaviour for which the manager leaves the search filter after changing destination without even showing the search bar anymore. Fix that and reset the list to the top instead of leaving it at the searched app's height

https://github.com/user-attachments/assets/268672af-ced9-4293-81df-4e1c7ef33489
original behaviour


https://github.com/user-attachments/assets/b9b318cf-273a-4130-b199-712e99f6ed72
changed behaviour

Tested-by: backslashxx [118538522+backslashxx@users.noreply.github.com](mailto:118538522+backslashxx@users.noreply.github.com)