### PR TITLE
manager: show module id on module page

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
@@ -564,6 +564,7 @@ fun ModuleItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 val moduleVersion = stringResource(id = R.string.module_version)
+                val moduleId = stringResource(id = R.string.module_id)
                 val moduleAuthor = stringResource(id = R.string.module_author)
 
                 Column(
@@ -580,6 +581,14 @@ fun ModuleItem(
 
                     Text(
                         text = "$moduleVersion: ${module.version}",
+                        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                        lineHeight = MaterialTheme.typography.bodySmall.lineHeight,
+                        fontFamily = MaterialTheme.typography.bodySmall.fontFamily,
+                        textDecoration = textDecoration
+                    )
+
+                    Text(
+                        text = "$moduleId: ${module.id}",
                         fontSize = MaterialTheme.typography.bodySmall.fontSize,
                         lineHeight = MaterialTheme.typography.bodySmall.lineHeight,
                         fontFamily = MaterialTheme.typography.bodySmall.fontFamily,

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="module_uninstall_success">%s uninstalled</string>
     <string name="module_uninstall_failed">Failed to uninstall: %s</string>
     <string name="module_version">Version</string>
+    <string name="module_id">Module ID</string>
     <string name="module_author">Author</string>
     <string name="module_overlay_fs_not_available">Modules are unavailable as OverlayFS is disabled by the kernel.</string>
     <string name="refresh">Refresh</string>


### PR DESCRIPTION
This is completely useless for most users, but sometimes some modules use weird abbreviations like `TA_utl` which you may not understand at first, so just being able to check which id corresponds to which module without opening the module.prop file can be helpful.
It can also help with the complains of "Why are the modules listed in such a weird order?" and they could realise themselves that its arranged alphabetically according to the module id, and its always nice to have all the details in one easy to access page.

Edit:
![Screenshot_2025-01-21-08-45-14-582_me weishu kernelsu](https://github.com/user-attachments/assets/2dfb71ad-6b07-4373-b07b-ab5bf3bff1ea)