### PR TITLE
selinux: Cache SID lookups for domain checks

### DIFF
--- a/kernel/ksud.c
+++ b/kernel/ksud.c
@@ -62,7 +62,6 @@ static struct work_struct stop_vfs_read_work;
 static struct work_struct stop_execve_hook_work;
 static struct work_struct stop_input_hook_work;
 
-u32 ksu_file_sid;
 void on_post_fs_data(void)
 {
     static bool done = false;
@@ -77,9 +76,6 @@ void on_post_fs_data(void)
     ksu_observer_init();
     // sanity check, this may influence the performance
     stop_input_hook();
-
-    ksu_file_sid = ksu_get_ksu_file_sid();
-    pr_info("ksu_file sid: %d\n", ksu_file_sid);
 }
 
 extern void ext4_unregister_sysfs(struct super_block *sb);
@@ -250,7 +246,7 @@ int ksu_handle_execveat_ksud(int *fd, struct filename **filename_ptr,
             check_argv(*argv, 1, "second_stage", buf, sizeof(buf))) {
             pr_info("/system/bin/init second_stage executed\n");
             apply_kernelsu_rules();
-            ksu_selinux_init();
+            cache_sid();
             setup_ksu_cred();
             init_second_stage_executed = true;
         }

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -21,6 +21,7 @@
 static u32 cached_su_sid __read_mostly = 0;
 static u32 cached_zygote_sid __read_mostly = 0;
 static u32 cached_init_sid __read_mostly = 0;
+u32 ksu_file_sid __read_mostly = 0;
 
 static int transive_to_domain(const char *domain, struct cred *cred)
 {
@@ -111,7 +112,7 @@ static void __security_release_secctx(struct lsm_context *cp)
  * Called once after SELinux policy is loaded (post-fs-data).
  * This eliminates expensive string comparisons in hot paths.
  */
-void ksu_selinux_init(void)
+void cache_sid(void)
 {
     int err;
 
@@ -140,6 +141,15 @@ void ksu_selinux_init(void)
         cached_init_sid = 0;
     } else {
         pr_info("Cached init SID: %u\n", cached_init_sid);
+    }
+
+    err = security_secctx_to_secid(KSU_FILE_CONTEXT, strlen(KSU_FILE_CONTEXT),
+                                   &ksu_file_sid);
+    if (err) {
+        pr_warn("Failed to cache ksu_file SID: %d\n", err);
+        ksu_file_sid = 0;
+    } else {
+        pr_info("Cached ksu_file SID: %u\n", ksu_file_sid);
     }
 }
 
@@ -197,15 +207,4 @@ bool is_zygote(const struct cred *cred)
 bool is_init(const struct cred *cred)
 {
     return is_sid_match(cred, cached_init_sid, INIT_CONTEXT);
-}
-
-u32 ksu_get_ksu_file_sid()
-{
-    u32 ksu_file_sid = 0;
-    int err = security_secctx_to_secid(KSU_FILE_CONTEXT,
-                                       strlen(KSU_FILE_CONTEXT), &ksu_file_sid);
-    if (err) {
-        pr_info("get ksufile sid err %d\n", err);
-    }
-    return ksu_file_sid;
 }

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -20,7 +20,7 @@ void setenforce(bool);
 
 bool getenforce();
 
-void ksu_selinux_init(void);
+void cache_sid(void);
 
 bool is_task_ksu_domain(const struct cred *cred);
 
@@ -31,8 +31,6 @@ bool is_zygote(const struct cred *cred);
 bool is_init(const struct cred *cred);
 
 void apply_kernelsu_rules();
-
-u32 ksu_get_ksu_file_sid();
 
 int handle_sepolicy(unsigned long arg3, void __user *arg4);
 


### PR DESCRIPTION
Cache SELinux SIDs for su/zygote/init contexts at init time instead of resolving them on every domain check. Reduces overhead from string-based lookups to simple integer comparisons.