### PR TITLE
display module details when installing via external shource 安装外部模块时显示模块详细信息

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ModuleParser.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ModuleParser.kt
@@ -1,0 +1,222 @@
+package me.weishu.kernelsu.ui.util
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.Uri
+import androidx.annotation.StringRes
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.viewmodel.ModuleViewModel
+import java.io.ByteArrayOutputStream
+import java.util.Properties
+import java.util.zip.ZipException
+import java.util.zip.ZipInputStream
+
+data class ParsedModuleInfo(
+    val id: String,
+    val name: String?,
+    val version: String?,
+    val versionCode: Int?,
+    val author: String?,
+    val description: String?
+)
+
+object ModuleParser {
+
+    class ModuleParseException(@StringRes val messageRes: Int, vararg val formatArgs: Any) :
+        Exception() {
+        fun getMessage(context: Context): String {
+            return context.getString(messageRes, *formatArgs)
+        }
+    }
+
+    private const val MAX_PROP_SIZE = 1 * 1024 * 1024 // 1 MiB
+
+    fun parse(context: Context, uri: Uri): Result<ParsedModuleInfo> {
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                val zipInputStream = ZipInputStream(inputStream)
+                val entry = zipInputStream.nextEntry ?: return@use Result.failure(
+                    ModuleParseException(R.string.module_error_invalid_zip)
+                )
+                val entriesSequence = sequence {
+                    yield(entry)
+                    yieldAll(generateSequence { zipInputStream.nextEntry })
+                }
+
+                val modulePropEntry = entriesSequence.firstOrNull { it.name == "module.prop" }
+
+                if (modulePropEntry != null) {
+                    val propertiesContentBytes = readEntry(zipInputStream)
+                    parseProperties(propertiesContentBytes)
+                } else {
+                    Result.failure(ModuleParseException(R.string.module_error_no_prop))
+                }
+            } ?: Result.failure(ModuleParseException(R.string.module_error_open_zip))
+        } catch (e: ZipException) {
+            Result.failure(ModuleParseException(R.string.module_error_invalid_zip))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun readEntry(zipInputStream: ZipInputStream): ByteArray {
+        val baos = ByteArrayOutputStream()
+        val buffer = ByteArray(1024)
+        var len: Int
+        var totalRead = 0L
+        while (zipInputStream.read(buffer).also { len = it } > -1) {
+            totalRead += len
+            if (totalRead > MAX_PROP_SIZE) {
+                throw ModuleParseException(R.string.module_error_prop_too_large)
+            }
+            baos.write(buffer, 0, len)
+        }
+        return baos.toByteArray()
+    }
+
+    private fun parseProperties(propBytes: ByteArray): Result<ParsedModuleInfo> {
+        val properties = Properties()
+        properties.load(propBytes.inputStream().reader(Charsets.UTF_8))
+
+        val id = properties.getProperty("id")?.trim()
+
+        if (id.isNullOrEmpty()) {
+            return Result.failure(ModuleParseException(R.string.module_error_missing_id))
+        }
+
+        if (!id.matches("^[a-zA-Z][a-zA-Z0-9._-]+$".toRegex())) {
+            return Result.failure(ModuleParseException(R.string.module_error_invalid_id, id))
+        }
+
+        val name = properties.getProperty("name")?.trim()
+        val version = properties.getProperty("version")?.trim()
+        val versionCodeStr = properties.getProperty("versionCode")?.trim()
+        val author = properties.getProperty("author")?.trim()
+        val description = properties.getProperty("description")?.trim()
+
+        val versionCode = versionCodeStr?.toIntOrNull()
+
+        return Result.success(
+            ParsedModuleInfo(
+                id = id,
+                name = name,
+                version = version,
+                versionCode = versionCode,
+                author = author,
+                description = description
+            )
+        )
+    }
+
+    @SuppressLint("StringFormatInvalid")
+    fun getModuleInstallDesc(
+        context: Context, uri: Uri, moduleList: List<ModuleViewModel.ModuleInfo>?
+    ): String {
+        val fileName = uri.getFileName(context) ?: uri.lastPathSegment ?: "Unknown"
+
+        return parse(context, uri).fold(
+            onSuccess = { newModuleInfo ->
+                val oldModuleInfo = moduleList?.find { it.id == newModuleInfo.id }
+                if (oldModuleInfo == null) {
+                    // fresh install
+                    buildString {
+                        appendLine(
+                            context.getString(
+                                R.string.module_install_prompt_with_name, fileName
+                            )
+                        )
+                        appendLine()
+                        val details = listOfNotNull(
+                            context.getString(R.string.module_info_id, newModuleInfo.id),
+                            newModuleInfo.name?.let {
+                                context.getString(
+                                    R.string.module_info_name, it
+                                )
+                            },
+                            newModuleInfo.version?.let {
+                                context.getString(
+                                    R.string.module_info_version, it
+                                )
+                            },
+                            newModuleInfo.versionCode?.let {
+                                context.getString(
+                                    R.string.module_info_version_code, it.toString()
+                                )
+                            },
+                            newModuleInfo.author?.let {
+                                context.getString(
+                                    R.string.module_info_author, it
+                                )
+                            },
+                            newModuleInfo.description?.let {
+                                context.getString(R.string.module_info_description, it)
+                            })
+                        append(details.joinToString("\n"))
+                    }
+                } else {
+                    buildString {
+                        appendLine(
+                            context.getString(
+                                R.string.module_update_prompt_with_name, fileName
+                            )
+                        )
+                        appendLine()
+
+                        fun compare(old: String, new: String?): String? {
+                            val newTrimmed = new?.trim()
+                            if ((newTrimmed.isNullOrEmpty() && old.isEmpty())) return null
+                            if (old == newTrimmed) return newTrimmed
+                            return when {
+                                old.isEmpty() -> "+++$newTrimmed"
+                                newTrimmed.isNullOrEmpty() -> "---$old"
+                                else -> "$old -> $newTrimmed"
+                            }
+                        }
+
+                        fun compareInt(old: Int, new: Int?): String? {
+                            if (new == null) return "---$old"
+                            if (old == new) return "$new"
+                            return "$old -> $new"
+                        }
+
+                        val changes = listOfNotNull(
+                            compare(oldModuleInfo.name, newModuleInfo.name)?.let {
+                                context.getString(R.string.module_info_name, it)
+                            },
+                            compare(oldModuleInfo.version, newModuleInfo.version)?.let {
+                                context.getString(R.string.module_info_version, it)
+                            },
+                            compareInt(oldModuleInfo.versionCode, newModuleInfo.versionCode)?.let {
+                                context.getString(R.string.module_info_version_code, it)
+                            },
+                            compare(oldModuleInfo.author, newModuleInfo.author)?.let {
+                                context.getString(R.string.module_info_author, it)
+                            })
+
+                        if (changes.isNotEmpty()) {
+                            appendLine(changes.joinToString("\n"))
+                        }
+
+                        newModuleInfo.description?.takeIf { it.isNotBlank() }?.let {
+                            appendLine(context.getString(R.string.module_info_description, it))
+                        }
+                    }
+                }
+            },
+            onFailure = { exception ->
+                val reason = if (exception is ModuleParseException) {
+                    exception.getMessage(context)
+                } else {
+                    exception.message ?: "unknown error"
+                }
+                buildString {
+                    appendLine(context.getString(R.string.module_parse_failed, fileName))
+                    appendLine()
+                    appendLine(context.getString(R.string.module_parse_reason, reason))
+                    appendLine()
+                    append(context.getString(R.string.module_install_confirm_extra))
+                }
+            },
+        )
+    }
+}

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -176,4 +176,20 @@
     <string name="color_teal">青色</string>
     <string name="color_pink">粉色</string>
     <string name="color_brown">棕色</string>
+    <string name="module_update_prompt_with_name">将会更新下面的模块: %1$s</string>
+    <string name="module_parse_failed">处理模块信息失败，模块可能损坏: %s</string>
+    <string name="module_parse_reason">原因: %s</string>
+    <string name="module_install_confirm_extra">你确定还要安装这个模块吗？</string>
+    <string name="module_info_id">模块ID: %s</string>
+    <string name="module_info_name">模块名称: %s</string>
+    <string name="module_info_version">版本: %s</string>
+    <string name="module_info_version_code">版本号: %s</string>
+    <string name="module_info_author">作者: %s</string>
+    <string name="module_info_description">模块描述: %s</string>
+    <string name="module_error_no_prop">没有在zip文件根目录中找到 module.prop 文件</string>
+    <string name="module_error_open_zip">从 URI 中打开 zip 文件失败</string>
+    <string name="module_error_invalid_zip">无效的 zip 文件</string>
+    <string name="module_error_prop_too_large">module.prop 文件过大 (&gt; 1MiB)</string>
+    <string name="module_error_missing_id">module.prop 缺少字段 \'id\'</string>
+    <string name="module_error_invalid_id">模块 ID \'%s\' 无效</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -180,4 +180,23 @@
     <string name="color_teal">Teal</string>
     <string name="color_pink">Pink</string>
     <string name="color_brown">Brown</string>
+
+    <string name="module_parse_failed">Failed to parse module information, module may be corrupted: %s</string>
+    <string name="module_parse_reason">Reason: %s</string>
+    <string name="module_install_confirm_extra">Do you still want to install this module?</string>
+    <string name="module_update_prompt_with_name">The following modules will be updated: %1$s</string>
+
+    <string name="module_info_id">ID: %s</string>
+    <string name="module_info_name">Name: %s</string>
+    <string name="module_info_version">Version: %s</string>
+    <string name="module_info_version_code">VersionCode: %s</string>
+    <string name="module_info_author">Author: %s</string>
+    <string name="module_info_description">Description: %s</string>
+
+    <string name="module_error_no_prop">module.prop not found in zip root</string>
+    <string name="module_error_open_zip">Failed to open zip file from URI</string>
+    <string name="module_error_invalid_zip">Invalid zip file format</string>
+    <string name="module_error_prop_too_large">module.prop is too large (&gt; 1MiB)</string>
+    <string name="module_error_missing_id">module.prop is missing required field \'id\'</string>
+    <string name="module_error_invalid_id">Module ID \'%s\' is invalid</string>
 </resources>


### PR DESCRIPTION
~~最近发现可以通过用管理器打开zip文件来安装模块了，所以就在模块安装前添加确认对话框，防止手滑误安装了不想安装的模块~~(#2989 已经实现)
写了一个模块信息收集，可以在外部模块安装前的确认对话框看到模块id版本号diff之类的

- 模块更新
![module-update](https://github.com/user-attachments/assets/1ef5e38b-ca85-453c-b12a-24a3d772609c)

- 模块安装
![module-fresh-install](https://github.com/user-attachments/assets/160cef3d-f87f-4643-95fb-c4e78fc78e24)

- 错误模块
![module-corrupt](https://github.com/user-attachments/assets/e414549d-8671-481e-9c87-750c44558b9e)

