### PR TITLE
kerenl: check package name before check manager signature

### DIFF
--- a/kernel/apk_sign.c
+++ b/kernel/apk_sign.c
@@ -15,6 +15,7 @@
 #endif
 
 #include "apk_sign.h"
+#include "app_profile.h"
 #include "klog.h" // IWYU pragma: keep
 
 struct sdesc {
@@ -306,7 +307,58 @@ module_param_cb(ksu_debug_manager_appid, &expected_size_ops,
 
 #endif
 
+int get_pkg_from_apk_path(char *pkg, const char *path)
+{
+    int len = strlen(path);
+    if (len >= KSU_MAX_PACKAGE_NAME || len < 1)
+        return -1;
+
+    const char *last_slash = NULL;
+    const char *second_last_slash = NULL;
+
+    int i;
+    for (i = len - 1; i >= 0; i--) {
+        if (path[i] == '/') {
+            if (!last_slash) {
+                last_slash = &path[i];
+            } else {
+                second_last_slash = &path[i];
+                break;
+            }
+        }
+    }
+
+    if (!last_slash || !second_last_slash)
+        return -1;
+
+    const char *last_hyphen = strchr(second_last_slash, '-');
+    if (!last_hyphen || last_hyphen > last_slash)
+        return -1;
+
+    int pkg_len = last_hyphen - second_last_slash - 1;
+    if (pkg_len >= KSU_MAX_PACKAGE_NAME || pkg_len <= 0)
+        return -1;
+
+    // Copying the package name
+    strncpy(pkg, second_last_slash + 1, pkg_len);
+    pkg[pkg_len] = '\0';
+
+    return 0;
+}
+
 bool is_manager_apk(char *path)
 {
+#ifdef KSU_MANAGER_PACKAGE
+    char pkg[KSU_MAX_PACKAGE_NAME];
+    if (get_pkg_from_apk_path(pkg, path) < 0) {
+        pr_err("Failed to get package name from apk path: %s\n", path);
+        return false;
+    }
+
+    // pkg is `<real package>`
+    if (strncmp(pkg, KSU_MANAGER_PACKAGE, sizeof(KSU_MANAGER_PACKAGE))) {
+        return false;
+    }
+#endif
     return check_v2_signature(path, EXPECTED_SIZE, EXPECTED_HASH);
 }

--- a/kernel/apk_sign.h
+++ b/kernel/apk_sign.h
@@ -4,5 +4,6 @@
 #include <linux/types.h>
 
 bool is_manager_apk(char *path);
+int get_pkg_from_apk_path(char *pkg, const char *path);
 
 #endif

--- a/kernel/throne_tracker.c
+++ b/kernel/throne_tracker.c
@@ -7,6 +7,7 @@
 #include <linux/version.h>
 
 #include "allowlist.h"
+#include "apk_sign.h"
 #include "klog.h" // IWYU pragma: keep
 #include "manager.h"
 #include "throne_tracker.h"
@@ -21,45 +22,6 @@ struct uid_data {
     char package[KSU_MAX_PACKAGE_NAME];
 };
 
-static int get_pkg_from_apk_path(char *pkg, const char *path)
-{
-    int len = strlen(path);
-    if (len >= KSU_MAX_PACKAGE_NAME || len < 1)
-        return -1;
-
-    const char *last_slash = NULL;
-    const char *second_last_slash = NULL;
-
-    int i;
-    for (i = len - 1; i >= 0; i--) {
-        if (path[i] == '/') {
-            if (!last_slash) {
-                last_slash = &path[i];
-            } else {
-                second_last_slash = &path[i];
-                break;
-            }
-        }
-    }
-
-    if (!last_slash || !second_last_slash)
-        return -1;
-
-    const char *last_hyphen = strchr(second_last_slash, '-');
-    if (!last_hyphen || last_hyphen > last_slash)
-        return -1;
-
-    int pkg_len = last_hyphen - second_last_slash - 1;
-    if (pkg_len >= KSU_MAX_PACKAGE_NAME || pkg_len <= 0)
-        return -1;
-
-    // Copying the package name
-    strncpy(pkg, second_last_slash + 1, pkg_len);
-    pkg[pkg_len] = '\0';
-
-    return 0;
-}
-
 static void crown_manager(const char *apk, struct list_head *uid_data)
 {
     char pkg[KSU_MAX_PACKAGE_NAME];
@@ -70,14 +32,6 @@ static void crown_manager(const char *apk, struct list_head *uid_data)
 
     pr_info("manager pkg: %s\n", pkg);
 
-#ifdef KSU_MANAGER_PACKAGE
-    // pkg is `/<real package>`
-    if (strncmp(pkg, KSU_MANAGER_PACKAGE, sizeof(KSU_MANAGER_PACKAGE))) {
-        pr_info("manager package is inconsistent with kernel build: %s\n",
-                KSU_MANAGER_PACKAGE);
-        return;
-    }
-#endif
     struct list_head *list = (struct list_head *)uid_data;
     struct uid_data *np;
 


### PR DESCRIPTION
If the package name of the manager is defined, check the package name before checking the signature.

Fixed the issue where if a package name is defined, but the first matching signature found by the kernel is not the manager, the real manager cannot be crowned.
e.g. When Android Studio previews Compose, it installs a package with the same signature as the manager on the device, such as me.weishu.kernelsu.test