### PR TITLE
kernel: Prune allowlist only after boot completed

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -13,6 +13,7 @@
 #include <linux/compiler_types.h>
 
 #include "klog.h" // IWYU pragma: keep
+#include "ksud.h"
 #include "selinux/selinux.h"
 #include "allowlist.h"
 #include "manager.h"
@@ -486,6 +487,11 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *),
 {
     struct perm_data *np = NULL;
     struct perm_data *n = NULL;
+
+    if (!ksu_boot_completed) {
+        pr_info("boot not completed, skip prune\n");
+        return;
+    }
 
     bool modified = false;
     // TODO: use RCU!

--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -24,6 +24,7 @@
 #include "ksud.h"
 #include "selinux/selinux.h"
 #include "syscall_hook_manager.h"
+#include "throne_tracker.h"
 
 bool ksu_module_mounted __read_mostly = false;
 bool ksu_boot_completed __read_mostly = false;
@@ -117,6 +118,7 @@ void on_module_mounted(void){
 void on_boot_completed(void){
     ksu_boot_completed = true;
     pr_info("on_boot_completed!\n");
+    track_throne(true);
     // remark process, we don't want to mark other init
     // forked process excepte zygote and adbd
     ksu_mark_running_process();

--- a/kernel/pkg_observer.c
+++ b/kernel/pkg_observer.c
@@ -32,7 +32,7 @@ static int ksu_handle_inode_event(struct fsnotify_mark *mark, u32 mask,
     if (file_name->len == 13 &&
         !memcmp(file_name->name, "packages.list", 13)) {
         pr_info("packages.list detected: %d\n", mask);
-        track_throne();
+        track_throne(false);
     }
     return 0;
 }

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -300,7 +300,7 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
     return exist;
 }
 
-void track_throne()
+void track_throne(bool prune_only)
 {
     struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
     if (IS_ERR(fp)) {
@@ -356,6 +356,9 @@ void track_throne()
     // now update uid list
     struct uid_data *np;
     struct uid_data *n;
+
+    if (prune_only)
+        goto prune;
 
     // first, check if manager_uid exist!
     bool manager_exist = false;

--- a/kernel/throne_tracker.h
+++ b/kernel/throne_tracker.h
@@ -5,6 +5,6 @@ void ksu_throne_tracker_init();
 
 void ksu_throne_tracker_exit();
 
-void track_throne();
+void track_throne(bool prune_only);
 
 #endif


### PR DESCRIPTION
For unknown reason, packages.list is not reliable during boot for oplus devices, so we have to disable pruning and re-run pruning after boot.