### PR TITLE
Revert "kernel: remove unused CONFIG guard becuase GKI kernel enable kprobe by default"

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -886,7 +886,9 @@ void __init ksu_core_init(void)
 
 void ksu_core_exit(void)
 {
+#ifdef CONFIG_KPROBES
 	pr_info("ksu_core_kprobe_exit\n");
 	// we dont use this now
 	// ksu_kprobe_exit();
+#endif
 }

--- a/kernel/ksu.c
+++ b/kernel/ksu.c
@@ -57,8 +57,12 @@ int __init kernelsu_init(void)
 
 	ksu_throne_tracker_init();
 
+#ifdef CONFIG_KPROBES
 	ksu_sucompat_init();
 	ksu_ksud_init();
+#else
+	pr_alert("KPROBES is disabled, KernelSU may not work, please check https://kernelsu.org/guide/how-to-integrate-for-non-gki.html");
+#endif
 
 #ifdef MODULE
 #ifndef CONFIG_KSU_DEBUG
@@ -76,8 +80,10 @@ void kernelsu_exit(void)
 
 	destroy_workqueue(ksu_workqueue);
 
+#ifdef CONFIG_KPROBES
 	ksu_ksud_exit();
 	ksu_sucompat_exit();
+#endif
 
 	ksu_core_exit();
 }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -189,6 +189,8 @@ int ksu_handle_devpts(struct inode *inode)
 	return 0;
 }
 
+#ifdef CONFIG_KPROBES
+
 static int faccessat_handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
 	struct pt_regs *real_regs = PT_REAL_REGS(regs);
@@ -230,6 +232,8 @@ static int pts_unix98_lookup_pre(struct kprobe *p, struct pt_regs *regs)
 	return ksu_handle_devpts(inode);
 }
 
+#endif
+
 static struct kprobe *init_kprobe(const char *name,
 				  kprobe_pre_handler_t handler)
 {
@@ -265,15 +269,19 @@ static struct kprobe *su_kps[4];
 // sucompat: permited process can execute 'su' to gain root access.
 void ksu_sucompat_init()
 {
+#ifdef CONFIG_KPROBES
 	su_kps[0] = init_kprobe(SYS_EXECVE_SYMBOL, execve_handler_pre);
 	su_kps[1] = init_kprobe(SYS_FACCESSAT_SYMBOL, faccessat_handler_pre);
 	su_kps[2] = init_kprobe(SYS_NEWFSTATAT_SYMBOL, newfstatat_handler_pre);
 	su_kps[3] = init_kprobe("pts_unix98_lookup", pts_unix98_lookup_pre);
+#endif
 }
 
 void ksu_sucompat_exit()
 {
+#ifdef CONFIG_KPROBES
 	for (int i = 0; i < ARRAY_SIZE(su_kps); i++) {
 		destroy_kprobe(&su_kps[i]);
 	}
+#endif
 }

--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -232,8 +232,6 @@ static int pts_unix98_lookup_pre(struct kprobe *p, struct pt_regs *regs)
 	return ksu_handle_devpts(inode);
 }
 
-#endif
-
 static struct kprobe *init_kprobe(const char *name,
 				  kprobe_pre_handler_t handler)
 {
@@ -265,6 +263,7 @@ static void destroy_kprobe(struct kprobe **kp_ptr)
 }
 
 static struct kprobe *su_kps[4];
+#endif
 
 // sucompat: permited process can execute 'su' to gain root access.
 void ksu_sucompat_init()


### PR DESCRIPTION
follow up to https://github.com/tiann/KernelSU/pull/2475#issuecomment-2680947145