### PR TITLE
kernel: core_hook: automate and refactor umount

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -704,10 +704,13 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
-	char buf[256];
+	// 384 is what throne_tracker uses, something sensible even for /data/app
+	// we can pattern match revanced mounts even.
+	// we are not really interested on mountpoints that are longer than that
+	char buf[384];
 	char *dir_name = d_path(path, buf, sizeof(buf));
-	
-	if (dir_name)
+
+	if (dir_name && dir_name != buf)
 		return ksu_mount_monitor(dev_name, dir_name, type);
 	else
 		return 0;

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -559,6 +559,7 @@ static void try_umount(const char *mnt, bool check_mnt, int flags)
 
 int ksu_handle_setuid(struct cred *new, const struct cred *old)
 {
+	char buf[256];
 	struct mount_entry *entry, *tmp;
 
 	// this hook is used for umounting overlayfs for some uid, if there isn't any module mounted, just ignore it!
@@ -612,7 +613,8 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 #endif
 
 	list_for_each_entry_safe(entry, tmp, &mount_list, list) {
-		ksu_umount_mnt(&entry->path, 0); 
+		char *actual_path = d_path(&entry->path, buf, sizeof(buf));
+		try_umount(actual_path, false, MNT_DETACH);
 	}
 	
 	try_umount("/data/adb/modules", false, MNT_DETACH);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -50,7 +50,6 @@ static bool ksu_module_mounted = false;
 extern int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 static bool ksu_su_compat_enabled = true;
-static bool ksu_mount_monitor_enabled = true;
 extern void ksu_sucompat_init();
 extern void ksu_sucompat_exit();
 
@@ -333,9 +332,6 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
 				pr_info("boot_complete triggered\n");
-				// turn off mount monitor
-				pr_info("turning off ksu_mount_monitor\n");
-				ksu_mount_monitor_enabled = false;
 			}
 			break;
 		}
@@ -596,10 +592,7 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *type) 
 {
-	if (!ksu_mount_monitor_enabled) {
-		return 0;
-	}
-
+	
 	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
 	char *fstype_copy = kstrdup(type, GFP_KERNEL);
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
@@ -711,10 +704,6 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
-	if (!ksu_mount_monitor_enabled) {
-		return 0;
-	}
-
 	// 384 is what throne_tracker uses, something sensible even for /data/app
 	// we can pattern match revanced mounts even.
 	// we are not really interested on mountpoints that are longer than that

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -600,12 +600,13 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
 	struct mount_entry *new_entry;
 	
-	if (!device_name_copy || !fstype_copy || !dirname_copy) {
+	if (!device_name_copy || !dirname_copy) {
 		goto out;
 	}
 	
-	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update
-	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") ) {
+	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update || MKSU magic mount
+	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") || 
+		( strstarts(device_name_copy, "/dev/workdir") && !strstarts(dirname_copy, "/dev/workdir")) || strstarts(device_name_copy, "/data/adb/modules") ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -50,6 +50,7 @@ static bool ksu_module_mounted = false;
 extern int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
 static bool ksu_su_compat_enabled = true;
+static bool ksu_mount_monitor_enabled = true;
 extern void ksu_sucompat_init();
 extern void ksu_sucompat_exit();
 
@@ -332,6 +333,9 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 			if (!boot_complete_lock) {
 				boot_complete_lock = true;
 				pr_info("boot_complete triggered\n");
+				// turn off mount monitor
+				pr_info("turning off ksu_mount_monitor\n");
+				ksu_mount_monitor_enabled = false;
 			}
 			break;
 		}
@@ -592,7 +596,10 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *type) 
 {
-	
+	if (!ksu_mount_monitor_enabled) {
+		return 0;
+	}
+
 	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
 	char *fstype_copy = kstrdup(type, GFP_KERNEL);
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
@@ -704,6 +711,10 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 static int ksu_sb_mount(const char *dev_name, const struct path *path,
                         const char *type, unsigned long flags, void *data)
 {
+	if (!ksu_mount_monitor_enabled) {
+		return 0;
+	}
+
 	// 384 is what throne_tracker uses, something sensible even for /data/app
 	// we can pattern match revanced mounts even.
 	// we are not really interested on mountpoints that are longer than that

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -635,7 +635,7 @@ int ksu_mount_monitor(const char *dev_name, const struct path *path, const char 
 	}
 	
 	// overlay, overlayfs, change pattern later
-	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "pattern", 7) == 0) ) {
+	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "KSU", 3) == 0) ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->path = *path; 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -617,6 +617,12 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	return 0;
 }
 
+static int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
+{
+	pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", dev_name, type, path->dentry->d_iname);
+	return 0;
+}
+
 // Init functons
 
 static int handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -699,11 +705,18 @@ static int ksu_task_fix_setuid(struct cred *new, const struct cred *old,
 	return ksu_handle_setuid(new, old);
 }
 
+static int ksu_sb_mount(const char *dev_name, const struct path *path,
+                        const char *type, unsigned long flags, void *data)
+{
+	return ksu_mount_monitor(dev_name, path, type);
+}
+
 #ifndef MODULE
 static struct security_hook_list ksu_hooks[] = {
 	LSM_HOOK_INIT(task_prctl, ksu_task_prctl),
 	LSM_HOOK_INIT(inode_rename, ksu_inode_rename),
 	LSM_HOOK_INIT(task_fix_setuid, ksu_task_fix_setuid),
+	LSM_HOOK_INIT(sb_mount, ksu_sb_mount),
 };
 
 void __init ksu_lsm_hook_init(void)

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -617,9 +617,28 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 	return 0;
 }
 
-static int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
+int ksu_mount_monitor(const char *dev_name, const struct path *path, const char *type) 
 {
-	pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", dev_name, type, path->dentry->d_iname);
+	// https://elixir.bootlin.com/linux/v4.14.336/source/include/linux/fs.h#L2083 ?
+	char *device_name_copy = kstrdup(dev_name, GFP_KERNEL);
+	char *fstype_copy = kstrdup(type, GFP_KERNEL);
+	char *path_name_copy = kstrdup(path->dentry->d_iname, GFP_KERNEL);
+	
+	if (!device_name_copy || !fstype_copy || !path_name_copy) {
+		goto out;
+	}
+	
+	// overlay, overlayfs, change pattern later
+	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "pattern", 7) == 0) ) {
+		pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, path_name_copy);
+		// add me to list after
+		// better pass path struct
+	}
+	
+out:
+	kfree(device_name_copy);
+	kfree(fstype_copy);
+	kfree(path_name_copy);
 	return 0;
 }
 

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -603,7 +603,7 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 	}
 	
 	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update
-	if ( ( !strncmp(device_name_copy, "KSU", 3) && ( strstr(fstype_copy, "overlay") || !strncmp(fstype_copy, "tmpfs", 5) ) ) || strstr(dirname_copy, "/data/adb/modules") ) {
+	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -525,8 +525,10 @@ static void try_umount(const char *mnt, int flags)
 	int val = path_umount(&path, flags);
 	if (val)
 		pr_info("umount %s failed: %d\n", mnt, val);
+#ifdef CONFIG_KSU_DEBUG
 	else
 		pr_info("umount %s success: %d\n", mnt, val);
+#endif
 }
 
 int ksu_handle_setuid(struct cred *new, const struct cred *old)
@@ -710,10 +712,14 @@ static int ksu_sb_mount(const char *dev_name, const struct path *path,
 	char buf[384];
 	char *dir_name = d_path(path, buf, sizeof(buf));
 
-	if (dir_name && dir_name != buf)
+	if (dir_name && dir_name != buf) {
+#ifdef CONFIG_KSU_DEBUG
+		pr_info("security_sb_mount: devname: %s path: %s type: %s \n", dev_name, dir_name, type);
+#endif
 		return ksu_mount_monitor(dev_name, dir_name, type);
-	else
+	} else {
 		return 0;
+	}
 }
 
 #ifndef MODULE

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -587,10 +587,8 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 		try_umount(entry->umountable, MNT_DETACH);
 	}
 
+	// unconditional umount for modules.img
 	try_umount("/data/adb/modules", MNT_DETACH);
-
-	// try umount ksu temp path
-	try_umount("/debug_ramdisk", MNT_DETACH);
 
 	return 0;
 }
@@ -606,13 +604,13 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 		goto out;
 	}
 	
-	// overlay, overlayfs, change pattern later
-	if ( strstr(fstype_copy, "overlay") && (strncmp(device_name_copy, "KSU", 3) == 0) ) {
+	// KSU devname, overlay/fs and tmpfs
+	if ( !strncmp(device_name_copy, "KSU", 3) && ( strstr(fstype_copy, "overlay") || !strncmp(fstype_copy, "tmpfs", 5) ) ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);
 			list_add(&new_entry->list, &mount_list);
-			pr_info("security_sb_mount: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, new_entry->umountable);
+			pr_info("ksu_mount_monitor: devicename %s fstype: %s path: %s\n", device_name_copy, fstype_copy, new_entry->umountable);
 		}
 	}
 out:

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -661,6 +661,21 @@ static struct kprobe renameat_kp = {
 	.pre_handler = renameat_handler_pre,
 };
 
+
+static int mount_handler_pre(struct kprobe *p, struct pt_regs *regs)
+{
+	const char *dev_name = (const char *)PT_REGS_PARM1(regs); 
+	const char *dir_name = (const char *)PT_REGS_PARM2(regs);
+ 	const char *type = (const char *)PT_REGS_PARM3(regs);
+
+	return ksu_mount_monitor(dev_name, dir_name, type);
+}
+
+static struct kprobe mount_hook_kp = {
+	.symbol_name = "do_mount",
+	.pre_handler = mount_handler_pre,
+};
+
 __maybe_unused int ksu_kprobe_init(void)
 {
 	int rc = 0;
@@ -899,6 +914,7 @@ void __init ksu_lsm_hook_init(void)
 	} else {
 		pr_warn("Failed to find task_fix_setuid!\n");
 	}
+	register_kprobe(&mount_hook_kp);
 	smp_mb();
 }
 #endif

--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -600,13 +600,12 @@ int ksu_mount_monitor(const char *dev_name, const char *dirname, const char *typ
 	char *dirname_copy = kstrdup(dirname, GFP_KERNEL);
 	struct mount_entry *new_entry;
 	
-	if (!device_name_copy || !dirname_copy) {
+	if (!device_name_copy || !fstype_copy || !dirname_copy) {
 		goto out;
 	}
 	
-	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update || MKSU magic mount
-	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") || 
-		( strstarts(device_name_copy, "/dev/workdir") && !strstarts(dirname_copy, "/dev/workdir")) || strstarts(device_name_copy, "/data/adb/modules") ) {
+	// KSU devname, overlay/fs or tmpfs || /data/adb/modules, modules_update
+	if (( !strcmp(device_name_copy, "KSU")  && ( strstarts(fstype_copy, "overlay") || !strcmp(fstype_copy, "tmpfs") ) ) || strstarts(dirname_copy, "/data/adb/modules") ) {
 		new_entry = kmalloc(sizeof(*new_entry), GFP_KERNEL);
 		if (new_entry) {
 			new_entry->umountable = kstrdup(dirname, GFP_KERNEL);


### PR DESCRIPTION
monitors and lists all incoming mounts by hooking **security_sb_mount** or alternatively, **sys_mount / do_mount**. 
this requires ksud to go back and use sys_mount instead of fsopen + move_mount

this also fixes that MNT_DETACH issue. (https://github.com/tiann/KernelSU/pull/2386#issuecomment-2615518282)
Modules also can create an overlay with KSU devname and it will be added to the list.
**This will also restore pre 5.2 manager support.**

Those might be a bit questionable, so it is a take it or reject it kind of situation.

sys_mount hook looks like
```
ksu_mount_monitor(copy_mount_string(dev_name), copy_mount_string(dir_name), copy_mount_string(type));
```
ref: https://github.com/backslashxx/mojito_krenol/commit/ac020b09d0ff7a02dea9d1411202d30b5806ec14


sys_mount / do_mount compatibility is for LKM and 6.8+ where you cant just do LSM hooks as is.
https://github.com/torvalds/linux/commit/9285c5ad9d00abfe0f4e2ce4039c8127e7a09738#diff-3b35df76d1c4627ed97cc307a957850d57b85e77917c19ac0813286c46b4ace2R556

Context: https://github.com/aviraxp/KernelSU/commit/c7facef72a6ac6bdd6039b20b7df9ec3ea511331#commitcomment-153941502

