### PR TITLE
Avoid unnecessarily overriding capabilities

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -1,3 +1,4 @@
+#include <linux/capability.h>
 #include <linux/compiler.h>
 #include <linux/fs.h>
 #include <linux/gfp.h>
@@ -62,12 +63,14 @@ static void remove_uid_from_arr(uid_t uid)
 
 static void init_default_profiles()
 {
+	kernel_cap_t full_cap = CAP_FULL_SET;
+
 	default_root_profile.uid = 0;
 	default_root_profile.gid = 0;
 	default_root_profile.groups_count = 1;
 	default_root_profile.groups[0] = 0;
-	memset(&default_root_profile.capabilities, 0xff,
-	       sizeof(default_root_profile.capabilities));
+	memcpy(&default_root_profile.capabilities.effective, &full_cap,
+		sizeof(default_root_profile.capabilities.effective));
 	default_root_profile.namespaces = 0;
 	strcpy(default_root_profile.selinux_domain, KSU_DEFAULT_SELINUX_DOMAIN);
 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -162,14 +162,10 @@ void escape_to_root(void)
 		profile->capabilities.effective | CAP_DAC_READ_SEARCH;
 	memcpy(&cred->cap_effective, &cap_for_ksud,
 	       sizeof(cred->cap_effective));
-	memcpy(&cred->cap_inheritable, &profile->capabilities.effective,
-	       sizeof(cred->cap_inheritable));
 	memcpy(&cred->cap_permitted, &profile->capabilities.effective,
 	       sizeof(cred->cap_permitted));
 	memcpy(&cred->cap_bset, &profile->capabilities.effective,
 	       sizeof(cred->cap_bset));
-	memcpy(&cred->cap_ambient, &profile->capabilities.effective,
-	       sizeof(cred->cap_ambient));
 
 	setup_groups(profile, cred);
 


### PR DESCRIPTION
Previously all capabilities were overridden with 0xffffffffffffffff, which is
not what normal processes have. This causes PR_CAPBSET_DROP prctl
fail because it is dropping invalid caps. Fix it.

This fixes https://gitlab.com/kalilinux/nethunter/apps/kali-nethunter-app/-/issues/378.

Co-Authored-By: 5ec1cff <56485584+5ec1cff@users.noreply.github.com>