### PR TITLE
ksud: set max page size to 16KB for Android targets

### DIFF
--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -29,6 +29,9 @@ fn get_git_version() -> Result<(u32, String), std::io::Error> {
 }
 
 fn main() {
+    if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "android" {
+        println!("cargo:rustc-link-arg=-Wl,-z,max-page-size=16384");
+    }
     let (code, name) = match get_git_version() {
         Ok((code, name)) => (code, name),
         Err(_) => {


### PR DESCRIPTION
Fixes ksud execution on Android devices with 16KB page sizes by explicitly setting the max page size during linking.

Solves: 
`
CANNOT LINK EXECUTABLE ".../libksud.so": empty/missing DT_HASH/DT_GNU_HASH in ".../libksud.so" (new hash type from the future?)
`