### PR TITLE
kernel: Remove sepolicy of kernel domain

### DIFF
--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -59,27 +59,6 @@ void apply_kernelsu_rules()
         ksu_allowxperm(db, KERNEL_SU_DOMAIN, ALL, "file", ALL);
     }
 
-    // we need to save allowlist in /data/adb/ksu
-    ksu_allow(db, "kernel", "adb_data_file", "dir", ALL);
-    ksu_allow(db, "kernel", "adb_data_file", "file", ALL);
-    // we need to search /data/app
-    ksu_allow(db, "kernel", "apk_data_file", "file", "open");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "open");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "read");
-    ksu_allow(db, "kernel", "apk_data_file", "dir", "search");
-    // we may need to do mount on shell
-    ksu_allow(db, "kernel", "shell_data_file", "file", ALL);
-    // we need to read /data/system/packages.list
-    // ksu_allow(db, "kernel", "kernel", "capability", "dac_override");
-    // Android 10+:
-    // http://aospxref.com/android-12.0.0_r3/xref/system/sepolicy/private/file_contexts#512
-    ksu_allow(db, "kernel", "packages_list_file", "file", ALL);
-    // Kernel 4.4
-    ksu_allow(db, "kernel", "packages_list_file", "dir", ALL);
-    // Android 9-:
-    // http://aospxref.com/android-9.0.0_r61/xref/system/sepolicy/private/file_contexts#360
-    ksu_allow(db, "kernel", "system_data_file", "file", ALL);
-    ksu_allow(db, "kernel", "system_data_file", "dir", ALL);
     // our ksud triggered by init
     ksu_allow(db, "init", "adb_data_file", "file", ALL);
     ksu_allow(db, "init", "adb_data_file", "dir", ALL); // #1289
@@ -115,10 +94,6 @@ void apply_kernelsu_rules()
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "file", "open");
     ksu_allow(db, "hwservicemanager", KERNEL_SU_DOMAIN, "process",
           "getattr");
-
-    // For mounting loop devices, mirrors, tmpfs
-    //ksu_allow(db, "kernel", ALL, "file", "read");
-    //ksu_allow(db, "kernel", ALL, "file", "write");
 
     // Allow all binder transactions
     ksu_allow(db, ALL, KERNEL_SU_DOMAIN, "binder", ALL);


### PR DESCRIPTION
Now that we have switched most workqueues to task work, file operations are all under non kernel context, either init, system server or su.

Moreover, dac_override for kernel make kernel read file it doesn't have access to, and break oneplus ace 3v wifi because a wrong config path is chosen.

Fix it by cleaning up unnecessary policies. Note that loop mount related policies are removed too, so meta modules should deal with module image context itself by chconing image.