### PR TITLE
fix 'for' loop problem

### DIFF
--- a/kernel/sucompat.c
+++ b/kernel/sucompat.c
@@ -279,7 +279,8 @@ void ksu_sucompat_init()
 void ksu_sucompat_exit()
 {
 #ifdef CONFIG_KPROBES
-	for (int i = 0; i < ARRAY_SIZE(su_kps); i++) {
+	int i;
+	for (i = 0; i < ARRAY_SIZE(su_kps); i++) {
 		destroy_kprobe(&su_kps[i]);
 	}
 #endif


### PR DESCRIPTION
fix ‘for’ loop initial declarations are only allowed in c99 or c11 mode