### PR TITLE
ksud/installer.sh: support odm handling

### DIFF
--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -407,6 +407,7 @@ install_module() {
   handle_partition vendor
   handle_partition system_ext
   handle_partition product
+  handle_partition odm
 
   if $BOOTMODE; then
     mktouch $NVBASE/modules/$MODID/update


### PR DESCRIPTION
mounting it is already supported on init_event.rs, but modules will still likely follow magisk module folder hierarchy, packing odm files on to MODDIR/system/odm.

since KernelSU is using overlayfs, we need to move those out.
