### PR TITLE
kernel: Identify manager without PER_USER_RANGE

### DIFF
--- a/kernel/allowlist.c
+++ b/kernel/allowlist.c
@@ -274,8 +274,8 @@ bool __ksu_is_allow_uid(uid_t uid)
         return false;
     }
 
-    if (likely(ksu_is_manager_uid_valid()) &&
-        unlikely(ksu_get_manager_uid() == uid)) {
+    if (likely(ksu_is_manager_appid_valid()) &&
+        unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
         // manager is always allowed!
         return true;
     }
@@ -305,8 +305,8 @@ bool __ksu_is_allow_uid_for_current(uid_t uid)
 bool ksu_uid_should_umount(uid_t uid)
 {
     struct app_profile profile = { .current_uid = uid };
-    if (likely(ksu_is_manager_uid_valid()) &&
-        unlikely(ksu_get_manager_uid() == uid)) {
+    if (likely(ksu_is_manager_appid_valid()) &&
+        unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
         // we should not umount on manager!
         return false;
     }

--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -290,15 +290,15 @@ clean:
 
 #ifdef CONFIG_KSU_DEBUG
 
-int ksu_debug_manager_uid = -1;
+int ksu_debug_manager_appid = -1;
 
 #include "manager.h"
 
 static int set_expected_size(const char *val, const struct kernel_param *kp)
 {
     int rv = param_set_uint(val, kp);
-    ksu_set_manager_uid(ksu_debug_manager_uid);
-    pr_info("ksu_manager_uid set to %d\n", ksu_debug_manager_uid);
+    ksu_set_manager_appid(ksu_debug_manager_appid);
+    pr_info("ksu_manager_appid set to %d\n", ksu_debug_manager_appid);
     return rv;
 }
 
@@ -307,8 +307,8 @@ static struct kernel_param_ops expected_size_ops = {
     .get = param_get_uint,
 };
 
-module_param_cb(ksu_debug_manager_uid, &expected_size_ops,
-        &ksu_debug_manager_uid, S_IRUSR | S_IWUSR);
+module_param_cb(ksu_debug_manager_appid, &expected_size_ops,
+        &ksu_debug_manager_appid, S_IRUSR | S_IWUSR);
 
 #endif
 

--- a/kernel/manager.h
+++ b/kernel/manager.h
@@ -3,34 +3,35 @@
 
 #include <linux/cred.h>
 #include <linux/types.h>
+#include "allowlist.h"
 
-#define KSU_INVALID_UID -1
+#define KSU_INVALID_APPID -1
 
-extern uid_t ksu_manager_uid; // DO NOT DIRECT USE
+extern uid_t ksu_manager_appid; // DO NOT DIRECT USE
 
-static inline bool ksu_is_manager_uid_valid()
+static inline bool ksu_is_manager_appid_valid()
 {
-    return ksu_manager_uid != KSU_INVALID_UID;
+    return ksu_manager_appid != KSU_INVALID_APPID;
 }
 
 static inline bool is_manager()
 {
-    return unlikely(ksu_manager_uid == current_uid().val);
+    return unlikely(ksu_manager_appid == current_uid().val % PER_USER_RANGE);
 }
 
-static inline uid_t ksu_get_manager_uid()
+static inline uid_t ksu_get_manager_appid()
 {
-    return ksu_manager_uid;
+    return ksu_manager_appid;
 }
 
-static inline void ksu_set_manager_uid(uid_t uid)
+static inline void ksu_set_manager_appid(uid_t appid)
 {
-    ksu_manager_uid = uid;
+    ksu_manager_appid = appid;
 }
 
 static inline void ksu_invalidate_manager_uid()
 {
-    ksu_manager_uid = KSU_INVALID_UID;
+    ksu_manager_appid = KSU_INVALID_APPID;
 }
 
 int ksu_observer_init(void);

--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -103,12 +103,7 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
         return 0;
     }
 
-    // if on private space, see if its possibly the manager
-    if (new_uid > PER_USER_RANGE && new_uid % PER_USER_RANGE == ksu_get_manager_uid()) {
-        ksu_set_manager_uid(new_uid);
-    }
-
-    if (ksu_get_manager_uid() == new_uid) {
+    if (ksu_get_manager_appid() == new_uid % PER_USER_RANGE) {
         pr_info("install fd for manager: %d\n", new_uid);
         ksu_install_fd();
         spin_lock_irq(&current->sighand->siglock);

--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -232,14 +232,14 @@ static int do_uid_should_umount(void __user *arg)
     return 0;
 }
 
-static int do_get_manager_uid(void __user *arg)
+static int do_get_manager_appid(void __user *arg)
 {
-    struct ksu_get_manager_uid_cmd cmd;
+    struct ksu_get_manager_appid_cmd cmd;
 
-    cmd.uid = ksu_get_manager_uid();
+    cmd.appid = ksu_get_manager_appid();
 
     if (copy_to_user(arg, &cmd, sizeof(cmd))) {
-        pr_err("get_manager_uid: copy_to_user failed\n");
+        pr_err("get_manager_appid: copy_to_user failed\n");
         return -EFAULT;
     }
 
@@ -594,7 +594,7 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
     { .cmd = KSU_IOCTL_GET_DENY_LIST, .name = "GET_DENY_LIST", .handler = do_get_deny_list, .perm_check = manager_or_root },
     { .cmd = KSU_IOCTL_UID_GRANTED_ROOT, .name = "UID_GRANTED_ROOT", .handler = do_uid_granted_root, .perm_check = manager_or_root },
     { .cmd = KSU_IOCTL_UID_SHOULD_UMOUNT, .name = "UID_SHOULD_UMOUNT", .handler = do_uid_should_umount, .perm_check = manager_or_root },
-    { .cmd = KSU_IOCTL_GET_MANAGER_UID, .name = "GET_MANAGER_UID", .handler = do_get_manager_uid, .perm_check = manager_or_root },
+    { .cmd = KSU_IOCTL_GET_MANAGER_APPID, .name = "GET_MANAGER_APPID", .handler = do_get_manager_appid, .perm_check = manager_or_root },
     { .cmd = KSU_IOCTL_GET_APP_PROFILE, .name = "GET_APP_PROFILE", .handler = do_get_app_profile, .perm_check = only_manager },
     { .cmd = KSU_IOCTL_SET_APP_PROFILE, .name = "SET_APP_PROFILE", .handler = do_set_app_profile, .perm_check = only_manager },
     { .cmd = KSU_IOCTL_GET_FEATURE, .name = "GET_FEATURE", .handler = do_get_feature, .perm_check = manager_or_root },

--- a/kernel/supercalls.h
+++ b/kernel/supercalls.h
@@ -50,8 +50,8 @@ struct ksu_uid_should_umount_cmd {
     __u8 should_umount; // Output: true if should umount, false otherwise
 };
 
-struct ksu_get_manager_uid_cmd {
-    __u32 uid; // Output: manager UID
+struct ksu_get_manager_appid_cmd {
+    __u32 appid; // Output: manager app id
 };
 
 struct ksu_get_app_profile_cmd {
@@ -114,7 +114,7 @@ struct ksu_add_try_umount_cmd {
 #define KSU_IOCTL_GET_DENY_LIST _IOC(_IOC_READ|_IOC_WRITE, 'K', 7, 0)
 #define KSU_IOCTL_UID_GRANTED_ROOT _IOC(_IOC_READ|_IOC_WRITE, 'K', 8, 0)
 #define KSU_IOCTL_UID_SHOULD_UMOUNT _IOC(_IOC_READ|_IOC_WRITE, 'K', 9, 0)
-#define KSU_IOCTL_GET_MANAGER_UID _IOC(_IOC_READ, 'K', 10, 0)
+#define KSU_IOCTL_GET_MANAGER_APPID _IOC(_IOC_READ, 'K', 10, 0)
 #define KSU_IOCTL_GET_APP_PROFILE _IOC(_IOC_READ|_IOC_WRITE, 'K', 11, 0)
 #define KSU_IOCTL_SET_APP_PROFILE _IOC(_IOC_WRITE, 'K', 12, 0)
 #define KSU_IOCTL_GET_FEATURE _IOC(_IOC_READ|_IOC_WRITE, 'K', 13, 0)

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -137,12 +137,8 @@ struct ksu_uid_should_umount_cmd {
     uint8_t should_umount; // Output: true if should umount, false otherwise
 };
 
-struct ksu_get_manager_uid_cmd {
-    uint32_t uid; // Output: manager UID
-};
-
-struct ksu_set_manager_uid_cmd {
-    uint32_t uid; // Input: new manager UID
+struct ksu_get_manager_appid_cmd {
+    uint32_t appid; // Output: manager app id
 };
 
 struct ksu_get_app_profile_cmd {
@@ -178,7 +174,7 @@ bool is_enhanced_security_enabled();
 #define KSU_IOCTL_GET_DENY_LIST _IOC(_IOC_READ|_IOC_WRITE, 'K', 7, 0)
 #define KSU_IOCTL_UID_GRANTED_ROOT _IOC(_IOC_READ|_IOC_WRITE, 'K', 8, 0)
 #define KSU_IOCTL_UID_SHOULD_UMOUNT _IOC(_IOC_READ|_IOC_WRITE, 'K', 9, 0)
-#define KSU_IOCTL_GET_MANAGER_UID _IOC(_IOC_READ, 'K', 10, 0)
+#define KSU_IOCTL_GET_MANAGER_APPID _IOC(_IOC_READ, 'K', 10, 0)
 #define KSU_IOCTL_GET_APP_PROFILE _IOC(_IOC_READ|_IOC_WRITE, 'K', 11, 0)
 #define KSU_IOCTL_SET_APP_PROFILE _IOC(_IOC_WRITE, 'K', 12, 0)
 #define KSU_IOCTL_GET_FEATURE _IOC(_IOC_READ|_IOC_WRITE, 'K', 13, 0)


### PR DESCRIPTION
appid is same for a single package across users, so we can identify manager without PER_USER_RANGE. Note, KSU_IOCTL_GET_MANAGER_UID will return real appid now.