### PR TITLE
ksud: add /my_bigball partition support

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -605,6 +605,7 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
 	// fixme: use `collect_mounts` and `iterate_mount` to iterate all mountpoint and
 	// filter the mountpoint whose target is `/data/adb`
+	try_umount("/my_bigball", true, 0);
 	try_umount("/odm", true, 0);
 	try_umount("/system", true, 0);
 	try_umount("/vendor", true, 0);

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -42,7 +42,7 @@ pub fn mount_modules_systemlessly(module_dir: &str) -> Result<()> {
 
     let mut system_lowerdir: Vec<String> = Vec::new();
 
-    let partition = vec!["vendor", "product", "system_ext", "odm", "oem"];
+    let partition = vec!["vendor", "product", "system_ext", "odm", "my_bigball", "oem"];
     let mut partition_lowerdir: HashMap<String, Vec<String>> = HashMap::new();
     for ele in &partition {
         partition_lowerdir.insert((*ele).to_string(), Vec::new());

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -408,6 +408,7 @@ install_module() {
   handle_partition system_ext
   handle_partition product
   handle_partition odm
+  handle_partition my_bigball
 
   if $BOOTMODE; then
     mktouch $NVBASE/modules/$MODID/update


### PR DESCRIPTION
some OnePlus devices mount a nonstandard partition at /my_bigball, which is used similarly to /odm or /vendor for preloaded system components.

this commit:
- adds /my_bigball to the partition list in init_event.rs
- handles /my_bigball in installer.sh like other partitions