### PR TITLE
ksud/installer: /odm handling

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -605,6 +605,7 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 	// fixme: use `collect_mounts` and `iterate_mount` to iterate all mountpoint and
 	// filter the mountpoint whose target is `/data/adb`
+	try_umount("/odm", true, 0);
 	try_umount("/system", true, 0);
 	try_umount("/vendor", true, 0);
 	try_umount("/product", true, 0);

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -407,6 +407,7 @@ install_module() {
   handle_partition vendor
   handle_partition system_ext
   handle_partition product
+  handle_partition odm
 
   if $BOOTMODE; then
     mktouch $NVBASE/modules/$MODID/update

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -309,7 +309,8 @@ handle_partition() {
         return;
     fi
 
-    if [ -L "/system/$1" ] && [ "$(readlink -f /system/$1)" = "/$1" ]; then
+    # we move the folder to / only if it is a native folder that is not a symlink
+    if [ -d "/$1" ] && [ ! -L "/$1" ]; then
         ui_print "- Handle partition /$1"
         # we create a symlink if module want to access $MODPATH/system/$1
         # but it doesn't always work(ie. write it in post-fs-data.sh would fail because it is readonly)


### PR DESCRIPTION
we move the folder out of system if it exists in real filesystem and it is not a symlink.
this is already supported on init_event.rs so only handle_partition logic was needed to make it happen

since KernelSU is using overlayfs, we need to move these out.

Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>