### PR TITLE
Hide namespace config in app profiles

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/profile/RootProfileConfig.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/profile/RootProfileConfig.kt
@@ -73,6 +73,7 @@ fun RootProfileConfig(
             )
         }
 
+        /* 
         var expanded by remember { mutableStateOf(false) }
         val currentNamespace = when (profile.namespace) {
             Natives.Profile.Namespace.INHERITED.ordinal -> stringResource(R.string.profile_namespace_inherited)
@@ -126,6 +127,7 @@ fun RootProfileConfig(
                 }
             }
         })
+        */
 
         UidPanel(uid = profile.uid, label = "uid", onUidChange = {
             onProfileChange(


### PR DESCRIPTION
This is never implemented in kernel (and likely never will be), so let's remove it from UI for now to avoid misleading users.