### PR TITLE
kernel: use correct errno when add_try_umount failed

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -482,7 +482,7 @@ static int add_try_umount(void __user *arg)
         new_entry->umountable = kstrdup(buf, GFP_KERNEL);
         if (!new_entry->umountable) {
             kfree(new_entry);
-            return -1;
+            return -ENOMEM;
         }
 
         down_write(&mount_list_lock);
@@ -495,7 +495,7 @@ static int add_try_umount(void __user *arg)
                 up_write(&mount_list_lock);
                 kfree(new_entry->umountable);
                 kfree(new_entry);
-                return -1;
+                return -EEXIST;
             }
         }
 


### PR DESCRIPTION
I think we should return -ENOMEM when kstrdup failed (memory alloc failed) return -EEXIST when try_umount already exist
Return more standard errno to let our ksud can output the real error when user execute command failed https://github.com/tiann/KernelSU/blob/main/userspace/ksud/src/ksucalls.rs#L158 https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno-base.h