### PR TITLE
kernel: fix dmesg splat and small cleanup(s)

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -42,7 +42,6 @@
 #include "manager.h"
 #include "selinux/selinux.h"
 #include "throne_tracker.h"
-#include "throne_tracker.h"
 #include "kernel_compat.h"
 
 static bool ksu_module_mounted = false;
@@ -482,7 +481,7 @@ int ksu_handle_prctl(int option, unsigned long arg2, unsigned long arg3,
 		bool enabled = (arg3 != 0);
 		if (enabled == ksu_su_compat_enabled) {
 			pr_info("cmd enable su but no need to change.\n");
-			if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {// return the reply_ok directly
+			if (copy_to_user(result, &reply_ok, sizeof(reply_ok))) {
 				pr_err("prctl reply error, cmd: %lu\n", arg2);
 			}
 			return 0;


### PR DESCRIPTION
* Dmesg splat:
[   11.300149] BUG: sleeping function called from invalid context at lib/strncpy_from_user.c:40
[   11.300159] in_atomic(): 0, irqs_disabled(): 0, pid: 832, name: ksud
[   11.300166] CPU: 6 PID: 832 Comm: ksud Tainted: G        W         4.19.325-st6-Shikishima-gc67b50cd2cff #1
[   11.300168] Hardware name: Qualcomm Technologies, Inc. SDM 660 PM660 + PM660L QRD (DT)
[   11.300169] Call trace:
[   11.300178] dump_backtrace+0x0/0x1b8
[   11.300184] __dump_stack+0x20/0x28
[   11.300186] dump_stack+0xc4/0xe8
[   11.300190] ___might_sleep+0xf4/0x104
[   11.300192] __might_sleep+0x34/0x88
[   11.300196] __might_fault+0x2c/0x34
[   11.300200] strncpy_from_user+0xc8/0x3bc
[   11.300203] handle_sepolicy+0x43c/0xb54
[   11.300205] ksu_handle_prctl+0x530/0xe88
[   11.300207] ksu_task_prctl+0xc/0x18
[   11.300210] security_task_prctl+0x64/0x98
[   11.300213] __arm64_sys_prctl+0x4c/0x720
[   11.300215] el0_svc_common+0x94/0x160
[   11.300217] el0_svc_handler+0x68/0x80
[   11.300219] el0_svc+0x8/0x500

Related-pr: https://github.com/tiann/KernelSU/pull/2646