### PR TITLE
Improve compatibility with Samsung 6.6 GKI 2.0 devices

### DIFF
--- a/.github/patches/6.6/add-min_kdp-symbols-2024-09.patch
+++ b/.github/patches/6.6/add-min_kdp-symbols-2024-09.patch
@@ -1,0 +1,86 @@
+From acb31159fa5b4a4eb9197624e15fbf6e51802b8c Mon Sep 17 00:00:00 2001
+From: Fede2782 <78815152+Fede2782@users.noreply.github.com>
+Date: Wed, 23 Jul 2025 18:35:13 +0200
+Subject: [PATCH] add min_kdp symbols
+
+This adds symbols provided by min_kdp which are required for bluetooth driver
+---
+ android/abi_gki_aarch64.stg | 41 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 41 insertions(+)
+
+diff --git a/android/abi_gki_aarch64.stg b/android/abi_gki_aarch64.stg
+index 78f10f7d9bec..445947cb14b9 100644
+--- a/android/abi_gki_aarch64.stg
++++ b/android/abi_gki_aarch64.stg
+@@ -316418,6 +316418,12 @@ function {
+   parameter_id: 0x3c0604da
+   parameter_id: 0x7584e7da
+ }
++function {
++  id: 0x1e5195df
++  return_type_id: 0x48b5725f
++  parameter_id: 0x3d551c03
++  parameter_id: 0x6720d32f
++}
+ function {
+   id: 0x1e571002
+   return_type_id: 0x48b5725f
+@@ -352019,6 +352025,11 @@ function {
+   return_type_id: 0x4585663f
+   parameter_id: 0x3e6396e0
+ }
++function {
++  id: 0xc18e39fb
++  return_type_id: 0x4585663f
++  parameter_id: 0x3d551c03
++}
+ function {
+   id: 0xc18f1240
+   return_type_id: 0x4585663f
+@@ -403638,6 +403649,33 @@ elf_symbol {
+   type_id: 0xc59b3a62
+   full_name: "lookup_user_key"
+ }
++elf_symbol {
++  id: 0xb0801f6e
++  name: "kdp_set_cred_non_rcu"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0x738bae5e
++  type_id: 0x1e5195df
++  full_name: "kdp_set_cred_non_rcu"
++}
++elf_symbol {
++  id: 0x3037c5bc
++  name: "kdp_usecount_dec_and_test"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xda582aa5
++  type_id: 0xc18e39fb
++  full_name: "kdp_usecount_dec_and_test"
++}
++elf_symbol {
++  id: 0x8334a496
++  name: "kdp_usecount_inc"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xfb342499
++  type_id: 0x1fcd1693
++  full_name: "kdp_usecount_inc"
++}
+ elf_symbol {
+   id: 0x493ce9fc
+   name: "loops_per_jiffy"
+@@ -441632,6 +441670,9 @@ interface {
+   symbol_id: 0x81dadb36
+   symbol_id: 0x9bfc3a5e
+   symbol_id: 0xc750a072
++  symbol_id: 0xb0801f6e
++  symbol_id: 0x3037c5bc
++  symbol_id: 0x8334a496
+   symbol_id: 0xbccf7511
+   symbol_id: 0xc29558ef
+   symbol_id: 0x3b31be3d
+-- 
+2.48.1
+

--- a/.github/patches/6.6/add-min_kdp-symbols.patch
+++ b/.github/patches/6.6/add-min_kdp-symbols.patch
@@ -1,0 +1,86 @@
+From acb31159fa5b4a4eb9197624e15fbf6e51802b8c Mon Sep 17 00:00:00 2001
+From: Fede2782 <78815152+Fede2782@users.noreply.github.com>
+Date: Wed, 23 Jul 2025 18:35:13 +0200
+Subject: [PATCH] add min_kdp symbols
+
+This adds symbols provided by min_kdp which are required for bluetooth driver
+---
+ android/abi_gki_aarch64.stg | 41 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 41 insertions(+)
+
+diff --git a/android/abi_gki_aarch64.stg b/android/abi_gki_aarch64.stg
+index 78f10f7d9bec..445947cb14b9 100644
+--- a/android/abi_gki_aarch64.stg
++++ b/android/abi_gki_aarch64.stg
+@@ -316418,6 +316418,12 @@ function {
+   parameter_id: 0x3c0604da
+   parameter_id: 0x7584e7da
+ }
++function {
++  id: 0x1e5195df
++  return_type_id: 0x48b5725f
++  parameter_id: 0x3d551c03
++  parameter_id: 0x6720d32f
++}
+ function {
+   id: 0x1e571002
+   return_type_id: 0x48b5725f
+@@ -352019,6 +352025,11 @@ function {
+   return_type_id: 0x4585663f
+   parameter_id: 0x3e6396e0
+ }
++function {
++  id: 0xc18e39fb
++  return_type_id: 0x4585663f
++  parameter_id: 0x3d551c03
++}
+ function {
+   id: 0xc18f1240
+   return_type_id: 0x4585663f
+@@ -403638,6 +403649,33 @@ elf_symbol {
+   type_id: 0xc59b3a62
+   full_name: "lookup_user_key"
+ }
++elf_symbol {
++  id: 0xb0801f6e
++  name: "kdp_set_cred_non_rcu"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0x738bae5e
++  type_id: 0x1e5195df
++  full_name: "kdp_set_cred_non_rcu"
++}
++elf_symbol {
++  id: 0x3037c5bc
++  name: "kdp_usecount_dec_and_test"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xda582aa5
++  type_id: 0xc18e39fb
++  full_name: "kdp_usecount_dec_and_test"
++}
++elf_symbol {
++  id: 0x8334a496
++  name: "kdp_usecount_inc"
++  is_defined: true
++  symbol_type: FUNCTION
++  crc: 0xfb342499
++  type_id: 0x1fcd1693
++  full_name: "kdp_usecount_inc"
++}
+ elf_symbol {
+   id: 0x493ce9fc
+   name: "loops_per_jiffy"
+@@ -441632,6 +441670,9 @@ interface {
+   symbol_id: 0x81dadb36
+   symbol_id: 0x9bfc3a5e
+   symbol_id: 0xc750a072
++  symbol_id: 0xb0801f6e
++  symbol_id: 0x3037c5bc
++  symbol_id: 0x8334a496
+   symbol_id: 0x132eb5f1
+   symbol_id: 0xbccf7511
+   symbol_id: 0xc29558ef
+-- 
+2.48.1
+

--- a/.github/patches/6.6/min_kdp.c
+++ b/.github/patches/6.6/min_kdp.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <asm-generic/sections.h>
+#include <linux/mm.h>
+#include "../mm/slab.h"
+#include <linux/slub_def.h>
+#include <linux/binfmts.h>
+
+#include <linux/mount.h>
+#include <linux/cred.h>
+#include <linux/security.h>
+#include <linux/init_task.h>
+#include "../fs/mount.h"
+
+void kdp_usecount_inc(struct cred *cred)
+{
+	atomic_long_inc(&cred->usage);
+}
+EXPORT_SYMBOL(kdp_usecount_inc);
+
+unsigned int kdp_usecount_dec_and_test(struct cred *cred)
+{
+	return atomic_long_dec_and_test(&cred->usage);
+}
+EXPORT_SYMBOL(kdp_usecount_dec_and_test);
+
+void kdp_set_cred_non_rcu(struct cred *cred, int val)
+{
+	cred->non_rcu = val;
+}
+EXPORT_SYMBOL(kdp_set_cred_non_rcu);

--- a/.github/workflows/gki-kernel.yml
+++ b/.github/workflows/gki-kernel.yml
@@ -148,6 +148,33 @@ jobs:
           repo status
           echo "[+] KernelSU setup done."
 
+      - name: Fix WiFi and Bluetooth on Samsung 6.6 GKI devices
+        if: ${{ ( inputs.version == 'android15-6.6' && inputs.build_lkm == false ) }}
+        run: |
+          COMMON_ROOT=$GITHUB_WORKSPACE/android-kernel/common
+          KSU_ROOT=$GITHUB_WORKSPACE/KernelSU
+          echo "[+] Adding Samsung KDP exported symbols to abi_gki_aarch64_galaxy"
+          SYMBOL_LIST=$COMMON_ROOT/android/abi_gki_aarch64_galaxy
+          echo "kdp_set_cred_non_rcu" >> $SYMBOL_LIST
+          echo "kdp_usecount_dec_and_test" >> $SYMBOL_LIST
+          echo "kdp_usecount_inc" >> $SYMBOL_LIST
+          echo "[+] Adding Samsung KDP exported symbols definition to abi_gki_aarch64.stg"
+          cd $COMMON_ROOT
+          if [[ -f "$KSU_ROOT/.github/patches/${{ inputs.patch_path }}/add-min_kdp-symbols-${{ inputs.os_patch_level }}.patch" ]]; then
+            PATCH="$KSU_ROOT/.github/patches/${{ inputs.patch_path }}/add-min_kdp-symbols-${{ inputs.os_patch_level }}.patch"
+          else
+            PATCH="$KSU_ROOT/.github/patches/${{ inputs.patch_path }}/add-min_kdp-symbols.patch"
+          fi
+          echo "[+] Samsung KDP exported symbols patch is $PATCH"
+          if patch -p1 --dry-run < $PATCH; then
+            echo "[+] Successfully added Samsung KDP exported symbols definition to abi_gki_aarch64.stg"
+            patch -p1 --no-backup-if-mismatch < $PATCH
+          fi
+          echo "[+] Adding Samsung minimal KDP driver"
+          cd $COMMON_ROOT/drivers
+          cp "$KSU_ROOT/.github/patches/${{ inputs.patch_path }}/min_kdp.c" min_kdp.c
+          echo "obj-y += min_kdp.o" >> $COMMON_ROOT/drivers/Makefile
+
       - name: Symbol magic
         run: |
           echo "[+] Export all symbol from abi_gki_aarch64.xml"


### PR DESCRIPTION
This PR aims to fix the two main issues Samsung GKI devices encounter when using GKI 2.0 images. This is for Samsung devices which really support GKI images as some devices, despite being on 5.10+, don't support GKI images as the OEM and the SoC Manufacturer include essential drivers in the kernel image instead of shipping them as modules.

One patch is included.

1) min_KDP support: Samsung devices with 6.6 kernel ship a Bluetooth driver (bluetooth.ko) which depends on these three KDP functions. Import a minimal KDP driver which behaves like the normal KDP driver when KDP is disabled by calling the required kernel functions.

Despite Samsung always adding a lot of obstacles this might really improve the situation as building kernels from Samsung sources usually takes time due to Samsung OSRC taking a lot of time to release them publicly.

Alternatively to this, a GKI variant specifically for Samsung KMIs (android12-5.10, android13-5.15, android14-6.1 and android15-6.6) can be made like is being done with ARCVM/WSA.