### PR TITLE
Update core_hook.c

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -69,7 +69,7 @@ static inline bool is_unsupported_uid(uid_t uid)
 	return appid > LAST_APPLICATION_UID;
 }
 
-static struct group_info root_groups = { .usage = ATOMIC_INIT(2) };
+static struct group_info root_groups = { .usage = { ATOMIC_INIT(2) } };
 
 static void setup_groups(struct root_profile *profile, struct cred *cred)
 {
@@ -721,8 +721,8 @@ static struct security_hook_list ksu_hooks[] = {
 
 void __init ksu_lsm_hook_init(void)
 {
-	security_add_hooks(ksu_hooks, ARRAY_SIZE(ksu_hooks), "ksu");
-}
+	security_add_hooks(ksu_hooks, ARRAY_SIZE(ksu_hooks), lsm_id ksu);
+
 
 #else
 static int override_security_head(void *head, const void *new_head, size_t len)


### PR DESCRIPTION
drivers/kernelsu/core_hook.c:72:40: error: missing braces around initializer [-Werror=missing-braces]
   72 | static struct group_info root_groups = { .usage = ATOMIC_INIT(2) };
      |                                        ^
drivers/kernelsu/core_hook.c:72:40: error: missing braces around initializer [-Werror=missing-braces]
drivers/kernelsu/core_hook.c: In function ‘ksu_lsm_hook_init’:
drivers/kernelsu/core_hook.c:711:62: error: passing argument 3 of ‘security_add_hooks’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  711 |         security_add_hooks(ksu_hooks, ARRAY_SIZE(ksu_hooks), "ksu");
      |                                                              ^~~~~
      |                                                              |
      |                                                              char *
In file included from drivers/kernelsu/core_hook.c:10:
./include/linux/lsm_hooks.h:140:53: note: expected ‘const struct lsm_id *’ but argument is of type ‘char *’
  140 |                                const struct lsm_id *lsmid);
      |                                ~~~~~~~~~~~~~~~~~~~~~^~~~~