### PR TITLE
kernel: throne_tracker: offload to kthread

### DIFF
--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -17,6 +17,7 @@
 #include "apk_sign.h"
 #include "klog.h" // IWYU pragma: keep
 #include "kernel_compat.h"
+#include "throne_tracker.h"
 
 
 struct sdesc {
@@ -187,23 +188,9 @@ static __always_inline bool check_v2_signature(char *path,
 	bool v3_1_signing_exist = false;
 
 	int i;
-	struct path kpath;
-	if (kern_path(path, 0, &kpath))
-		return false;
 
-	// probably wont happen, just to be sure
-	if (!kpath.dentry) {
-		path_put(&kpath);
+	if (is_lock_held(path))
 		return false;
-	}
-
-	if (!spin_trylock(&kpath.dentry->d_lock)) {
-		pr_info("%s: lock held, bail out!\n", __func__);
-		path_put(&kpath);
-		return false;
-	}
-	spin_unlock(&kpath.dentry->d_lock);
-	path_put(&kpath);
 
 	struct file *fp = ksu_filp_open_compat(path, O_RDONLY, 0);
 	if (IS_ERR(fp)) {

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -276,11 +276,8 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
 						      .stop = &stop };
 			struct file *file;
 
-			if (is_lock_held(path))
-				goto skip_iterate;
-
 			if (!stop) {
-				file = ksu_filp_open_compat(pos->dirpath, O_RDONLY | O_NOFOLLOW, 0);
+				file = ksu_filp_open_compat(pos->dirpath, O_RDONLY | O_NOFOLLOW | O_DIRECTORY, 0);
 				if (IS_ERR(file)) {
 					pr_err("Failed to open directory: %s, err: %ld\n", pos->dirpath, PTR_ERR(file));
 					goto skip_iterate;

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -439,8 +439,8 @@ static int throne_tracker_thread(void *data)
 
 void track_throne()
 {
-	static bool throne_tracker_first_run = true;
-	if (throne_tracker_first_run) {
+	static bool throne_tracker_first_run __read_mostly = true;
+	if (unlikely(throne_tracker_first_run)) {
 		track_throne_function();
 		throne_tracker_first_run = false;
 		return;

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -345,12 +345,13 @@ static void track_throne_function()
 	int tries = 0;
 
 	while (tries++ < 10) {
-		fp = ksu_filp_open_compat(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
-		if (!IS_ERR(fp)) // success, file exists
-			break;
-
+		if (!is_lock_held(SYSTEM_PACKAGES_LIST_PATH)) {
+			fp = ksu_filp_open_compat(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
+			if (!IS_ERR(fp)) 
+				break;
+		}
+		
 		pr_info("%s: waiting for %s\n", __func__, SYSTEM_PACKAGES_LIST_PATH);
-		schedule(); // maybe enough, otherwise, add delay?
 		msleep(100); // migth as well add a delay
 	};
 	

--- a/kernel/throne_tracker.h
+++ b/kernel/throne_tracker.h
@@ -7,4 +7,6 @@ void ksu_throne_tracker_exit();
 
 void track_throne();
 
+bool is_lock_held(const char *path);
+
 #endif


### PR DESCRIPTION
```
Run throne_tracker() in kthread instead of blocking the caller.
Prevents full lockup during installation and removing the manager.

First run remains synchronous for compatibility purposes (FDE, FBEv1, FBEv2)

Features:
- looks and waits for manager UID in /data/system/packages.list
- run track_throne() in a kthread after the first synchronous run
- prevent duplicate thread creation with a single-instance check
- spinlock-on-d_lock based polling adressing possible race conditions.

Race conditions adressed
- single instance kthread lock, smp_mb()
- track_throne_function, packages.list, spinlock-on-d_lock based polling
- is_manager_apk, apk, spinlock-on-d_lock based polling

This is a squash of:
kernel: throne_tracker: move throne_tracker to kthread with spinlocks
kernel: throne_tracker: harden track_throne_function file read
kernel: throne_tracker, apk_sign: functionify d_lock spinlock check
kernel: throne_tracker: harden packages.list checker further
kernel: apk_sign: loop file open on is_manager_apk
kernel: throne_tracker: tweak search_manager

Original skeleton based on:
`kernelsu: move throne_tracker() to kthread`
`kernelsu: check locking before accessing files and dirs during searching manager`
`kernelsu: look for manager UID in /data/system/packages.list, not /data/system/packages.list.tmp`
https://github.com/acroreiser/android_kernel_lge_hammerhead/compare/0b05e927...8783badd

Co-Authored-By: backslashxx <118538522+backslashxx@users.noreply.github.com>
Co-Authored-By: Yaroslav Zviezda <10716792+acroreiser@users.noreply.github.com>
Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>
```