### PR TITLE
fix(webui): The `internal/colors.css` is empty source when WebUIActivity started by shortcut

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
-import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -89,8 +88,7 @@ class MainActivity : ComponentActivity() {
         if (isManager && !Natives.requireNewKernel()) install()
 
         setContent {
-            val context = LocalActivity.current ?: this
-            val prefs = context.getSharedPreferences("settings", MODE_PRIVATE)
+            val prefs = LocalContext.current.getSharedPreferences("settings", MODE_PRIVATE)
             var colorMode by remember { mutableIntStateOf(prefs.getInt("color_mode", 0)) }
             var keyColorInt by remember { mutableIntStateOf(prefs.getInt("key_color", 0)) }
             val keyColor = remember(keyColorInt) { if (keyColorInt == 0) null else Color(keyColorInt) }


### PR DESCRIPTION
Applies the `KernelSUTheme` to the `WebUIActivity`, ensuring it provide not empty css when it started by shortcut