### PR TITLE
Update KSU config to require EXT4_FS

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -2,11 +2,12 @@ menu "KernelSU"
 
 config KSU
 	tristate "KernelSU function support"
-	depends on KPROBES
+	depends on KPROBES && EXT4_FS
 	default y
 	help
 	  Enable kernel-level root privileges on Android System.
 	  Requires CONFIG_KPROBES for kernel hooking support.
+	  Requires CONFIG_EXT4_FS for `ext4_unregister_sysfs`.
 	  To compile as a module, choose M here: the
 	  module will be called kernelsu.
 


### PR DESCRIPTION
Add dependency on EXT4_FS for KernelSU support for `ext4_unregister_sysfs`.