### PR TITLE
kernel: Replace kmalloc() usages with kzalloc()

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -43,7 +43,7 @@ static void remove_uid_from_arr(uid_t uid)
     if (allow_list_pointer == 0)
         return;
 
-    temp_arr = kmalloc(sizeof(allow_list_arr), GFP_KERNEL);
+    temp_arr = kzalloc(sizeof(allow_list_arr), GFP_KERNEL);
     if (temp_arr == NULL) {
         pr_err("%s: unable to allocate memory\n", __func__);
         return;
@@ -198,7 +198,7 @@ bool ksu_set_app_profile(struct app_profile *profile, bool persist)
     }
 
     // not found, alloc a new node!
-    p = (struct perm_data *)kmalloc(sizeof(struct perm_data), GFP_KERNEL);
+    p = (struct perm_data *)kzalloc(sizeof(struct perm_data), GFP_KERNEL);
     if (!p) {
         pr_err("ksu_set_app_profile alloc failed\n");
         return false;

--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -28,7 +28,7 @@ static struct sdesc *init_sdesc(struct crypto_shash *alg)
     int size;
 
     size = sizeof(struct shash_desc) + crypto_shash_descsize(alg);
-    sdesc = kmalloc(size, GFP_KERNEL);
+    sdesc = kzalloc(size, GFP_KERNEL);
     if (!sdesc)
         return ERR_PTR(-ENOMEM);
     sdesc->shash.tfm = alg;

--- a/kernel/kernel_umount.c
+++ b/kernel/kernel_umount.c
@@ -155,7 +155,7 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
     // umount the target mnt
     pr_info("handle umount for uid: %d, pid: %d\n", new_uid, current->pid);
 
-    tw = kmalloc(sizeof(*tw), GFP_ATOMIC);
+    tw = kzalloc(sizeof(*tw), GFP_ATOMIC);
     if (!tw)
         return 0;
 

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -354,7 +354,7 @@ static void add_xperm_rule_raw(struct policydb *db, struct type_datum *src,
 
         if (datum->u.xperms == NULL) {
             datum->u.xperms =
-                (struct avtab_extended_perms *)(kmalloc(
+                (struct avtab_extended_perms *)(kzalloc(
                     sizeof(xperms), GFP_KERNEL));
             if (!datum->u.xperms) {
                 pr_err("alloc xperms failed\n");
@@ -548,7 +548,7 @@ static bool add_filename_trans(struct policydb *db, const char *s,
         trans = (struct filename_trans_datum *)kcalloc(sizeof(*trans),
                                    1, GFP_ATOMIC);
         struct filename_trans_key *new_key =
-            (struct filename_trans_key *)kmalloc(sizeof(*new_key),
+            (struct filename_trans_key *)kzalloc(sizeof(*new_key),
                                  GFP_ATOMIC);
         *new_key = key;
         new_key->name = kstrdup(key.name, GFP_ATOMIC);

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -160,7 +160,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
 
     if (d_type == DT_DIR && my_ctx->depth > 0 &&
         (my_ctx->stop && !*my_ctx->stop)) {
-        struct data_path *data = kmalloc(sizeof(struct data_path), GFP_ATOMIC);
+        struct data_path *data = kzalloc(sizeof(struct data_path), GFP_ATOMIC);
 
         if (!data) {
             pr_err("Failed to allocate memory for %s\n", dirpath);
@@ -195,7 +195,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name,
                 }
             } else {
                 struct apk_path_hash *apk_data =
-                    kmalloc(sizeof(struct apk_path_hash), GFP_ATOMIC);
+                    kzalloc(sizeof(struct apk_path_hash), GFP_ATOMIC);
                 apk_data->hash = hash;
                 apk_data->exists = true;
                 list_add_tail(&apk_data->list, &apk_path_hash_list);


### PR DESCRIPTION
This ensures we won't use uninitialized pointers for task work.