### PR TITLE
manager: Fix SecurityException when loading icons for secondary users

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/AppIconImage.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/AppIconImage.kt
@@ -102,7 +102,12 @@ fun AppIconImage(
 
                 // Add system badges
                 val handle = UserHandle.getUserHandleForUid(applicationInfo.uid)
-                val badgedDrawable = pm.getUserBadgedIcon(finalDrawable, handle)
+                val badgedDrawable = try {
+                    pm.getUserBadgedIcon(finalDrawable, handle)
+                } catch (_: Exception) {
+                    // Fallback to unbadged icon for users in a different profile group (e.g., secondary users)
+                    finalDrawable
+                }
 
                 if (badgedDrawable is BitmapDrawable && (badgedDrawable.intrinsicWidth > targetSizePx * 2 || badgedDrawable.intrinsicHeight > targetSizePx * 2)) {
 


### PR DESCRIPTION
after #3232 we can manage users across different profile groups (e.g., secondary users). However, invoking pm.getUserBadgedIcon for these isolated users triggers a SecurityException due to system permission restrictions on cross-profile interaction.