### PR TITLE
kernel: apk_sign: Extract package names for debug logs

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -22,6 +22,45 @@ struct uid_data {
     char package[KSU_MAX_PACKAGE_NAME];
 };
 
+int get_pkg_from_apk_path(char *pkg, const char *path)
+{
+    int len = strlen(path);
+    if (len >= KSU_MAX_PACKAGE_NAME || len < 1)
+        return -1;
+
+    const char *last_slash = NULL;
+    const char *second_last_slash = NULL;
+
+    int i;
+    for (i = len - 1; i >= 0; i--) {
+        if (path[i] == '/') {
+            if (!last_slash) {
+                last_slash = &path[i];
+            } else {
+                second_last_slash = &path[i];
+                break;
+            }
+        }
+    }
+
+    if (!last_slash || !second_last_slash)
+        return -1;
+
+    const char *last_hyphen = strchr(second_last_slash, '-');
+    if (!last_hyphen || last_hyphen > last_slash)
+        return -1;
+
+    int pkg_len = last_hyphen - second_last_slash - 1;
+    if (pkg_len >= KSU_MAX_PACKAGE_NAME || pkg_len <= 0)
+        return -1;
+
+    // Copying the package name
+    strncpy(pkg, second_last_slash + 1, pkg_len);
+    pkg[pkg_len] = '\0';
+
+    return 0;
+}
+
 static void crown_manager(const char *apk, struct list_head *uid_data)
 {
     char pkg[KSU_MAX_PACKAGE_NAME];


### PR DESCRIPTION
Add extract_package_name() helper to show readable package names in signature check debug logs.
Only compiled  when CONFIG_KSU_DEBUG is enabled.

Signed-off-by: sakana164 <76257039+sakana164@users.noreply.github.com>