### PR TITLE
Fix reference count leak in nuke_ext4_sysfs()

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -236,10 +236,12 @@ static void nuke_ext4_sysfs() {
 	const char* name = sb->s_type->name;
 	if (strcmp(name, "ext4") != 0) {
 		pr_info("nuke but module aren't mounted\n");
+		path_put(&path);
 		return;
 	}
 
 	ext4_unregister_sysfs(sb);
+ 	path_put(&path);
 }
 
 int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,


### PR DESCRIPTION
We need to call path_put() to decrease the refcount.