### PR TITLE
kernel: clear securebits

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -151,6 +151,7 @@ void escape_to_root(void)
 	cred->fsgid.val = profile->gid;
 	cred->sgid.val = profile->gid;
 	cred->egid.val = profile->gid;
+	cred->securebits = 0;
 
 	BUILD_BUG_ON(sizeof(profile->capabilities.effective) !=
 		     sizeof(kernel_cap_t));


### PR DESCRIPTION
fix adb shell cannot escape to root after https://github.com/tiann/KernelSU/pull/2381