### PR TITLE
kernel: Install manager fd in task work

### DIFF
--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -71,15 +71,10 @@ static inline bool is_allow_su()
     return ksu_is_allow_uid_for_current(current_uid().val);
 }
 
-struct ksu_install_manager_fd_tw {
-    struct callback_head cb;
-};
-
 static void ksu_install_manager_fd_tw_func(struct callback_head *cb)
 {
-    struct ksu_install_manager_fd_tw *tw = container_of(cb, struct ksu_install_manager_fd_tw, cb);
     ksu_install_fd();
-    kfree(tw);
+    kfree(cb);
 }
 
 int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
@@ -115,20 +110,18 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
     }
 
     if (ksu_get_manager_appid() == new_uid % PER_USER_RANGE) {
-        struct ksu_install_manager_fd_tw *tw;
-
         spin_lock_irq(&current->sighand->siglock);
         ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
         ksu_set_task_tracepoint_flag(current);
         spin_unlock_irq(&current->sighand->siglock);
 
         pr_info("install fd for manager: %d\n", new_uid);
-        tw = kzalloc(sizeof(*tw), GFP_ATOMIC);
-        if (!tw)
+        struct callback_head *cb = kzalloc(sizeof(*cb), GFP_ATOMIC);
+        if (!cb)
             return 0;
-        tw->cb.func = ksu_install_manager_fd_tw_func;
-        if (task_work_add(current, &tw->cb, TWA_RESUME)) {
-            kfree(tw);
+        cb->func = ksu_install_manager_fd_tw_func;
+        if (task_work_add(current, cb, TWA_RESUME)) {
+            kfree(cb);
             pr_warn("install manager fd add task_work failed\n");
         }
         return 0;


### PR DESCRIPTION
Tracepoint context disables preemption, so we cannot install fd which can sleep.