### PR TITLE
Implement workqueue for unmounting

### DIFF
--- a/kernel/core_hook.c
+++ b/kernel/core_hook.c
@@ -22,6 +22,7 @@
 #include <linux/uaccess.h>
 #include <linux/uidgid.h>
 #include <linux/version.h>
+#include <linux/workqueue.h>
 
 #include "allowlist.h"
 #include "arch.h"
@@ -36,6 +37,8 @@
 #include "supercalls.h"
 
 bool ksu_module_mounted = false;
+
+static struct workqueue_struct *ksu_workqueue;
 
 extern int handle_sepolicy(unsigned long arg3, void __user *arg4);
 
@@ -259,6 +262,17 @@ static void try_umount(const char *mnt, bool check_mnt, int flags)
     ksu_umount_mnt(&path, flags);
 }
 
+static void do_umount_work(struct work_struct *work)
+{
+    try_umount("/odm", true, 0);
+    try_umount("/system", true, 0);
+    try_umount("/vendor", true, 0);
+    try_umount("/product", true, 0);
+    try_umount("/system_ext", true, 0);
+    try_umount("/data/adb/modules", false, MNT_DETACH);
+    kfree(work);
+}
+
 int ksu_handle_setuid(struct cred *new, const struct cred *old)
 {
     if (!new || !old) {
@@ -317,12 +331,14 @@ int ksu_handle_setuid(struct cred *new, const struct cred *old)
 
     // fixme: use `collect_mounts` and `iterate_mount` to iterate all mountpoint and
     // filter the mountpoint whose target is `/data/adb`
-    try_umount("/odm", true, 0);
-    try_umount("/system", true, 0);
-    try_umount("/vendor", true, 0);
-    try_umount("/product", true, 0);
-    try_umount("/system_ext", true, 0);
-    try_umount("/data/adb/modules", false, MNT_DETACH);
+    struct work_struct *work = kmalloc(sizeof(struct work_struct), GFP_ATOMIC);
+    if (!work) {
+        pr_err("Failed to allocate work\n");
+        return 0;
+    }
+
+    INIT_WORK(work, do_umount_work);
+    queue_work(ksu_workqueue, work);
 
     return 0;
 }
@@ -407,6 +423,10 @@ __maybe_unused int ksu_kprobe_exit(void)
 
 void __init ksu_core_init(void)
 {
+    ksu_workqueue = alloc_workqueue("ksu_umount", WQ_UNBOUND, 0);
+    if (!ksu_workqueue) {
+        pr_err("Failed to create ksu workqueue\n");
+    }
 #ifdef CONFIG_KPROBES
     int rc = ksu_kprobe_init();
     if (rc) {
@@ -421,4 +441,8 @@ void ksu_core_exit(void)
     pr_info("ksu_core_exit\n");
     ksu_kprobe_exit();
 #endif
+    if (ksu_workqueue) {
+        flush_workqueue(ksu_workqueue);
+        destroy_workqueue(ksu_workqueue);
+    }
 }


### PR DESCRIPTION
umount schedules, so it cannot be used in kprobe context.