### PR TITLE
add hasFragileUserData to keep manager data when uninstall

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="false"
         android:fullBackupContent="@xml/backup_rules"
+        android:hasFragileUserData="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"


### PR DESCRIPTION
现在管理器有一些设置存在SharedPreferences中，例如
- 主题
- webview调试
- 超级用户是否显示系统应用
- 检查更新
...

不确定以后会不会多起来。添加hasFragileUserData方便选择卸载后保留管理器相关的数据

方便以下操作：

- 卸载管理器避免检测
- 保留数据从ci降级到稳定版(~尽管不推荐，但还是能做到~)
