### PR TITLE
kernel: file_wrapper: copy mode of original inode

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -366,6 +366,8 @@ static int do_get_wrapper_fd(void __user *arg) {
     struct file* pf = fget(ret);
 
     struct inode* wrapper_inode = file_inode(pf);
+    // copy original inode mode
+    wrapper_inode->i_mode = file_inode(f)->i_mode;
     struct inode_security_struct *sec = selinux_inode(wrapper_inode);
     if (sec) {
         sec->sid = ksu_file_sid;


### PR DESCRIPTION
Bionic uses fstat to determine whether an fd is a tty and set proper buffering flags, so we also need to set the wrapper file's inode mode to the original inode mode.

see: https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/upstream-openbsd/lib/libc/stdio/makebuf.c;l=61-95;drc=9a4b68e20d617b2cb3355071521f16e8c3d538df