### PR TITLE
[RFC] kernel: restore non-kprobe support, sucompat toggle for non-kp.

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,6 +2,7 @@ menu "KernelSU"
 
 config KSU
 	tristate "KernelSU function support"
+	depends on EXT4_FS
 	depends on OVERLAY_FS
 	default y
 	help

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -9,6 +9,14 @@ config KSU
 	  To compile as a module, choose M here: the
 	  module will be called kernelsu.
 
+config KSU_WITH_KPROBES
+	bool "Use kprobes for kernelsu"
+	depends on KSU
+	depends on KPROBES
+	default y
+	help
+	  Make sure to disable this if you use manual hooks.
+
 config KSU_DEBUG
 	bool "KernelSU debug mode"
 	depends on KSU

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -883,7 +883,9 @@ void __init ksu_core_init(void)
 
 void ksu_core_exit(void)
 {
+#ifdef CONFIG_KPROBES
 	pr_info("ksu_core_kprobe_exit\n");
 	// we dont use this now
 	// ksu_kprobe_exit();
+#endif
 }

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -883,7 +883,7 @@ void __init ksu_core_init(void)
 
 void ksu_core_exit(void)
 {
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 	pr_info("ksu_core_kprobe_exit\n");
 	// we dont use this now
 	// ksu_kprobe_exit();

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -57,7 +57,7 @@ int __init kernelsu_init(void)
 
 	ksu_throne_tracker_init();
 
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 	ksu_sucompat_init();
 	ksu_ksud_init();
 #else
@@ -80,7 +80,7 @@ void kernelsu_exit(void)
 
 	destroy_workqueue(ksu_workqueue);
 
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 	ksu_ksud_exit();
 	ksu_sucompat_exit();
 #endif

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -57,8 +57,12 @@ int __init kernelsu_init(void)
 
 	ksu_throne_tracker_init();
 
+#ifdef CONFIG_KPROBES
 	ksu_sucompat_init();
 	ksu_ksud_init();
+#else
+	pr_alert("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html");
+#endif
 
 #ifdef MODULE
 #ifndef CONFIG_KSU_DEBUG
@@ -76,8 +80,10 @@ void kernelsu_exit(void)
 
 	destroy_workqueue(ksu_workqueue);
 
+#ifdef CONFIG_KPROBES
 	ksu_ksud_exit();
 	ksu_sucompat_exit();
+#endif
 
 	ksu_core_exit();
 }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -189,6 +189,8 @@ int ksu_handle_devpts(struct inode *inode)
 	return 0;
 }
 
+#ifdef CONFIG_KPROBES
+
 static int faccessat_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct pt_regs *real_regs = PT_REAL_REGS(regs);
@@ -230,6 +232,8 @@ static int pts_unix98_lookup_pre(struct kprobe *p, struct pt_regs *regs)
 	return ksu_handle_devpts(inode);
 }
 
+#endif
+
 static struct kprobe *init_kprobe(const char *name,
 				  kprobe_pre_handler_t handler)
 {
@@ -265,15 +269,19 @@ static struct kprobe *su_kps[4];
 // sucompat: permited process can execute 'su' to gain root access.
 void ksu_sucompat_init()
 {
+#ifdef CONFIG_KPROBES
 	su_kps[0] = init_kprobe(SYS_EXECVE_SYMBOL, execve_handler_pre);
 	su_kps[1] = init_kprobe(SYS_FACCESSAT_SYMBOL, faccessat_handler_pre);
 	su_kps[2] = init_kprobe(SYS_NEWFSTATAT_SYMBOL, newfstatat_handler_pre);
 	su_kps[3] = init_kprobe("pts_unix98_lookup", pts_unix98_lookup_pre);
+#endif
 }
 
 void ksu_sucompat_exit()
 {
+#ifdef CONFIG_KPROBES
 	for (int i = 0; i < ARRAY_SIZE(su_kps); i++) {
 		destroy_kprobe(&su_kps[i]);
 	}
+#endif
 }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -189,7 +189,7 @@ int ksu_handle_devpts(struct inode *inode)
 	return 0;
 }
 
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 
 static int faccessat_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
@@ -232,8 +232,6 @@ static int pts_unix98_lookup_pre(struct kprobe *p, struct pt_regs *regs)
 	return ksu_handle_devpts(inode);
 }
 
-#endif
-
 static struct kprobe *init_kprobe(const char *name,
 				  kprobe_pre_handler_t handler)
 {
@@ -265,11 +263,12 @@ static void destroy_kprobe(struct kprobe **kp_ptr)
 }
 
 static struct kprobe *su_kps[4];
+#endif
 
 // sucompat: permited process can execute 'su' to gain root access.
 void ksu_sucompat_init()
 {
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 	su_kps[0] = init_kprobe(SYS_EXECVE_SYMBOL, execve_handler_pre);
 	su_kps[1] = init_kprobe(SYS_FACCESSAT_SYMBOL, faccessat_handler_pre);
 	su_kps[2] = init_kprobe(SYS_NEWFSTATAT_SYMBOL, newfstatat_handler_pre);
@@ -279,7 +278,7 @@ void ksu_sucompat_init()
 
 void ksu_sucompat_exit()
 {
-#ifdef CONFIG_KPROBES
+#ifdef CONFIG_KSU_WITH_KPROBES
 	for (int i = 0; i < ARRAY_SIZE(su_kps); i++) {
 		destroy_kprobe(&su_kps[i]);
 	}

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -81,27 +81,12 @@ int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
 
 	char path[sizeof(su) + 1];
 	memset(path, 0, sizeof(path));
-// Remove this later!! we use syscall hook, so this will never happen!!!!!
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0) && 0
-	// it becomes a `struct filename *` after 5.18
-	// https://elixir.bootlin.com/linux/v5.18/source/fs/stat.c#L216
-	const char sh[] = SH_PATH;
-	struct filename *filename = *((struct filename **)filename_user);
-	if (IS_ERR(filename)) {
-		return 0;
-	}
-	if (likely(memcmp(filename->name, su, sizeof(su))))
-		return 0;
-	pr_info("vfs_statx su->sh!\n");
-	memcpy((void *)filename->name, sh, sizeof(sh));
-#else
 	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
 
 	if (unlikely(!memcmp(path, su, sizeof(su)))) {
 		pr_info("newfstatat su->sh!\n");
 		*filename_user = sh_user_path();
 	}
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
this will revert 500ff9b
"kernel: remove unused CONFIG guard becuase GKI kernel enable kprobe by default"

This pr can allow gki kernels to be built with manual hooks. It also comes with a port of 
sucompat toggle for the sake of feature parity.

If this gets accepted, I also plan to get manual hooks guide on par with kprobes hook.
https://github.com/backslashxx/KernelSU/issues/5

ofcourse, this will depend now on KernelSU policy, as this will **re-introduce an ifdef hell**. 
This will make maintenance harder, you now have to keep track a lot of different states, etc etc,
but even if this does NOT get accepted, this can still be a demo on how you can have manual 
hooks on gki kernels.