### PR TITLE
kernel: sucompat: sucompat toggle support for non-kp

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -23,7 +23,7 @@
 extern void escape_to_root();
 
 #ifndef CONFIG_KPROBES
-bool ksu_sucompat_non_kp __read_mostly = true;
+static bool ksu_sucompat_non_kp __read_mostly = true;
 #endif
 
 static void __user *userspace_stack_buffer(const void *d, size_t len)


### PR DESCRIPTION
This is done like how vfs_read_hook, input_hook and execve_hook is disabled.
While this is not exactly the same thing, this *CAN* achieve the same results.
The complete disabling of all KernelSU hooks.

While this is likely unneeded, It keeps feature parity to non-kprobe builds.

adapted from:
	kernel: Allow to re-enable sucompat - https://github.com/tiann/KernelSU/commit/4593ae81c78998dffbc81291eac15726a273a538

