### PR TITLE
Don't unshare after entering global namespace

### DIFF
--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -305,7 +305,6 @@ pub fn run() -> Result<()> {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 utils::switch_mnt_ns(1)?;
-                utils::unshare_mnt_ns()?;
             }
             match command {
                 Module::Install { zip } => module::install_module(&zip),

--- a/userspace/ksud/src/su.rs
+++ b/userspace/ksud/src/su.rs
@@ -26,7 +26,6 @@ pub fn grant_root(global_mnt: bool) -> Result<()> {
         command.pre_exec(move || {
             if global_mnt {
                 let _ = utils::switch_mnt_ns(1);
-                let _ = utils::unshare_mnt_ns();
             }
             Result::Ok(())
         })
@@ -263,7 +262,6 @@ pub fn root_shell() -> Result<()> {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if mount_master {
                 let _ = utils::switch_mnt_ns(1);
-                let _ = utils::unshare_mnt_ns();
             }
 
             set_identity(uid, gid, &groups);

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -141,12 +141,6 @@ pub fn switch_mnt_ns(pid: i32) -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
-pub fn unshare_mnt_ns() -> Result<()> {
-    unshare(UnshareFlags::NEWNS)?;
-    Ok(())
-}
-
 fn switch_cgroup(grp: &str, pid: u32) {
     let path = Path::new(grp).join("cgroup.procs");
     if !path.exists() {


### PR DESCRIPTION
Global namespace is usually used to publicly apply mounts so calling unshare after entering root namespace is not desired bahavior. This also keeps -M option same as Magisk.