### PR TITLE
kernel: Map KSU_INVALID_UID to INVALID_UID

### DIFF
--- a/kernel/manager.h
+++ b/kernel/manager.h
@@ -6,7 +6,7 @@
 #include <linux/uidgid.h>
 #include "allowlist.h"
 
-#define KSU_INVALID_APPID ((uid_t) -1)
+#define KSU_INVALID_APPID ((uid_t) - 1)
 
 extern uid_t ksu_manager_appid; // DO NOT DIRECT USE
 


### PR DESCRIPTION
Or if manager is not crowned, -1 will pass the check when userspace calls setresuid(-1, -1, -1) and incorrectly install fd for whatever app. Luckily, first setuid is usually called when zygote forks into app and task flag is unmarked there, so this is not a security issue.