### PR TITLE
kernel: use kvrealloc

### DIFF
--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -550,21 +550,13 @@ static bool add_genfscon(struct policydb *db, const char *fs_name,
     return false;
 }
 
-static void *ksu_realloc(void *old, size_t new_size, size_t old_size)
-{
-    // we can't use krealloc, because it may be read-only
-    void *new = kzalloc(new_size, GFP_ATOMIC);
-    if (!new) {
-        return NULL;
-    }
-    if (old_size) {
-        memcpy(new, old, old_size);
-    }
-    // we can't use kfree, because it may be read-only
-    // there maybe some leaks, maybe we can check ptr_write, but it's not a big deal
-    // kfree(old);
-    return new;
-}
+// https://github.com/torvalds/linux/commit/590b9d576caec6b4c46bba49ed36223a399c3fc5#diff-cc9aa90e094e6e0f47bd7300db4f33cf4366b98b55d8753744f31eb69c691016R844-R845
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 12, 0)
+#define ksu_kvrealloc(p, new_size, _old_size) kvrealloc(p, new_size, GFP_ATOMIC)
+#else
+#define ksu_kvrealloc(p, new_size, old_size)                                   \
+    kvrealloc(p, old_size, new_size, GFP_ATOMIC)
+#endif
 
 static bool add_type(struct policydb *db, const char *type_name, bool attr)
 {
@@ -597,8 +589,8 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
     }
 
     struct ebitmap *new_type_attr_map_array =
-        ksu_realloc(db->type_attr_map_array, value * sizeof(struct ebitmap),
-                    (value - 1) * sizeof(struct ebitmap));
+        ksu_kvrealloc(db->type_attr_map_array, value * sizeof(struct ebitmap),
+                      (value - 1) * sizeof(struct ebitmap));
 
     if (!new_type_attr_map_array) {
         pr_err("add_type: alloc type_attr_map_array failed\n");
@@ -606,9 +598,9 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
     }
 
     struct type_datum **new_type_val_to_struct =
-        ksu_realloc(db->type_val_to_struct,
-                    sizeof(*db->type_val_to_struct) * value,
-                    sizeof(*db->type_val_to_struct) * (value - 1));
+        ksu_kvrealloc(db->type_val_to_struct,
+                      sizeof(*db->type_val_to_struct) * value,
+                      sizeof(*db->type_val_to_struct) * (value - 1));
 
     if (!new_type_val_to_struct) {
         pr_err("add_type: alloc type_val_to_struct failed\n");
@@ -616,8 +608,8 @@ static bool add_type(struct policydb *db, const char *type_name, bool attr)
     }
 
     char **new_val_to_name_types =
-        ksu_realloc(db->sym_val_to_name[SYM_TYPES], sizeof(char *) * value,
-                    sizeof(char *) * (value - 1));
+        ksu_kvrealloc(db->sym_val_to_name[SYM_TYPES], sizeof(char *) * value,
+                      sizeof(char *) * (value - 1));
     if (!new_val_to_name_types) {
         pr_err("add_type: alloc val_to_name failed\n");
         return false;


### PR DESCRIPTION
We used to think that oneplus protected the original memory with RO, but we are wrong. Why kfree() panic kernel is that original memory isn't allocated with kmalloc() but kvmalloc(). Normal device will eventually use kmalloc() anyway, but oneplus seems to use more aggressive memory allocation optimization and switched to vmalloc() path.

Use kvrealloc() to fix it. Note, kvrealloc() will check flags first and use kmalloc() if GFP_ATOMIC is passed, so it is fine to be called in kprobe context. This also fix the last memory leak we found in ksu driver.