### PR TITLE
manager: add enableScriptDebug setting to manager

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Settings.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Settings.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.rounded.RemoveModerator
 import androidx.compose.material.icons.rounded.RestartAlt
 import androidx.compose.material.icons.rounded.Update
 import androidx.compose.material.icons.rounded.UploadFile
+import androidx.compose.material.icons.rounded.ViewInAr
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,6 +54,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.content.edit
+import com.topjohnwu.superuser.io.SuFile
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
@@ -509,6 +511,34 @@ fun SettingPager(
                                 if (Natives.setDefaultUmountModules(it)) {
                                     umountChecked = it
                                 }
+                            }
+                        )
+
+                        val enableScriptDebug by produceState(initialValue = false) {
+                            value = SuFile("/data/adb/ksu/.enable_script_debug").exists()
+                        }
+                        var isScriptDebuggingEnabled by rememberSaveable(enableScriptDebug) {
+                            mutableStateOf(enableScriptDebug)
+                        }
+                        SuperSwitch(
+                            title = stringResource(id = R.string.enable_script_debugging),
+                            summary = stringResource(id = R.string.enable_script_debugging_summary),
+                            startAction = {
+                                Icon(
+                                    Icons.Rounded.ViewInAr,
+                                    modifier = Modifier.padding(end = 16.dp),
+                                    contentDescription = stringResource(id = R.string.enable_script_debugging),
+                                    tint = colorScheme.onBackground
+                                )
+                            },
+                            checked = isScriptDebuggingEnabled,
+                            onCheckedChange = {
+                                if (isScriptDebuggingEnabled) {
+                                    SuFile("/data/adb/ksu/.enable_script_debug").delete()
+                                } else {
+                                    SuFile("/data/adb/ksu/.enable_script_debug").createNewFile()
+                                }
+                                isScriptDebuggingEnabled = !isScriptDebuggingEnabled
                             }
                         )
 

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -114,6 +114,8 @@
     <string name="open">打开</string>
     <string name="enable_web_debugging">WebView 调试</string>
     <string name="enable_web_debugging_summary">可用于调试 WebUI，请仅在需要时启用。</string>
+    <string name="enable_script_debugging">模块脚本调试</string>
+    <string name="enable_script_debugging_summary">可用于调试模块脚本，请仅在需要时启用。</string>
     <string name="direct_install">直接安装（推荐）</string>
     <string name="select_file">选择一个文件</string>
     <string name="install_inactive_slot">安装到未使用的槽位（OTA 后）</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -119,6 +119,8 @@
     <string name="open">Open</string>
     <string name="enable_web_debugging">WebView debugging</string>
     <string name="enable_web_debugging_summary">Can be used to debug WebUI. Please enable only when needed.</string>
+    <string name="enable_script_debugging">Module Script debugging</string>
+    <string name="enable_script_debugging_summary">Can be used to debug Module Scripts. Please enable only when needed.</string>
     <string name="direct_install">Direct install (Recommended)</string>
     <string name="select_file">Select a file</string>
     <string name="install_inactive_slot">Install to inactive slot (After OTA)</string>


### PR DESCRIPTION
From pr #3205, i think we can add an option to manager, default disable, but when user enable that, we record every script output in ksud
this is just manager change, create /data/adb/ksu/.enable_script_debug when user enable, delete that when user disable, ksud can simple check this file exists or not to know record or not record script output