### PR TITLE
Minor UI improvements

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -45,6 +45,7 @@ import me.weishu.kernelsu.ui.screen.BottomBarDestination
 import me.weishu.kernelsu.ui.theme.KernelSUTheme
 import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.rootAvailable
+import me.weishu.kernelsu.ui.util.install
 
 class MainActivity : ComponentActivity() {
 
@@ -57,6 +58,9 @@ class MainActivity : ComponentActivity() {
         }
 
         super.onCreate(savedInstanceState)
+
+	val isManager = Natives.becomeManager(ksuApp.packageName)
+	if (isManager) install()
 
         setContent {
             KernelSUTheme {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Home.kt
@@ -73,9 +73,6 @@ fun HomeScreen(navigator: DestinationsNavigator) {
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             val isManager = Natives.becomeManager(ksuApp.packageName)
-            SideEffect {
-                if (isManager) install()
-            }
             val ksuVersion = if (isManager) Natives.version else null
             val lkmMode = ksuVersion?.let {
                 if (it >= Natives.MINIMAL_SUPPORTED_KERNEL_LKM && kernelVersion.isGKI()) Natives.isLkmMode else null

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
@@ -493,15 +493,8 @@ fun ModuleItem(
                             onValueChange = { onClick(module) }
                         )
                     } else {
-                        toggleable(
-                            value = isChecked,
-                            interactionSource = interactionSource,
-                            role = Role.Switch,
-                            indication = indication,
-                            onValueChange = onCheckChanged,
-                            enabled = !module.update
-                        )
-                    }
+			this
+		    }
                 }
                 .padding(22.dp, 18.dp, 22.dp, 12.dp)
         ) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Wysiwyg
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
@@ -588,17 +590,18 @@ fun ModuleItem(
                         contentPadding = ButtonDefaults.TextButtonContentPadding
                     ) {
                         Icon(
-                            modifier = Modifier
-                                .padding(end = 7.dp)
-                                .size(20.dp),
+			    modifier = Modifier.size(20.dp),
                             imageVector = Icons.Outlined.PlayArrow,
                             contentDescription = null
                         )
-                        Text(
-                            text = stringResource(R.string.action),
-                            fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
-                            fontSize = MaterialTheme.typography.labelMedium.fontSize
-                        )
+			if (!module.hasWebUi && updateUrl.isEmpty()) {
+                            Text(
+				modifier = Modifier.padding(start = 7.dp),
+                                text = stringResource(R.string.action),
+                                fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
+                                fontSize = MaterialTheme.typography.labelMedium.fontSize
+                            )
+			}
                     }
 
                     Spacer(modifier = Modifier.weight(0.1f, true))
@@ -611,20 +614,19 @@ fun ModuleItem(
                         interactionSource = interactionSource,
                         contentPadding = ButtonDefaults.TextButtonContentPadding
                     ) {
-                        if (!module.hasActionScript) {
-                            Icon(
-                                modifier = Modifier
-                                    .padding(end = 7.dp)
-                                    .size(20.dp),
-                                imageVector = Icons.AutoMirrored.Outlined.Wysiwyg,
-                                contentDescription = null
+                        Icon(
+			    modifier = Modifier.size(20.dp),
+                            imageVector = Icons.AutoMirrored.Outlined.Wysiwyg,
+                            contentDescription = null
+                        )
+                        if (!module.hasActionScript && updateUrl.isEmpty()) {
+                            Text(
+				modifier = Modifier.padding(start = 7.dp),
+                            	fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
+                            	fontSize = MaterialTheme.typography.labelMedium.fontSize,
+                            	text = stringResource(R.string.open)
                             )
                         }
-                        Text(
-                            fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
-                            fontSize = MaterialTheme.typography.labelMedium.fontSize,
-                            text = stringResource(R.string.open)
-                        )
                     }
                 }
 
@@ -637,11 +639,19 @@ fun ModuleItem(
                         shape = ButtonDefaults.textShape,
                         contentPadding = ButtonDefaults.TextButtonContentPadding
                     ) {
-                        Text(
-                            fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
-                            fontSize = MaterialTheme.typography.labelMedium.fontSize,
-                            text = stringResource(R.string.module_update)
-                        )
+			Icon(
+    			    modifier = Modifier.size(20.dp),
+    			    imageVector = Icons.Outlined.Download,
+    			    contentDescription = null
+			)
+			if (!module.hasActionScript || !module.hasWebUi) {  
+                            Text(
+				modifier = Modifier.padding(start = 7.dp),
+                                fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
+                                fontSize = MaterialTheme.typography.labelMedium.fontSize,
+                                text = stringResource(R.string.module_update)
+                            )
+			}
                     }
 
                     Spacer(modifier = Modifier.weight(0.1f, true))
@@ -653,11 +663,19 @@ fun ModuleItem(
                     onClick = { onUninstall(module) },
                     contentPadding = ButtonDefaults.TextButtonContentPadding
                 ) {
-                    Text(
-                        fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
-                        fontSize = MaterialTheme.typography.labelMedium.fontSize,
-                        text = stringResource(R.string.uninstall)
-                    )
+		    Icon(
+    			modifier = Modifier.size(20.dp),
+    		    	imageVector = Icons.Outlined.Delete,
+    		    	contentDescription = null
+		    )
+		    if (!module.hasActionScript && !module.hasWebUi && updateUrl.isEmpty()) {  
+                    	Text(
+			    modifier = Modifier.padding(start = 7.dp),
+                            fontFamily = MaterialTheme.typography.labelMedium.fontFamily,
+                            fontSize = MaterialTheme.typography.labelMedium.fontSize,
+                            text = stringResource(R.string.uninstall)
+                        )
+		    }
                 }
             }
         }


### PR DESCRIPTION
**Changes**
1. With the addition of the Action button the module card feels pretty bloated when all of them are present at the same time.
![Screenshot_20241220-221644_KernelSU](https://github.com/user-attachments/assets/c8d7ce07-0cb2-43a0-aea2-95864d2bd018)
To improve it we can use icons only instead of text since they take less space; this also means adding an icon for Update and Uninstall buttons.
![Screenshot_20241220-220450_KernelSU](https://github.com/user-attachments/assets/2991f7fa-71f8-49b9-872c-ca0d9a8bf373)
Below are displayed other possible behaviors when not all of them are present:
![Screenshot_20241220-221227_KernelSU](https://github.com/user-attachments/assets/b61374e6-00c4-4216-9c0f-21c60301b22b)
![Screenshot_20241220-221214_KernelSU](https://github.com/user-attachments/assets/6df3535f-b451-4053-9b86-928a282a943f)
![Screenshot_20241220-220428_KernelSU](https://github.com/user-attachments/assets/6eebd4d3-956b-46b3-a402-9e09954a46c8)
Since the Update button appears less frequently than the others, make it always display its text unless both Action and WebUI are present.
![Screenshot_20241220-221401_KernelSU](https://github.com/user-attachments/assets/3ff8ce6d-80b9-4bdd-b66a-04dd6a5e44ca)

2. Minor change to avoid possible missclicks caused by smaller buttons. Enabling and disabling modules is pretty rare by itself and considering overlayfs isn't as fast as magic mount a missclick often feels pretty punishing.

3. The commit 7b3e732 readded transitions to all sections but I noticed they were missing from Home. With the help of @rifsxd I found out it was cause of the lag generated by the install function, which is called everytime you go to Home. Since installing magiskboot multiple times isn't needed, moving it to MainActivity ensures it's executed on app launch only avoiding unnecessary lag.

Tested-by: backslashxx 118538522+backslashxx@users.noreply.github.com