### PR TITLE
ci: Fix LKM version number anomaly and Git ownership issues

### DIFF
--- a/.github/workflows/ddk-lkm.yml
+++ b/.github/workflows/ddk-lkm.yml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Build kernelsu.ko
       run: |
+        git config --global --add safe.directory /__w/KernelSU/KernelSU
+
         cd kernel
 
         echo "=== Building kernelsu.ko for KMI: ${{ inputs.kmi }} ==="


### PR DESCRIPTION
**Fix LKM version number anomaly and Git ownership issues**

The issue, introduced in commit cf361a7, was caused by a user permission mismatch between the Docker container and the host, which made Git detect "suspicious ownership" and blocked proper version retrieval during the build.

Added `git config --global --add safe.directory` to bypass Git's ownership check, allowing the KernelSU module to build correctly in CI pipelines and retrieve the correct version number.