### PR TITLE
Provide TMPDIR for boot image repacking

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/KernelSUApplication.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/KernelSUApplication.kt
@@ -1,6 +1,7 @@
 package me.weishu.kernelsu
 
 import android.app.Application
+import android.system.Os
 import coil.Coil
 import coil.ImageLoader
 import me.zhanghai.android.appiconloader.coil.AppIconFetcher
@@ -30,6 +31,9 @@ class KernelSUApplication : Application() {
         if (!webroot.exists()) {
             webroot.mkdir()
         }
+
+        // Provide working env for rust's temp_dir()
+        Os.setenv("TMPDIR", cacheDir.absolutePath, true)
     }
 
 


### PR DESCRIPTION
/data/local/tmp is never writable for normal apps, why previously it works is that Rust's temp_dir() gets path from env, and since A13, TMPDIR is set to app's cache dir. This is not the case for A12, so it breaks. Fix it by set TMPDIR ourselves.