### PR TITLE
kernel: fix sometimes sucompat can not toggle by manager

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -470,6 +470,9 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		bool enabled = (arg3 != 0);
 		if (enabled == ksu_su_compat_enabled) {
 			pr_info("cmd enable su but no need to change.\n");
+			if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {// return the reply_ok directly
+				pr_err("prctl reply error, cmd: %lu\n", arg2);
+			}
 			return 0;
 		}
 


### PR DESCRIPTION
When the manager is already running, if other programs / kernel toggle the sucompat enable status, 
The manager "Disable SU Compat" toggle button can not work, kmesg print "cmd enable su but no need to change."

I think we should still return reply_ok when the syscall value is consistent with the kernel, which would fix the issue.