### PR TITLE
kernel: use selinux_cred() method instead of directly use cred->security

### DIFF
--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -15,7 +15,7 @@ static int transive_to_domain(const char *domain, struct cred *cred)
 #else
     struct cred_security_struct *tsec;
 #endif
-    tsec = cred->security;
+    tsec = selinux_cred(cred);
     if (!tsec) {
         pr_err("tsec == NULL!\n");
         return -1;


### PR DESCRIPTION
directly use cred->security will get the first registered security cred blob, if newer kernel add a new lsm register a security cred too and load before selinux, we will get that, and do undefined behavior

enfore use selinux_cred(cred) would fix this issue

See: https://cs.android.com/android/_/android/kernel/common/+/bbd3662a834813730912a58efb44dd6df6d952e6