### PR TITLE
kernel/throne_tracker: we just uninstalled the manager, stop looking for it

### DIFF
--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -357,12 +357,14 @@ void track_throne()
 		if (ksu_is_manager_uid_valid()) {
 			pr_info("manager is uninstalled, invalidate it!\n");
 			ksu_invalidate_manager_uid();
+			goto prune;
 		}
 		pr_info("Searching manager...\n");
 		search_manager("/data/app", 2, &uid_list);
 		pr_info("Search manager finished\n");
 	}
 
+prune:
 	// then prune the allowlist
 	ksu_prune_allowlist(is_uid_exist, &uid_list);
 out:


### PR DESCRIPTION
When the manager UID disappears from packages.list, we correctly invalidate it — good. But, in the very next breath, we start scanning /data/app hoping to find it again?

Skip the scan — we’ll catch the reinstall next time packages.list updates.