### PR TITLE
内核：通过解析 /data/user_de/ 中的 UID 来添加真实的 UID

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -203,18 +203,25 @@ int ksu_handle_rename(struct dentry *old_dentry, struct dentry *new_dentry)
 		return 0;
 	}
 
-	//  It still monitors changes to certain system files to trigger scans, but does not rely on packages.list.
-	if (strstr(new_dentry->d_iname, "packages") &&
-		strstr(new_dentry->d_iname, "list")) {
-		char path[128];
-		char *buf = dentry_path_raw(new_dentry, path, sizeof(path));
-		if (!IS_ERR(buf) && strstr(buf, "/system/")) {
-			pr_info("System package change detected: %s -> %s, triggering user scan\n", 
-				old_dentry->d_iname, new_dentry->d_iname);
-			track_throne();
-		}
+	// /data/system/packages.list.tmp -> /data/system/packages.list
+	if (strcmp(new_dentry->d_iname, "packages.list")) {
 		return 0;
 	}
+
+	char path[128];
+	char *buf = dentry_path_raw(new_dentry, path, sizeof(path));
+	if (IS_ERR(buf)) {
+		pr_err("dentry_path_raw failed.\n");
+		return 0;
+	}
+
+	if (!strstr(buf, "/system/packages.list")) {
+		return 0;
+	}
+	pr_info("renameat: %s -> %s, new path: %s\n", old_dentry->d_iname,
+		new_dentry->d_iname, buf);
+
+	track_throne();
 
 	return 0;
 }

--- a/kernel/kernel_compat.h
+++ b/kernel/kernel_compat.h
@@ -5,6 +5,29 @@
 #include <linux/version.h>
 #include "ss/policydb.h"
 #include "linux/key.h"
+#include <linux/list.h>
+
+/**
+ * list_count_nodes - count the number of nodes in a list
+ * the head of the list
+ * 
+ * Returns the number of nodes in the list
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+static inline __maybe_unused size_t list_count_nodes(const struct list_head *head)
+{
+    const struct list_head *pos;
+    size_t count = 0;
+
+    if (!head)
+        return 0;
+
+    list_for_each(pos, head)
+        count++;
+
+	return count;
+}
+#endif
 
 /*
  * Adapt to Huawei HISI kernel without affecting other kernels ,

--- a/kernel/kernel_compat.h
+++ b/kernel/kernel_compat.h
@@ -9,9 +9,16 @@
 
 /**
  * list_count_nodes - count the number of nodes in a list
- * the head of the list
- * 
- * Returns the number of nodes in the list
+ * @head: the head of the list
+ *
+ * This function iterates over the list starting from @head and counts
+ * the number of nodes in the list. It does not modify the list.
+ *
+ * Context: Any context. The function is safe to call in any context,
+ *          including interrupt context, as it does not sleep or allocate
+ *          memory.
+ *
+ * Return: the number of nodes in the list (excluding the head)
  */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 static inline __maybe_unused size_t list_count_nodes(const struct list_head *head)

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -213,8 +213,9 @@ FILLDIR_RETURN_TYPE user_data_actor(struct dir_context *ctx, const char *name,
 	}
 
 	data->uid = uid;
-	strncpy(data->package, name, min(namelen, KSU_MAX_PACKAGE_NAME - 1));
-	data->package[min(namelen, KSU_MAX_PACKAGE_NAME - 1)] = '\0';
+	size_t copy_len = min(namelen, KSU_MAX_PACKAGE_NAME - 1);
+	strncpy(data->package, name, copy_len);
+	data->package[copy_len] = '\0';
 	
 	list_add_tail(&data->list, my_ctx->uid_list);
 	
@@ -503,8 +504,7 @@ void track_throne()
 		filp_close(fp, 0);
 		pr_info("Loaded %zu packages from packages.list fallback\n", fallback_count);
 	} else {
-		uid_count = list_count_nodes(&uid_list);
-		pr_info("UserDE UID: Successfully loaded %zu packages from user data directory\n", uid_count);
+		pr_info("UserDE UID: Successfully loaded %zu packages from user data directory\n", list_count_nodes(&uid_list));
 	}
 
 	// now update uid list

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -441,7 +441,6 @@ void track_throne()
 
 	pr_info("Starting UID scan from user data directory\n");
 	int ret = scan_user_data_for_uids(&uid_list);
-	size_t uid_count;
 	
 	if (ret < 0) {
 		pr_warn("Failed to scan user data directory (%d), falling back to packages.list\n", ret);

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -20,8 +20,6 @@ uid_t ksu_manager_uid = KSU_INVALID_UID;
 #define USER_DATA_BASE_PATH "/data/user_de"
 #define MAX_SUPPORTED_USERS 32 // Supports up to 32 users
 #define USER_DATA_PATH_LEN 384 // 384 is enough for /data/user_de/{userid}/<package>
-#define MAX_ANDROID_USER_ID 999
-#define MIN_ANDROID_USER_ID 0
 
 struct uid_data {
 	struct list_head list;
@@ -151,44 +149,74 @@ struct user_data_context {
 	struct user_scan_context *scan_ctx;
 };
 
+struct user_de_context {
+    struct dir_context ctx;
+    uid_t *user_ids;
+    size_t count;
+    size_t max_users;
+};
+
+// Actor function to collect user IDs from /data/user_de
+FILLDIR_RETURN_TYPE user_de_actor(struct dir_context *ctx, const char *name,
+                                  int namelen, loff_t off, u64 ino,
+                                  unsigned int d_type)
+{
+    struct user_de_context *data = container_of(ctx, struct user_de_context, ctx);
+
+    if (d_type != DT_DIR)
+        return FILLDIR_ACTOR_CONTINUE;
+
+    if (strncmp(name, ".", namelen) == 0 || strncmp(name, "..", namelen) == 0)
+        return FILLDIR_ACTOR_CONTINUE;
+
+    uid_t uid = 0;
+    for (int i = 0; i < namelen; i++) {
+        if (name[i] < '0' || name[i] > '9')
+            return FILLDIR_ACTOR_CONTINUE;
+        uid = uid * 10 + (name[i] - '0');
+    }
+
+    if (data->count >= data->max_users)
+        return FILLDIR_ACTOR_STOP;
+
+    data->user_ids[data->count++] = uid;
+    return FILLDIR_ACTOR_CONTINUE;
+}
+
 // Retrieve a list of all active Android user IDs in the system
 static int get_active_user_ids(uid_t *user_ids, size_t max_users, size_t *found_users)
 {
     struct file *dir_file;
     int ret = 0;
-    size_t count = 0;
-
-    const char *opened_base = NULL;
 
     *found_users = 0;
 
     dir_file = ksu_filp_open_compat(USER_DATA_BASE_PATH, O_RDONLY, 0);
     if (IS_ERR(dir_file)) {
         pr_err("Failed to open user data path %s: %ld\n",
-		       USER_DATA_BASE_PATH, PTR_ERR(dir_file));
+               USER_DATA_BASE_PATH, PTR_ERR(dir_file));
         return PTR_ERR(dir_file);
     }
-    opened_base = USER_DATA_BASE_PATH;
 
-    for (uid_t user_id = MIN_ANDROID_USER_ID;
-         user_id <= MAX_ANDROID_USER_ID && count < max_users;
-         user_id++) {
+    struct {
+        struct dir_context ctx;
+        uid_t *user_ids;
+        size_t count;
+        size_t max_users;
+    } ctx = {
+        .ctx.actor = user_de_actor,
+        .user_ids = user_ids,
+        .count = 0,
+        .max_users = max_users
+    };
 
-        char user_path[USER_DATA_PATH_LEN];
-        struct path path;
-
-        snprintf(user_path, sizeof(user_path), "%s/%u", opened_base, user_id);
-
-        if (!kern_path(user_path, 0, &path)) {
-            user_ids[count++] = user_id;
-            path_put(&path);
-        }
-    }
-
+    ret = iterate_dir(dir_file, &ctx.ctx);
     filp_close(dir_file, NULL);
-    *found_users = count;
-    if (count > 0)
-        pr_info("UserDE UID: Found %zu active users\n", count);
+
+    *found_users = ctx.count;
+
+    if (ctx.count > 0)
+        pr_info("UserDE UID: Found %zu active users\n", ctx.count);
 
     return ret;
 }

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -19,7 +19,7 @@ uid_t ksu_manager_uid = KSU_INVALID_UID;
 
 #define USER_DATA_BASE_PATH "/data/user_de"
 #define MAX_SUPPORTED_USERS 32 // Supports up to 32 users
-#define USER_DATA_PATH_LEN 384 // 384 is enough for /data/user_de/{userid}/<package>
+#define DATA_PATH_LEN 384 // 384 is enough for /data/app/<package>/base.apk and /data/user_de/{userid}/<package>
 
 struct uid_data {
 	struct list_head list;
@@ -27,12 +27,58 @@ struct uid_data {
 	char package[KSU_MAX_PACKAGE_NAME];
 };
 
-struct user_scan_context {
+struct user_scan_ctx {
 	struct list_head *uid_list;
 	uid_t user_id;
-	size_t packages_found;
-	size_t errors_count;
+	size_t pkg_count;
+	size_t error_count;
 };
+
+struct user_dir_ctx {
+	struct dir_context ctx;
+	struct user_scan_ctx *scan_ctx;
+};
+
+struct user_id_ctx {
+	struct dir_context ctx;
+	uid_t *user_ids;
+	size_t count;
+	size_t max_count;
+};
+
+struct data_path {
+	char dirpath[DATA_PATH_LEN];
+	int depth;
+	struct list_head list;
+};
+
+struct apk_path_hash {
+	unsigned int hash;
+	bool exists;
+	struct list_head list;
+};
+
+static struct list_head apk_path_hash_list;
+
+struct my_dir_context {
+	struct dir_context ctx;
+	struct list_head *data_path_list;
+	char *parent_dir;
+	void *private_data;
+	int depth;
+	int *stop;
+};
+// https://docs.kernel.org/filesystems/porting.html
+// filldir_t (readdir callbacks) calling conventions have changed. Instead of returning 0 or -E... it returns bool now. false means "no more" (as -E... used to) and true - "keep going" (as 0 in old calling conventions). Rationale: callers never looked at specific -E... values anyway. -> iterate_shared() instances require no changes at all, all filldir_t ones in the tree converted.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#define FILLDIR_RETURN_TYPE bool
+#define FILLDIR_ACTOR_CONTINUE true
+#define FILLDIR_ACTOR_STOP false
+#else
+#define FILLDIR_RETURN_TYPE int
+#define FILLDIR_ACTOR_CONTINUE 0
+#define FILLDIR_ACTOR_STOP -EINVAL
+#endif
 
 static int get_pkg_from_apk_path(char *pkg, const char *path)
 {
@@ -103,243 +149,180 @@ static void crown_manager(const char *apk, struct list_head *uid_data)
 	}
 }
 
-#define DATA_PATH_LEN 384 // 384 is enough for /data/app/<package>/base.apk
-
-struct data_path {
-	char dirpath[DATA_PATH_LEN];
-	int depth;
-	struct list_head list;
-};
-
-struct apk_path_hash {
-	unsigned int hash;
-	bool exists;
-	struct list_head list;
-};
-
-static struct list_head apk_path_hash_list = LIST_HEAD_INIT(apk_path_hash_list);
-
-struct my_dir_context {
-	struct dir_context ctx;
-	struct list_head *data_path_list;
-	char *parent_dir;
-	void *private_data;
-	int depth;
-	int *stop;
-};
-// https://docs.kernel.org/filesystems/porting.html
-// filldir_t (readdir callbacks) calling conventions have changed. Instead of returning 0 or -E... it returns bool now. false means "no more" (as -E... used to) and true - "keep going" (as 0 in old calling conventions). Rationale: callers never looked at specific -E... values anyway. -> iterate_shared() instances require no changes at all, all filldir_t ones in the tree converted.
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
-#define FILLDIR_RETURN_TYPE bool
-#define FILLDIR_ACTOR_CONTINUE true
-#define FILLDIR_ACTOR_STOP false
-#else
-#define FILLDIR_RETURN_TYPE int
-#define FILLDIR_ACTOR_CONTINUE 0
-#define FILLDIR_ACTOR_STOP -EINVAL
-#endif
-
-struct uid_scan_stats {
-	size_t total_found;
-	size_t errors_encountered;
-};
-
-struct user_data_context {
-	struct dir_context ctx;
-	struct user_scan_context *scan_ctx;
-};
-
-struct user_de_context {
-    struct dir_context ctx;
-    uid_t *user_ids;
-    size_t count;
-    size_t max_users;
-};
-
-// Actor function to collect user IDs from /data/user_de
-FILLDIR_RETURN_TYPE user_de_actor(struct dir_context *ctx, const char *name,
-                                  int namelen, loff_t off, u64 ino,
-                                  unsigned int d_type)
+FILLDIR_RETURN_TYPE collect_user_ids(struct dir_context *ctx, const char *name,
+				     int namelen, loff_t off, u64 ino, unsigned int d_type)
 {
-    struct user_de_context *data = container_of(ctx, struct user_de_context, ctx);
+	struct user_id_ctx *uctx = container_of(ctx, struct user_id_ctx, ctx);
 
-    if (d_type != DT_DIR)
-        return FILLDIR_ACTOR_CONTINUE;
+	// Skip non-directories and dot entries
+	if (d_type != DT_DIR || namelen <= 0)
+		return FILLDIR_ACTOR_CONTINUE;
+	if (name[0] == '.' && (namelen == 1 || (namelen == 2 && name[1] == '.')))
+		return FILLDIR_ACTOR_CONTINUE;
 
-    if (strncmp(name, ".", namelen) == 0 || strncmp(name, "..", namelen) == 0)
-        return FILLDIR_ACTOR_CONTINUE;
-
-    uid_t uid = 0;
-    for (int i = 0; i < namelen; i++) {
-        if (name[i] < '0' || name[i] > '9')
-            return FILLDIR_ACTOR_CONTINUE;
-        uid = uid * 10 + (name[i] - '0');
-    }
-
-    if (data->count >= data->max_users)
-        return FILLDIR_ACTOR_STOP;
-
-    data->user_ids[data->count++] = uid;
-    return FILLDIR_ACTOR_CONTINUE;
-}
-
-// Retrieve a list of all active Android user IDs in the system
-static int get_active_user_ids(uid_t *user_ids, size_t max_users, size_t *found_users)
-{
-    struct file *dir_file;
-    int ret = 0;
-
-    *found_users = 0;
-
-    dir_file = ksu_filp_open_compat(USER_DATA_BASE_PATH, O_RDONLY, 0);
-    if (IS_ERR(dir_file)) {
-        pr_err("Failed to open user data path %s: %ld\n",
-               USER_DATA_BASE_PATH, PTR_ERR(dir_file));
-        return PTR_ERR(dir_file);
-    }
-
-    struct {
-        struct dir_context ctx;
-        uid_t *user_ids;
-        size_t count;
-        size_t max_users;
-    } ctx = {
-        .ctx.actor = user_de_actor,
-        .user_ids = user_ids,
-        .count = 0,
-        .max_users = max_users
-    };
-
-    ret = iterate_dir(dir_file, &ctx.ctx);
-    filp_close(dir_file, NULL);
-
-    *found_users = ctx.count;
-
-    if (ctx.count > 0)
-        pr_info("UserDE UID: Found %zu active users\n", ctx.count);
-
-    return ret;
-}
-
-FILLDIR_RETURN_TYPE user_data_actor(struct dir_context *ctx, const char *name,
-				     int namelen, loff_t off, u64 ino,
-				     unsigned int d_type)
-{
-	struct user_data_context *my_ctx = 
-		container_of(ctx, struct user_data_context, ctx);
-	
-	if (!my_ctx || !my_ctx->scan_ctx || !my_ctx->scan_ctx->uid_list) {
-		return FILLDIR_ACTOR_STOP;
+	// Parse numeric user ID
+	uid_t uid = 0;
+	for (int i = 0; i < namelen; i++) {
+		if (name[i] < '0' || name[i] > '9')
+			return FILLDIR_ACTOR_CONTINUE; // Skip non-numeric entries
+		uid = uid * 10 + (name[i] - '0');
 	}
 
-	struct user_scan_context *scan_ctx = my_ctx->scan_ctx;
+	// Store user ID if space available
+	if (uctx->count >= uctx->max_count)
+		return FILLDIR_ACTOR_STOP;
 
-	if (!strncmp(name, "..", namelen) || !strncmp(name, ".", namelen))
+	uctx->user_ids[uctx->count++] = uid;
+	return FILLDIR_ACTOR_CONTINUE;
+}
+
+// Get all active Android user IDs
+static int get_active_user_ids(uid_t *user_ids, size_t max_users, size_t *found_count)
+{
+	struct file *dir_file;
+	int ret;
+
+	*found_count = 0;
+
+	dir_file = ksu_filp_open_compat(USER_DATA_BASE_PATH, O_RDONLY, 0);
+	if (IS_ERR(dir_file)) {
+		pr_err("Cannot open %s: %ld\n", USER_DATA_BASE_PATH, PTR_ERR(dir_file));
+		return PTR_ERR(dir_file);
+	}
+
+	struct user_id_ctx uctx = {
+		.ctx.actor = collect_user_ids,
+		.user_ids = user_ids,
+		.count = 0,
+		.max_count = max_users
+	};
+
+	ret = iterate_dir(dir_file, &uctx.ctx);
+	filp_close(dir_file, NULL);
+
+	*found_count = uctx.count;
+	if (uctx.count > 0)
+		pr_info("Found %zu active users\n", uctx.count);
+
+	return ret;
+}
+
+FILLDIR_RETURN_TYPE scan_user_packages(struct dir_context *ctx, const char *name,
+				       int namelen, loff_t off, u64 ino, unsigned int d_type)
+{
+	struct user_dir_ctx *uctx = container_of(ctx, struct user_dir_ctx, ctx);
+	struct user_scan_ctx *scan_ctx = uctx->scan_ctx;
+
+	// Validate context and skip dot entries
+	if (!scan_ctx || !scan_ctx->uid_list)
+		return FILLDIR_ACTOR_STOP;
+	if (d_type != DT_DIR || namelen <= 0)
+		return FILLDIR_ACTOR_CONTINUE;
+	if (name[0] == '.' && (namelen == 1 || (namelen == 2 && name[1] == '.')))
 		return FILLDIR_ACTOR_CONTINUE;
 
-	if (d_type != DT_DIR)
-		return FILLDIR_ACTOR_CONTINUE;
-
+	// Check package name length
 	if (namelen >= KSU_MAX_PACKAGE_NAME) {
 		pr_warn("Package name too long: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
-		scan_ctx->errors_count++;
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
-	char package_path[USER_DATA_PATH_LEN];
-	if (snprintf(package_path, sizeof(package_path), "%s/%u/%.*s", 
-		     USER_DATA_BASE_PATH, scan_ctx->user_id, namelen, name) >= sizeof(package_path)) {
-		pr_err("Path too long for package: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
-		scan_ctx->errors_count++;
+	// Build package path
+	char pkg_path[DATA_PATH_LEN];
+	int path_len = snprintf(pkg_path, sizeof(pkg_path), "%s/%u/%.*s",
+				USER_DATA_BASE_PATH, scan_ctx->user_id, namelen, name);
+	if (path_len >= sizeof(pkg_path)) {
+		pr_err("Path too long for: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
+	// Get package path attributes
 	struct path path;
-	int err = kern_path(package_path, LOOKUP_FOLLOW, &path);
+	int err = kern_path(pkg_path, LOOKUP_FOLLOW, &path);
 	if (err) {
-		pr_debug("Package path lookup failed: %s (err: %d)\n", package_path, err);
-		scan_ctx->errors_count++;
+		pr_debug("Path lookup failed: %s (%d)\n", pkg_path, err);
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
 	struct kstat stat;
 	err = vfs_getattr(&path, &stat, STATX_UID, AT_STATX_SYNC_AS_STAT);
 	path_put(&path);
-	
+
 	if (err) {
-		pr_debug("Failed to get attributes for: %s (err: %d)\n", package_path, err);
-		scan_ctx->errors_count++;
+		pr_debug("Failed to get attributes: %s (%d)\n", pkg_path, err);
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
+	// Extract UID and validate
 	uid_t uid = from_kuid(&init_user_ns, stat.uid);
 	if (uid == (uid_t)-1) {
-		pr_warn("Invalid UID for package: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
-		scan_ctx->errors_count++;
+		pr_warn("Invalid UID for: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
-	struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_KERNEL);
-	if (!data) {
-		pr_err("Failed to allocate memory for package: %.*s (user %u)\n", namelen, name, scan_ctx->user_id);
-		scan_ctx->errors_count++;
+	// Allocate and populate UID data entry
+	struct uid_data *uid_entry = kzalloc(sizeof(struct uid_data), GFP_KERNEL);
+	if (!uid_entry) {
+		pr_err("Memory allocation failed for: %.*s\n", namelen, name);
+		scan_ctx->error_count++;
 		return FILLDIR_ACTOR_CONTINUE;
 	}
 
-	data->uid = uid;
+	uid_entry->uid = uid;
 	size_t copy_len = min_t(size_t, namelen, KSU_MAX_PACKAGE_NAME - 1);
-	strncpy(data->package, name, copy_len);
-	data->package[copy_len] = '\0';
-	
-	list_add_tail(&data->list, scan_ctx->uid_list);
-	scan_ctx->packages_found++;
-	
-	pr_info("UserDE UID: Found package: %s, uid: %u (user %u)\n", 
-		 data->package, data->uid, scan_ctx->user_id);
-	
+	strncpy(uid_entry->package, name, copy_len);
+	uid_entry->package[copy_len] = '\0';
+
+	list_add_tail(&uid_entry->list, scan_ctx->uid_list);
+	scan_ctx->pkg_count++;
+
+	pr_info("User Package: %s, UID: %u (user %u)\n", uid_entry->package, uid, scan_ctx->user_id);
 	return FILLDIR_ACTOR_CONTINUE;
 }
 
-static int scan_user_data_for_user(uid_t user_id, struct list_head *uid_list, 
-					   size_t *packages_found, size_t *errors_count)
+static int scan_user_directory(uid_t user_id, struct list_head *uid_list,
+			      size_t *pkg_count, size_t *error_count)
 {
+	char user_path[DATA_PATH_LEN];
 	struct file *dir_file;
-	char user_path[USER_DATA_PATH_LEN];
-	int ret = 0;
-	
-	*packages_found = 0;
-	*errors_count = 0;
-	
+	int ret;
+
+	*pkg_count = *error_count = 0;
+
 	snprintf(user_path, sizeof(user_path), "%s/%u", USER_DATA_BASE_PATH, user_id);
-	
+
 	dir_file = ksu_filp_open_compat(user_path, O_RDONLY, 0);
 	if (IS_ERR(dir_file)) {
-		pr_debug("Failed to open user data path: %s (%ld)\n", user_path, PTR_ERR(dir_file));
+		pr_debug("Cannot open user path: %s (%ld)\n", user_path, PTR_ERR(dir_file));
 		return PTR_ERR(dir_file);
 	}
 
-	struct user_scan_context scan_ctx = {
+	struct user_scan_ctx scan_ctx = {
 		.uid_list = uid_list,
 		.user_id = user_id,
-		.packages_found = 0,
-		.errors_count = 0
+		.pkg_count = 0,
+		.error_count = 0
 	};
-	
-	struct user_data_context ctx = {
-		.ctx.actor = user_data_actor,
+
+	struct user_dir_ctx uctx = {
+		.ctx.actor = scan_user_packages,
 		.scan_ctx = &scan_ctx
 	};
 
-	ret = iterate_dir(dir_file, &ctx.ctx);
+	ret = iterate_dir(dir_file, &uctx.ctx);
 	filp_close(dir_file, NULL);
 
-	*packages_found = scan_ctx.packages_found;
-	*errors_count = scan_ctx.errors_count;
-	
-	if (scan_ctx.packages_found > 0 && scan_ctx.errors_count > 0) {
-		pr_info("UserDE UID: Scanned user %u, found %zu packages with %zu errors\n", 
-			user_id, scan_ctx.packages_found, scan_ctx.errors_count);
-	}
+	*pkg_count = scan_ctx.pkg_count;
+	*error_count = scan_ctx.error_count;
+
+	if (scan_ctx.pkg_count > 0 || scan_ctx.error_count > 0)
+		pr_info("User %u: %zu packages, %zu errors\n",
+			user_id, scan_ctx.pkg_count, scan_ctx.error_count);
 
 	return ret;
 }
@@ -347,48 +330,38 @@ static int scan_user_data_for_user(uid_t user_id, struct list_head *uid_list,
 int scan_user_data_for_uids(struct list_head *uid_list)
 {
 	uid_t user_ids[MAX_SUPPORTED_USERS];
-	size_t active_users = 0;
-	size_t total_packages = 0;
-	size_t total_errors = 0;
-	int ret = 0;
-	
-	if (!uid_list) {
-		return -EINVAL;
-	}
+	size_t active_users, total_packages = 0, total_errors = 0;
+	int ret;
 
-	// Retrieve all active user IDs
+	if (!uid_list)
+		return -EINVAL;
+
+	// Get all active user IDs
 	ret = get_active_user_ids(user_ids, ARRAY_SIZE(user_ids), &active_users);
 	if (ret < 0 || active_users == 0) {
-		pr_err("Failed to get active user IDs or no users found: %d\n", ret);
-		return -ENOENT;
+		pr_err("No active users found: %d\n", ret);
+		return ret < 0 ? ret : -ENOENT;
 	}
 
-	// Scan each user's data directory
+	// Scan each user's directory
 	for (size_t i = 0; i < active_users; i++) {
-		uid_t user_id = user_ids[i];
-		size_t packages_found = 0;
-		size_t errors_count = 0;
-		
-		ret = scan_user_data_for_user(user_id, uid_list, &packages_found, &errors_count);
-		
+		size_t pkg_count, error_count;
+
+		ret = scan_user_directory(user_ids[i], uid_list, &pkg_count, &error_count);
 		if (ret < 0) {
-			pr_warn("Failed to scan user %u data directory: %d\n", user_id, ret);
+			pr_warn("Scan failed for user %u: %d\n", user_ids[i], ret);
 			total_errors++;
 			continue;
 		}
-		
-		total_packages += packages_found;
-		total_errors += errors_count;
+
+		total_packages += pkg_count;
+		total_errors += error_count;
 	}
 
-	if (total_errors > 0) {
-		pr_warn("UserDE UID: Encountered %zu errors while scanning user data directories\n", 
-			total_errors);
-	}
+	if (total_errors > 0)
+		pr_warn("Scan completed with %zu errors\n", total_errors);
 
-	pr_info("UserDE UID: Scan completed - %zu users, %zu packages found\n", 
-		active_users, total_packages);
-
+	pr_info("Scanned %zu users, found %zu packages\n", active_users, total_packages);
 	return total_packages > 0 ? 0 : -ENOENT;
 }
 
@@ -413,11 +386,11 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 		return FILLDIR_ACTOR_CONTINUE; // Skip "." and ".."
 
 	if (d_type == DT_DIR && namelen >= 8 && !strncmp(name, "vmdl", 4) &&
- 	    !strncmp(name + namelen - 4, ".tmp", 4)) {
- 		pr_info("Skipping directory: %.*s\n", namelen, name);
- 		return FILLDIR_ACTOR_CONTINUE; // Skip staging package
- 	}
-	
+	    !strncmp(name + namelen - 4, ".tmp", 4)) {
+		pr_info("Skipping directory: %.*s\n", namelen, name);
+		return FILLDIR_ACTOR_CONTINUE; // Skip staging package
+	}
+
 	if (snprintf(dirpath, DATA_PATH_LEN, "%s/%.*s", my_ctx->parent_dir,
 		     namelen, name) >= DATA_PATH_LEN) {
 		pr_err("Path too long: %s/%.*s\n", my_ctx->parent_dir, namelen,
@@ -462,9 +435,9 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 				}
 			} else {
 				struct apk_path_hash *apk_data = kmalloc(sizeof(struct apk_path_hash), GFP_ATOMIC);
-					apk_data->hash = hash;
-					apk_data->exists = true;
-					list_add_tail(&apk_data->list, &apk_path_hash_list);
+				apk_data->hash = hash;
+				apk_data->exists = true;
+				list_add_tail(&apk_data->list, &apk_path_hash_list);
 			}
 		}
 	}
@@ -478,7 +451,7 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
 	struct list_head data_path_list;
 	INIT_LIST_HEAD(&data_path_list);
 	unsigned long data_app_magic = 0;
-	
+
 	// Initialize APK cache list
 	struct apk_path_hash *pos, *n;
 	list_for_each_entry(pos, &apk_path_hash_list, list) {
@@ -527,7 +500,7 @@ void search_manager(const char *path, int depth, struct list_head *uid_data)
 					filp_close(file, NULL);
 					goto skip_iterate;
 				}
-
+				
 				iterate_dir(file, &ctx.ctx);
 				filp_close(file, NULL);
 			}
@@ -601,7 +574,7 @@ void track_throne()
 		search_manager("/data/app", 2, &uid_list);
 		pr_info("Search manager finished\n");
 	}
-	
+
 prune:
 	// then prune the allowlist
 	ksu_prune_allowlist(is_uid_exist, &uid_list);


### PR DESCRIPTION
- 获取活跃用户UserID列表
- 通过 "/data/user_de/{userid}/<package>解析对应用户应用的UID
- 弃用通过不稳定的 packages.list 获取