### PR TITLE
Add a .gitignore file to the kernel directory

### DIFF
--- a/kernel/.gitignore
+++ b/kernel/.gitignore
@@ -1,0 +1,3 @@
+modules.*
+*.o
+*.o.cmd


### PR DESCRIPTION
This PR is to fix a personal annoyance. The `.o` and `.o.cmd` files generated during the build process should probably be ignored by Git.

Also @KernelSU-Next or @rifsxd, please pull this as well. (if this gets accepted)

Thank you.