### PR TITLE
[add device]: Samsung M30s (M307F)

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -719,5 +719,12 @@
         "kernel_name": "android_kernel_samsung_sm7225",
         "kernel_link": "https://github.com/itejo443/android_kernel_samsung_sm7225",
         "devices": "Samsung Galaxy F23 and M23 (m23xq)"
+    },
+    {
+        "maintainer": "JuiIm",
+        "maintainer_link": "https://github.com/JuiIm",
+        "kernel_name": "M30s-custom-kernel",
+        "kernel_link": "https://github.com/JuiIm/M30s-custom-kernel-M307f---KernelSU-support/",
+        "devices": "Samsung Galaxy M30s (M307F)"
     }
 ]


### PR DESCRIPTION
Adding Unofficial Support for Samsung M30s (Non gki)