### PR TITLE
[add device]: All Huawei & Honor devices (Project:KernelSU_on_Huawei)

### DIFF
--- a/website/docs/repos.json
+++ b/website/docs/repos.json
@@ -733,5 +733,12 @@
         "kernel_name": "android_kernel_samsung_sma155f",
         "kernel_link": "https://github.com/poqdavid/android_kernel_samsung_sma155f",
         "devices": "Samsung Galaxy A15 4G (sma155f) | MediaTek Helio G99"
+    },
+    {
+        "maintainer": "xixiaobei",
+        "maintainer_link": "https://github.com/xixiaobei-bei",
+        "kernel_name": "KernelSU_on_Huawei",
+        "kernel_link": "https://github.com/xixiaobei-bei/KernelSU_on_Huawei",
+        "devices": "All Huawei & Honor devices"
     }
 ]


### PR DESCRIPTION
# Add all Huawei & Honor devices supports on Unofficially supported devices.

## This PR introduces:

- Project: KernelSU_on_Huawei

- Scope: All Huawei/Honor devices

- Goal: To provide a unified kernel modification method and pre-built KernelSU integration guides for the entire Huawei community.

This centralized approach will help users and developers collaborate more efficiently. The project has already gathered traction in the Huawei modding community.