### PR TITLE
manager: 修复模板状态显示问题

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/AppProfile.kt
@@ -318,7 +318,12 @@ private fun AppProfileInner(
                     ProfileBox(mode, true) {
                         // template mode shouldn't change profile here!
                         if (it == Mode.Default || it == Mode.Custom) {
-                            onProfileChange(profile.copy(rootUseDefault = it == Mode.Default))
+                            onProfileChange(
+                                profile.copy(
+                                    rootUseDefault = it == Mode.Default,
+                                    rootTemplate = null
+                                )
+                            )
                         }
                         mode = it
                     }


### PR DESCRIPTION
修复当app设置过模板后再使用自定义配置，离开页面后再次打开，管理器显示应用使用的是模板而不是自定义配置的问题