### PR TITLE
manager: Revert remove `shortcut_type` intent's extra

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -425,8 +425,6 @@ private fun ShortcutIntentHandler(
         val intent = activity.intent
         val type = intent?.getStringExtra("shortcut_type") ?: return@LaunchedEffect
 
-        intent.removeExtra("shortcut_type")
-
         when (type) {
             "module_action" -> {
                 val moduleId = intent.getStringExtra("module_id") ?: return@LaunchedEffect


### PR DESCRIPTION
When the Action is executed through a shortcut, it will neither display a toast notification nor remove the task.