### PR TITLE
kernel: Ensure manager is valid before installing fd

### DIFF
--- a/kernel/setuid_hook.c
+++ b/kernel/setuid_hook.c
@@ -86,7 +86,7 @@ int ksu_handle_setresuid(uid_t ruid, uid_t euid, uid_t suid)
     }
 
     if (likely(ksu_is_manager_appid_valid()) &&
-        unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
+        unlikely(ksu_get_manager_appid() == new_uid % PER_USER_RANGE)) {
         spin_lock_irq(&current->sighand->siglock);
         ksu_seccomp_allow_cache(current->seccomp.filter, __NR_reboot);
         ksu_set_task_tracepoint_flag(current);


### PR DESCRIPTION
Or if manager is not crowned, userspace can pass the check if calling setresuid(-1, -1, -1). Luckily, first setuid is usually called when zygote forks into app and task flag is unmarked there, so this is not a security issue.