### PR TITLE
manager: cleanup Downloader and fix warnings

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SendLogDialog.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SendLogDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -44,6 +45,7 @@ fun SendLogDialog(
     loadingDialog: LoadingDialogHandle,
 ) {
     val context = LocalContext.current
+    val resources = LocalResources.current
     val scope = rememberCoroutineScope()
     val exportBugreportLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.CreateDocument("application/gzip")
@@ -58,7 +60,7 @@ fun SendLogDialog(
             }
             loadingDialog.hide()
             withContext(Dispatchers.Main) {
-                Toast.makeText(context, context.getString(R.string.log_saved), Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, resources.getString(R.string.log_saved), Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -132,7 +134,7 @@ fun SendLogDialog(
                         context.startActivity(
                             Intent.createChooser(
                                 shareIntent,
-                                context.getString(R.string.send_log)
+                                resources.getString(R.string.send_log)
                             )
                         )
                     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/Module.kt
@@ -118,7 +118,6 @@ import me.weishu.kernelsu.ui.component.rememberLoadingDialog
 import me.weishu.kernelsu.ui.navigation3.Navigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.theme.isInDarkTheme
-import me.weishu.kernelsu.ui.util.DownloadListener
 import me.weishu.kernelsu.ui.util.download
 import me.weishu.kernelsu.ui.util.getFileName
 import me.weishu.kernelsu.ui.util.hasMagisk
@@ -643,12 +642,12 @@ fun ModulePager(
                 )
                 val selectZipLauncher = rememberLauncherForActivityResult(
                     contract = ActivityResultContracts.StartActivityForResult()
-                ) {
+                ) { activityResult ->
                     val uris = mutableListOf<Uri>()
-                    if (it.resultCode != RESULT_OK) {
+                    if (activityResult.resultCode != RESULT_OK) {
                         return@rememberLauncherForActivityResult
                     }
-                    val data = it.data ?: return@rememberLauncherForActivityResult
+                    val data = activityResult.data ?: return@rememberLauncherForActivityResult
                     val clipData = data.clipData
 
                     if (clipData != null) {
@@ -842,7 +841,6 @@ fun ModulePager(
                             .hazeSource(state = hazeState),
                         scope = scope,
                         modules = modules,
-                        onInstallModule = { navigator.push(Route.Flash(FlashIt.FlashModules(listOf(it)))) },
                         onClickModule = { id, name, hasWebUi ->
                             onModuleClick(id, name, hasWebUi)
                         },
@@ -1037,7 +1035,6 @@ private fun ModuleList(
     modifier: Modifier = Modifier,
     scope: CoroutineScope,
     modules: List<ModuleViewModel.ModuleInfo>,
-    onInstallModule: (Uri) -> Unit,
     onClickModule: (id: String, name: String, hasWebUi: Boolean) -> Unit,
     onModuleUninstall: suspend (ModuleViewModel.ModuleInfo) -> Unit,
     onModuleUndoUninstall: suspend (ModuleViewModel.ModuleInfo) -> Unit,
@@ -1198,7 +1195,6 @@ private fun ModuleList(
             }
         }
     }
-    DownloadListener(context, onInstallModule)
 }
 
 @Composable

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/ModuleRepo.kt
@@ -95,7 +95,6 @@ import me.weishu.kernelsu.ui.component.rememberConfirmDialog
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.theme.isInDarkTheme
-import me.weishu.kernelsu.ui.util.DownloadListener
 import me.weishu.kernelsu.ui.util.download
 import me.weishu.kernelsu.ui.util.isNetworkAvailable
 import me.weishu.kernelsu.ui.util.module.fetchModuleDetail
@@ -1218,6 +1217,5 @@ fun ModuleRepoDetailScreen(
                 }
             }
         }
-        DownloadListener(context, onInstallModule)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/Downloader.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/Downloader.kt
@@ -1,19 +1,10 @@
 package me.weishu.kernelsu.ui.util
 
 import android.annotation.SuppressLint
-import android.app.DownloadManager
-import android.content.BroadcastReceiver
-import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.net.Uri
 import android.os.Environment
 import android.os.Handler
 import android.os.Looper
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import me.weishu.kernelsu.ksuApp
 import me.weishu.kernelsu.ui.util.module.LatestVersionInfo
 import okhttp3.Request
@@ -108,44 +99,4 @@ fun checkNewVersion(): LatestVersionInfo {
             }
     }
     return defaultValue
-}
-
-@Composable
-fun DownloadListener(context: Context, onDownloaded: (Uri) -> Unit) {
-    DisposableEffect(context) {
-        val receiver = object : BroadcastReceiver() {
-            @SuppressLint("Range")
-            override fun onReceive(context: Context?, intent: Intent?) {
-                if (intent?.action == DownloadManager.ACTION_DOWNLOAD_COMPLETE) {
-                    val id = intent.getLongExtra(
-                        DownloadManager.EXTRA_DOWNLOAD_ID, -1
-                    )
-                    val query = DownloadManager.Query().setFilterById(id)
-                    val downloadManager =
-                        context?.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-                    val cursor = downloadManager.query(query)
-                    if (cursor.moveToFirst()) {
-                        val status = cursor.getInt(
-                            cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
-                        )
-                        if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                            val uri = cursor.getString(
-                                cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)
-                            )
-                            onDownloaded(uri.toUri())
-                        }
-                    }
-                }
-            }
-        }
-        ContextCompat.registerReceiver(
-            context,
-            receiver,
-            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-            ContextCompat.RECEIVER_EXPORTED
-        )
-        onDispose {
-            context.unregisterReceiver(receiver)
-        }
-    }
 }


### PR DESCRIPTION
commit (b3d58209) refactored the download logic to use OkHttp downloader instead of the system's DownloadManager. However, the DownloadListener was designed to listen for DownloadManager's broadcasts, was inadvertently left behind.