### PR TITLE
website: Update Galaxy A05 to Galaxy A05/A04 repository link

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -709,9 +709,9 @@
     {
       "maintainer": "rsuntkOrgs",
         "maintainer_link": "https://github.com/rsuntkOrgs",
-        "kernel_name": "android_kernel_samsung_a05",
-        "kernel_link": "https://github.com/rsuntkOrgs/android_kernel_samsung_a05",
-        "devices": "Samsung Galaxy A05 (a05m) | SM-A055F/M | MT6768"
+        "kernel_name": "kernel_samsung_wingtech",
+        "kernel_link": "https://github.com/rsuntkOrgs/kernel_samsung_wingtech",
+        "devices": "Samsung Galaxy A05 (a05m) and A04 (a04)"
      },
     {
         "maintainer": "itejo443",


### PR DESCRIPTION
On latest update, we've added support for Samsung Galaxy A04 (a04), which force me to change the repository name to avoid confusion.