### PR TITLE
ci: fix ksud release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,20 @@ jobs:
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
+      - name: Rename ksud
+        run: |
+          mkdir -p ksud
+          for dir in ./ksud-*; do
+              if [ -d "$dir" ]; then
+                 echo "----- Rename $dir -----"
+                 ksud_platform_name=$(basename "$dir")
+                 find "$dir" -type f -name "ksud" -path "*/release/*" | while read -r ksud_file; do
+                   if [ -f "$ksud_file" ]; then
+                     mv "$ksud_file" "ksud/$ksud_platform_name"
+                   fi
+                 done
+              fi
+          done
       - name: Zip AnyKernel3
         run: |
           for dir in AnyKernel3-*; do
@@ -79,4 +93,4 @@ jobs:
             boot-images-*/Image-*/*.img.gz
             kernel-WSA*.zip
             kernel-ARCVM*.zip
-            ksud-*
+            ksud/ksud-*


### PR DESCRIPTION
fix #2306

in release steps:
https://github.com/tiann/KernelSU/blob/f715af0688b95a4eed61e4f12c375f3b2666a6a6/.github/workflows/release.yml#L82
ksud-* is a directory instead of elf file:

https://github.com/tiann/KernelSU/actions/runs/11625295599/job/32377938534#step:6:1547

When new release published,it only give a info instead of give an error:

https://github.com/tiann/KernelSU/actions/runs/11625295599/job/32377938534#step:7:13