### PR TITLE
kernel: sucompat: increase reliability, commonize and micro-optimize

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -45,65 +45,86 @@ static char __user *ksud_user_path(void)
 	return userspace_stack_buffer(ksud_path, sizeof(ksud_path));
 }
 
-int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
-			 int *__unused_flags)
+__attribute__((hot))
+static long ksu_strncpy_from_user_retry(char *dst, 
+			const void __user *unsafe_addr, long count)
+{
+	long ret = ksu_strncpy_from_user_nofault(dst, unsafe_addr, count);
+	if (likely(ret >= 0))
+		return ret;
+
+	// we faulted! fallback to slow path
+	if (unlikely(!access_ok(unsafe_addr, count)))
+		return -EFAULT;
+
+	return strncpy_from_user(dst, unsafe_addr, count);
+}
+
+// every little bit helps here
+__attribute__((hot))
+static bool is_su_allowed(const void *ptr_to_check)
+{
+	if (unlikely(!ptr_to_check))
+		return false;
+
+	if (likely(!ksu_is_allow_uid(current_uid().val)))
+		return false;
+	
+	return true;
+}
+
+static int ksu_sucompat_common(const char __user **filename_user, const char *syscall_name,
+				const bool escalate)
 {
 	const char su[] = SU_PATH;
 
-	if (!ksu_is_allow_uid(current_uid().val)) {
-		return 0;
-	}
-
 	char path[sizeof(su) + 1];
-	memset(path, 0, sizeof(path));
-	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
+	long len = ksu_strncpy_from_user_retry(path, *filename_user, sizeof(path));
+	if (len <= 0) // sizeof(su) is not zero
+		return 0;
 
-	if (unlikely(!memcmp(path, su, sizeof(su)))) {
-		pr_info("faccessat su->sh!\n");
+	path[sizeof(path) - 1] = '\0';
+
+	if (memcmp(path, su, sizeof(su)))
+		return 0;
+
+	if (escalate) {
+		pr_info("%s su found\n", syscall_name);
+		*filename_user = ksud_user_path();
+		escape_to_root(); // escalate !!
+	} else {
+		pr_info("%s su->sh!\n", syscall_name);
 		*filename_user = sh_user_path();
 	}
 
 	return 0;
 }
 
+int ksu_handle_faccessat(int *dfd, const char __user **filename_user, int *mode,
+			 int *__unused_flags)
+{
+	if (!is_su_allowed((const void *)filename_user))
+		return 0;
+
+	return ksu_sucompat_common(filename_user, "faccessat", false);
+}
+
 int ksu_handle_stat(int *dfd, const char __user **filename_user, int *flags)
 {
-	// const char sh[] = SH_PATH;
-	const char su[] = SU_PATH;
-
-	if (!ksu_is_allow_uid(current_uid().val)) {
+	if (!is_su_allowed((const void *)filename_user))
 		return 0;
-	}
 
-	if (unlikely(!filename_user)) {
+	return ksu_sucompat_common(filename_user, "newfstatat", false);
+}
+
+int ksu_handle_execve_sucompat(int *fd, const char __user **filename_user,
+			       void *__never_use_argv, void *__never_use_envp,
+			       int *__never_use_flags)
+{
+	if (!is_su_allowed((const void *)filename_user))
 		return 0;
-	}
 
-	char path[sizeof(su) + 1];
-	memset(path, 0, sizeof(path));
-// Remove this later!! we use syscall hook, so this will never happen!!!!!
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0) && 0
-	// it becomes a `struct filename *` after 5.18
-	// https://elixir.bootlin.com/linux/v5.18/source/fs/stat.c#L216
-	const char sh[] = SH_PATH;
-	struct filename *filename = *((struct filename **)filename_user);
-	if (IS_ERR(filename)) {
-		return 0;
-	}
-	if (likely(memcmp(filename->name, su, sizeof(su))))
-		return 0;
-	pr_info("vfs_statx su->sh!\n");
-	memcpy((void *)filename->name, sh, sizeof(sh));
-#else
-	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
-
-	if (unlikely(!memcmp(path, su, sizeof(su)))) {
-		pr_info("newfstatat su->sh!\n");
-		*filename_user = sh_user_path();
-	}
-#endif
-
-	return 0;
+	return ksu_sucompat_common(filename_user, "sys_execve", true);
 }
 
 // the call from execve_handler_pre won't provided correct value for __never_use_argument, use them after fix execve_handler_pre, keeping them for consistence for manually patched code
@@ -115,7 +136,7 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	const char sh[] = KSUD_PATH;
 	const char su[] = SU_PATH;
 
-	if (unlikely(!filename_ptr))
+	if (!is_su_allowed((const void *)filename_ptr))
 		return 0;
 
 	filename = *filename_ptr;
@@ -126,38 +147,8 @@ int ksu_handle_execveat_sucompat(int *fd, struct filename **filename_ptr,
 	if (likely(memcmp(filename->name, su, sizeof(su))))
 		return 0;
 
-	if (!ksu_is_allow_uid(current_uid().val))
-		return 0;
-
 	pr_info("do_execveat_common su found\n");
 	memcpy((void *)filename->name, sh, sizeof(sh));
-
-	escape_to_root();
-
-	return 0;
-}
-
-int ksu_handle_execve_sucompat(int *fd, const char __user **filename_user,
-			       void *__never_use_argv, void *__never_use_envp,
-			       int *__never_use_flags)
-{
-	const char su[] = SU_PATH;
-	char path[sizeof(su) + 1];
-
-	if (unlikely(!filename_user))
-		return 0;
-
-	memset(path, 0, sizeof(path));
-	ksu_strncpy_from_user_nofault(path, *filename_user, sizeof(path));
-
-	if (likely(memcmp(path, su, sizeof(su))))
-		return 0;
-
-	if (!ksu_is_allow_uid(current_uid().val))
-		return 0;
-
-	pr_info("sys_execve su found\n");
-	*filename_user = ksud_user_path();
 
 	escape_to_root();
 


### PR DESCRIPTION
```
On plain ARMv8.0 devices (A53,A57,A73), strncpy_from_user_nofault() sometimes
fails to copy `filename_user` string correctly. This breaks su ofc, breaking
some apps like Termux (Play Store ver), ZArchiver and Root Explorer.

This does NOT seem to affect newer ARMv8.2+ CPUs (A75/A76 and newer)

My speculation? ARMv8.0 has weak speculation :)

here we replace `ksu_strncpy_from_user_nofault` with ksu_strncpy_from_user_retry:
- ksu_strncpy_from_user_nofault as fast-path copy
- fallback to access_ok to validate the pointer + strncpy_from_user
- manual null-termination just in case, as strncpy_from_user_nofault also does it
- remove that memset, seems useless as it is an strncpy, not strncat

basically, we retry on pagefualt

for usercopies, its not like were doing
	memset(dest, 0, sizeof(dest));
	strncat(dest, var, bytes);

that memset seems unneeded. instead we use strncpy itself to do proper
error and oob check and null term it after.

as for optimizations
- just return early if unauthorized
- commonized logic
- reduced duplication

Tested on:
- ARMv8.0 A73.a53, A57.a53, A53.a53
- ARMv8.2 A76.a55
- ARMV9.2 X4.A720.a520

Signed-off-by: backslashxx <118538522+backslashxx@users.noreply.github.com>
```