### PR TITLE
Apply patch for glibc 2.38 compatibility in bazel build system

### DIFF
--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -131,8 +131,15 @@ jobs:
           DRIVER_KCONFIG=$GKI_ROOT/common/drivers/Kconfig
           grep -q "kernelsu" "$DRIVER_MAKEFILE" || printf "\nobj-\$(CONFIG_KSU) += kernelsu/\n" >> "$DRIVER_MAKEFILE"
           grep -q "kernelsu" "$DRIVER_KCONFIG" || sed -i "/endmenu/i\\source \"drivers/kernelsu/Kconfig\"" "$DRIVER_KCONFIG"
-          echo "[+] Apply KernelSU patches"
-          cd $GKI_ROOT/common/ && git apply $GITHUB_WORKSPACE/KernelSU/.github/patches/$PATCH_PATH/*.patch || echo "[-] No patch found"
+          echo "[+] Apply Compilation Patches"
+          if [ ! -e build/build.sh ]; then
+            GLIBC_VERSION=$(ldd --version 2>/dev/null | head -n 1 | awk '{print $NF}')
+            echo "GLIBC_VERSION: $GLIBC_VERSION"
+            if [ "$(printf '%s\n' "2.38" "$GLIBC_VERSION" | sort -V | head -n1)" = "2.38" ]; then
+              echo "Patching resolve_btfids/Makefile"
+              cd $GKI_ROOT/common/ && sed -i '/\$(Q)\$(MAKE) -C \$(SUBCMD_SRC) OUTPUT=\$(abspath \$(dir \$@))\/ \$(abspath \$@)/s//$(Q)$(MAKE) -C $(SUBCMD_SRC) EXTRA_CFLAGS="$(CFLAGS)" OUTPUT=$(abspath $(dir $@))\/ $(abspath $@)/' tools/bpf/resolve_btfids/Makefile || echo "No patch needed."
+            fi
+          fi
 
           if [ "$IS_DEBUG_KERNEL" = "true" ]; then
             echo "[+] Enable debug features for kernel"


### PR DESCRIPTION
Based on the commit from [android.googlesource.com](https://android.googlesource.com/kernel/common/+/75f82c6a15c4188cbb32825892fc6ae3e95479f0%5E%21/), this change applies a patch to the bazel build system for source code that does not include this fix and is using glibc version 2.38 or later. This ensures that the build process does not encounter linkage errors related to undefined symbols such as __isoc23_strtol, __isoc23_strtoul, and __isoc23_strtoull.