### PR TITLE
manager: Use ParcelableSerializer for Nav3

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/navigation3/Routes.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/navigation3/Routes.kt
@@ -1,7 +1,8 @@
 package me.weishu.kernelsu.ui.navigation3
 
+import android.os.Parcelable
 import androidx.navigation3.runtime.NavKey
-import kotlinx.serialization.Contextual
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import me.weishu.kernelsu.ui.screen.FlashIt
 import me.weishu.kernelsu.ui.screen.RepoModuleArg
@@ -44,13 +45,13 @@ sealed interface Route : NavKey {
     data object Install : Route
 
     @Serializable
-    data class ModuleRepoDetail(val module: @Contextual RepoModuleArg) : Route
+    data class ModuleRepoDetail(val module: RepoModuleArg) : Route
 
     @Serializable
     data object ModuleRepo : Route
 
     @Serializable
-    data class Flash(val flashIt: @Contextual FlashIt) : Route
+    data class Flash(val flashIt: FlashIt) : Route
 
     @Serializable
     data class ExecuteModuleAction(val moduleId: String) : Route

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt
@@ -56,6 +56,7 @@ import me.weishu.kernelsu.ui.component.KeyEventBlocker
 import me.weishu.kernelsu.ui.navigation3.Navigator
 import me.weishu.kernelsu.ui.util.FlashResult
 import me.weishu.kernelsu.ui.util.LkmSelection
+import me.weishu.kernelsu.ui.util.UriListSerializer
 import me.weishu.kernelsu.ui.util.UriSerializer
 import me.weishu.kernelsu.ui.util.flashModule
 import me.weishu.kernelsu.ui.util.installBoot
@@ -249,7 +250,7 @@ sealed class FlashIt : Parcelable {
     ) : FlashIt()
 
     @Serializable
-    data class FlashModules(val uris: List<@Serializable(with = UriSerializer::class) Uri>) : FlashIt()
+    data class FlashModules(@Serializable(with = UriListSerializer::class) val uris: List<Uri>) : FlashIt()
 
     @Serializable
     data object FlashRestore : FlashIt()

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.ConfirmDialogHandle
 import me.weishu.kernelsu.ui.component.GithubMarkdown
@@ -137,6 +138,7 @@ import java.text.Collator
 import java.util.Locale
 
 @Parcelize
+@Serializable
 data class ReleaseAssetArg(
     val name: String,
     val downloadUrl: String,
@@ -145,6 +147,7 @@ data class ReleaseAssetArg(
 ) : Parcelable
 
 @Parcelize
+@Serializable
 data class ReleaseArg(
     val tagName: String,
     val name: String,
@@ -154,12 +157,14 @@ data class ReleaseArg(
 ) : Parcelable
 
 @Parcelize
+@Serializable
 data class AuthorArg(
     val name: String,
     val link: String,
 ) : Parcelable
 
 @Parcelize
+@Serializable
 data class RepoModuleArg(
     val moduleId: String,
     val moduleName: String,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -259,8 +259,10 @@ fun uninstallPermanently(
 sealed class LkmSelection : Parcelable {
     @Serializable
     data class LkmUri(@Serializable(with = UriSerializer::class) val uri: Uri) : LkmSelection()
+
     @Serializable
     data class KmiString(val value: String) : LkmSelection()
+
     @Serializable
     data object KmiNone : LkmSelection()
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ParcelExtensions.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ParcelExtensions.kt
@@ -1,0 +1,18 @@
+package me.weishu.kernelsu.ui.util
+
+import android.os.Parcel
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+inline fun <R> Parcel.use(block: (Parcel) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    return try {
+        block(this)
+    } finally {
+        recycle()
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SuperUserViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SuperUserViewModel.kt
@@ -67,8 +67,7 @@ class SuperUserViewModel : ViewModel() {
     @Serializable
     data class AppInfo(
         val label: String,
-        @Serializable(PackageInfoSerializer::class)
-        val packageInfo: PackageInfo,
+        @Serializable(with = PackageInfoSerializer::class) val packageInfo: PackageInfo,
         val profile: Natives.Profile?,
     ) : Parcelable {
         val packageName: String


### PR DESCRIPTION
This pull request introduces improvements to how `Parcelable` types are serialized and deserialized throughout the app, replacing custom or contextual serializers with a new, unified approach. It adds a generic `ParcelableSerializer` for easier and more robust serialization of `Parcelable` classes using Base64 encoding, and updates related data classes and serializers accordingly. Additionally, it introduces a utility extension for safely using and recycling `Parcel` objects.

**Serialization improvements:**

* Introduced a generic `ParcelableSerializer` in `Serialization.kt` to handle serialization/deserialization of any `Parcelable` type using Base64 encoding, and replaced previous custom serializers for `Uri` and `PackageInfo` with this approach. Also added `UriListSerializer` for lists of `Uri`. (`manager/app/src/main/java/me/weishu/kernelsu/ui/util/Serialization.kt`)
* Updated usage of serializers in `FlashIt.FlashModules`, `SuperUserViewModel.AppInfo`, and navigation routes to use the new `ParcelableSerializer`-based serializers instead of contextual or custom ones. (`manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt`, `manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SuperUserViewModel.kt`, `manager/app/src/main/java/me/weishu/kernelsu/ui/navigation3/Routes.kt`) [[1]](diffhunk://#diff-0ba5bfb1a91dd51230d479bce5634e8681c9d2137d2f41fa526160672ff46375L252-R253) [[2]](diffhunk://#diff-593318b0393bef6c79d0e20ee017190951db0622bc46cba5640ea9b3b53af9aeL70-R70) [[3]](diffhunk://#diff-6850682e3127373d01fdb2cdf8536f3eae8933d3905e30a3278e92d37d9f4e6aL47-R54)

**Data class serialization annotations:**

* Added `@Serializable` annotations to several `@Parcelize` data classes (`ReleaseAssetArg`, `ReleaseArg`, `AuthorArg`, `RepoModuleArg`) to ensure they are compatible with Kotlin serialization. (`manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt`) [[1]](diffhunk://#diff-b47073bcea05aed8480852855c8e11d624078b0fa5c569ca6cc64179d3a1ab35R141) [[2]](diffhunk://#diff-b47073bcea05aed8480852855c8e11d624078b0fa5c569ca6cc64179d3a1ab35R150) [[3]](diffhunk://#diff-b47073bcea05aed8480852855c8e11d624078b0fa5c569ca6cc64179d3a1ab35R160-R167)

**Utility improvements:**

* Added a `Parcel.use` extension function for safe usage and recycling of `Parcel` objects, reducing the risk of resource leaks. (`manager/app/src/main/java/me/weishu/kernelsu/ui/util/ParcelExtensions.kt`)

**Dependency cleanup:**

* Removed unused imports and contextual serialization where no longer necessary, reflecting the new unified serialization approach. (`manager/app/src/main/java/me/weishu/kernelsu/ui/navigation3/Routes.kt`, `manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Flash.kt`, `manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt`) [[1]](diffhunk://#diff-6850682e3127373d01fdb2cdf8536f3eae8933d3905e30a3278e92d37d9f4e6aR3-R5) [[2]](diffhunk://#diff-0ba5bfb1a91dd51230d479bce5634e8681c9d2137d2f41fa526160672ff46375R59) [[3]](diffhunk://#diff-b47073bcea05aed8480852855c8e11d624078b0fa5c569ca6cc64179d3a1ab35R88)

These changes collectively simplify and standardize how `Parcelable` objects are serialized across the codebase, making the code easier to maintain and less error-prone.