### PR TITLE
manager: fix ksu.fullScreen

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewInterface.kt
@@ -177,6 +177,7 @@ class WebViewInterface(
                 }
             }
         }
+        enableInsets(enable)
     }
 
     @JavascriptInterface


### PR DESCRIPTION
since insets is toggeable in #3083, fullScreen will only toggle system bar but not insets. This commit restore how fullScreen function like previous version, both system bar and insets are toggled simultaniously.