### PR TITLE
Imitate terminal clear command in manager

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ExecuteModuleAction.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ExecuteModuleAction.kt
@@ -49,6 +49,7 @@ import java.util.Locale
 @Destination<RootGraph>
 fun ExecuteModuleActionScreen(navigator: DestinationsNavigator, moduleId: String) {
     var text by rememberSaveable { mutableStateOf("") }
+    var tempText : String
     val logContent = rememberSaveable { StringBuilder() }
     val snackBarHost = LocalSnackbarHost.current
     val scope = rememberCoroutineScope()
@@ -63,7 +64,12 @@ fun ExecuteModuleActionScreen(navigator: DestinationsNavigator, moduleId: String
             runModuleAction(
                 moduleId = moduleId,
                 onStdout = {
-                    text += "$it\n"
+                    tempText = "$it\n"
+                    if (tempText.startsWith("[H[J")) { // clear command
+                        text = tempText.substring(6)
+                    } else {
+                        text += tempText
+                    }
                     logContent.append(it).append("\n")
                 },
                 onStderr = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt
@@ -81,6 +81,7 @@ enum class FlashingStatus {
 fun FlashScreen(navigator: DestinationsNavigator, flashIt: FlashIt) {
 
     var text by rememberSaveable { mutableStateOf("") }
+    var tempText : String
     val logContent = rememberSaveable { StringBuilder() }
     var showFloatAction by rememberSaveable { mutableStateOf(false) }
 
@@ -107,7 +108,12 @@ fun FlashScreen(navigator: DestinationsNavigator, flashIt: FlashIt) {
                 }
                 flashing = if (code == 0) FlashingStatus.SUCCESS else FlashingStatus.FAILED
             }, onStdout = {
-                text += "$it\n"
+                tempText = "$it\n"
+                if (tempText.startsWith("[H[J")) { // clear command
+                    text = tempText.substring(6)
+                } else {
+                    text += tempText
+                }
                 logContent.append(it).append("\n")
             }, onStderr = {
                 logContent.append(it).append("\n")


### PR DESCRIPTION
The current implementation of KSU manager's output screen simply prints `[H[J` when the `clear` command is used (in both the flashing module & action button screen) instead of clearing the screen:
<img src="https://github.com/user-attachments/assets/c30ceb87-13ac-4ba6-a7c5-045564e83181" width="300" />

This limits the ability of shell scripts to purely textual & linear outputs, and prevents more flexible outputs such as a refreshing progress bar or even a progress circle for long running scripts. The current implementation moreover limits the output to 65536 bytes for the String `text`, causing the app to hang once this limit has been reached for scripts with more verbose outputs.

This PR fixes these issues by allowing for usage of the `clear` command in shell scripts to clear the screen. It works by checking if the current output line starts with "[H[J", which is the default output of the `clear` command in KSU's busybox, and clears the previous outputs if there is a match. This should work universally since the `clear` command defaults to this implementation when ran in KSU manager.

A working example can be seen below, where the `clear` command is heavily used (24 times a second) to test for performance & reliability of the code:

https://github.com/user-attachments/assets/c45fb6f1-1b40-4b67-8837-4d9a00429715

Tested-by: backslashxx