### PR TITLE
Create wireguard.root template

### DIFF
--- a/website/docs/public/templates/wireguard.root
+++ b/website/docs/public/templates/wireguard.root
@@ -1,0 +1,18 @@
+{
+    "id":"wireguard.root",
+    "name":"Wireguard kernel module function",
+    "author":"hotfur",
+    "description":"Essential permissions for a working Wireguard kernel module backend. The optional Wireguard command line tools installation requires DAC_OVERRIDE for writing binaries to /system/bin. Because it is optional for operation, DAC_OVERRIDE is not granted here but you can grant the capability temporarily then revoke it after the app installed the command line binaries.",
+    "uid":0,
+    "gid":0,
+    "groups":[
+        "ROOT"
+    ],
+    "capabilities":[
+        "CAP_DAC_READ_SEARCH",
+        "CAP_NET_ADMIN",
+        "CAP_NET_RAW"
+    ],
+    "context":"u:r:su:s0",
+    "namespace":"INHERITED",
+}


### PR DESCRIPTION
These two permission is absolutely required:
- CAP_NET_ADMIN is needed for modifying routes.
- CAP_NET_RAW is for modifying iptables.
When the app starts to set up a tunnel, it seems to execute "cat /sys/module/wireguard/version" to check if wireguard kernel module is loaded or not. Despite the permission seems okay, without CAP_DAC_READ_SEARCH it could not read the version number and threw an error in the application log.
CAP_DAC_OVERRIDE is needed optionally for installing Wireguard command line tools. It could be turned back off once the binaries have been copied.