### PR TITLE
templates/shizuku.root: Fix shizuku service unable to run properly

### DIFF
--- a/website/docs/public/templates/shizuku.root
+++ b/website/docs/public/templates/shizuku.root
@@ -1,7 +1,7 @@
 {
     "id":"shizuku.root",
     "name":"Shizuku Service",
-    "author":"JohnRTitor",
+    "author":"Rem01Gaming & JohnRTitor",
     "description":"Only essential permissions to start Shizuku service.",
     "uid":0,
     "gid":0,
@@ -9,7 +9,8 @@
         "SHELL"
     ],
     "capabilities":[
-        "CAP_DAC_READ_SEARCH"
+        "CAP_DAC_OVERRIDE",
+        "CAP_CHOWN"
     ],
     "context":"u:r:su:s0",
     "namespace":"INHERITED",


### PR DESCRIPTION
## Shizuku needs DAC_OVERRIDE and CHOWN capabilities to work properly
previous settings only grant `DAC_READ_SEARCH` causing Shizuku unable to chown service executable and making it unable to work properly. `DAC_OVERRIDE` capability added to allow Shizuku to execute it's service after chown.

---

### Before Fix
![IMG_20241226_210507_769](https://github.com/user-attachments/assets/cea7329c-e393-4d8b-88cf-83be086971e5)

---
### After Fix
![IMG_20241226_211118_445](https://github.com/user-attachments/assets/e12a7aa8-2ee6-4bea-baca-47b99a4f8a44)
