### PR TITLE
kernel: Fix `setup_selinux` using `__task_cred` directly

### DIFF
--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -147,12 +147,12 @@ void escape_with_root_profile(void)
            sizeof(cred->cap_bset));
 
     setup_groups(profile, cred);
+    setup_selinux(profile->selinux_domain, cred);
 
     commit_creds(cred);
 
     disable_seccomp();
 
-    setup_selinux(profile->selinux_domain);
     for_each_thread (p, t) {
         ksu_set_task_tracepoint_flag(t);
     }

--- a/kernel/selinux/selinux.c
+++ b/kernel/selinux/selinux.c
@@ -51,9 +51,9 @@ static int transive_to_domain(const char *domain, struct cred *cred)
     return error;
 }
 
-void setup_selinux(const char *domain)
+void setup_selinux(const char *domain, struct cred *cred)
 {
-    if (transive_to_domain(domain, (struct cred *)__task_cred(current))) {
+    if (transive_to_domain(domain, cred) {
         pr_err("transive domain failed.\n");
         return;
     }

--- a/kernel/selinux/selinux.h
+++ b/kernel/selinux/selinux.h
@@ -14,7 +14,7 @@
 #define ZYGOTE_CONTEXT "u:r:zygote:s0"
 #define INIT_CONTEXT "u:r:init:s0"
 
-void setup_selinux(const char *);
+void setup_selinux(const char *, struct cred *);
 
 void setenforce(bool);
 


### PR DESCRIPTION
This PR fixes an unsafe direct modification of task credentials in the SELinux integration code used by KernelSU.

In `kernel/selinux`, KernelSU currently accesses and mutates the struct cred returned by `__task_cred()`. While this may work on many kernels, it can cause kernel crashes on systems that enforce additional protections on credential memory, such as Samsung devices using the RKP (UH) hypervisor.

On such systems, the credential pages returned by `__task_cred()` may be write-protected, and writing to them directly can result in a panic during early boot or when launching the KernelSU manager app.

More recent KernelSU versions already address this issue in the “escape to root” logic by switching to the proper kernel APIs (`prepare_creds()` / `commit_creds()`), which avoids directly modifying protected credential memory.
However, `setup_selinux()` (in `selinux/selinux.c`) still accesses `__task_cred()` directly. This patch updates that code path to use the same safe credential handling approach, eliminating the remaining unsafe 

This change improves compatibility with kernels that enforce credential memory protections (e.g. Samsung kernels with RKP enabled) and removes the need for users to disable CONFIG_UH as a workaround.


I do not currently have access to a GKI-based device to test this on real hardware. However:
    The change builds successfully in the AOSP mainline kernel tree
    I've backported the logic to my Samsung 4.14 non-GKI kernel tree and KernelSU 0.9.5 works (even with `CONFIG_UH=y`)


Additional note:
It may be helpful to document this behavior in the non-GKI integration notes, particularly for Samsung kernels that enable RKP/UH.
Several users (myself included) have run into build-time or runtime issues on Samsung kernels due to this interaction and initially worked around it by disabling RKP or switching to a non-kernel-based root solution. Making this information more visible could help others avoid those problems.
I’d be happy to help update or contribute to the relevant documentation if that would be useful.