### PR TITLE
manager: Add settings icon to home screen TopBar for uninstalled state

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -213,10 +213,10 @@ class MainActivity : ComponentActivity() {
                                 entry<Route.Install> { InstallScreen() }
                                 entry<Route.Flash> { key -> FlashScreen(key.flashIt) }
                                 entry<Route.ExecuteModuleAction> { key -> ExecuteModuleActionScreen(key.moduleId) }
-                                entry<Route.Home> { MainScreen() }
-                                entry<Route.SuperUser> { MainScreen() }
-                                entry<Route.Module> { MainScreen() }
-                                entry<Route.Settings> { MainScreen() }
+                                entry<Route.Home> { MainScreen(initialPage = 0) }
+                                entry<Route.SuperUser> { MainScreen(initialPage = 1) }
+                                entry<Route.Module> { MainScreen(initialPage = 2) }
+                                entry<Route.Settings> { MainScreen(initialPage = 3) }
                             }
                         )
                     }
@@ -241,12 +241,13 @@ class MainActivity : ComponentActivity() {
 val LocalMainPagerState = staticCompositionLocalOf<MainPagerState> { error("LocalMainPagerState not provided") }
 
 @Composable
-fun MainScreen() {
+fun MainScreen(initialPage: Int = 0) {
     val navController = LocalNavigator.current
     val enableBlur = LocalEnableBlur.current
     val enableFloatingBottomBar = LocalEnableFloatingBottomBar.current
     val enableFloatingBottomBarBlur = LocalEnableFloatingBottomBarBlur.current
-    var currentPage by rememberSaveable { mutableIntStateOf(0) }
+    // Use initialPage as key to ensure different routes have independent saved states
+    var currentPage by rememberSaveable(initialPage) { mutableIntStateOf(initialPage) }
     val pagerState = rememberPagerState(initialPage = currentPage, pageCount = { 4 })
     LaunchedEffect(pagerState.currentPage) {
         currentPage = pagerState.currentPage

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -34,6 +35,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -94,14 +96,16 @@ fun HomePagerMaterial(
 ) {
     val kernelVersion = getKernelVersion()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+    var refreshKey by remember { mutableIntStateOf(0) }
+    val isManager = remember(refreshKey) { Natives.isManager }
+    val fullFeatured = remember(refreshKey) { isManager && !Natives.requireNewKernel() && rootAvailable() }
 
     Scaffold(
-        topBar = { TopBar(scrollBehavior = scrollBehavior) },
+        topBar = { TopBar(navigator = navigator, fullFeatured = fullFeatured, scrollBehavior = scrollBehavior) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
         val context = LocalContext.current
         val loadingDialog = rememberLoadingDialog()
-        var refreshKey by remember { mutableIntStateOf(0) }
         val scope = rememberCoroutineScope()
 
         Column(
@@ -112,7 +116,6 @@ fun HomePagerMaterial(
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            val isManager = remember(refreshKey) { Natives.isManager }
             val ksuVersion = remember(refreshKey) { if (isManager) Natives.version else null }
             val lkmMode = remember(refreshKey) {
                 ksuVersion?.let {
@@ -120,8 +123,6 @@ fun HomePagerMaterial(
                 }
             }
             val mainState = LocalMainPagerState.current
-
-            val fullFeatured = remember(refreshKey) { isManager && !Natives.requireNewKernel() && rootAvailable() }
 
             StatusCard(
                 kernelVersion,
@@ -233,11 +234,24 @@ private fun UpdateCard() {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun TopBar(
+    navigator: Navigator,
+    fullFeatured: Boolean,
     scrollBehavior: TopAppBarScrollBehavior? = null
 ) {
     LargeFlexibleTopAppBar(
         title = { Text(stringResource(R.string.app_name)) },
-        actions = { RebootListPopup() },
+        actions = {
+            if (fullFeatured) {
+                RebootListPopup()
+            } else {
+                IconButton(onClick = { navigator.push(Route.Settings) }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Settings,
+                        contentDescription = stringResource(R.string.settings)
+                    )
+                }
+            }
+        },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.surface,
             scrolledContainerColor = MaterialTheme.colorScheme.surface

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
@@ -87,6 +87,7 @@ import top.yukonga.miuix.kmp.basic.ButtonDefaults
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
 import top.yukonga.miuix.kmp.basic.Icon
+import top.yukonga.miuix.kmp.basic.IconButton
 import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.basic.ScrollBehavior
@@ -95,6 +96,7 @@ import top.yukonga.miuix.kmp.basic.TextButton
 import top.yukonga.miuix.kmp.basic.TopAppBar
 import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.extended.Link
+import top.yukonga.miuix.kmp.icon.extended.Settings
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.isDynamicColor
@@ -123,14 +125,19 @@ fun HomePagerMiuix(
     val context = LocalContext.current
     val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
     val checkUpdate = prefs.getBoolean("check_update", true)
+    var refreshKey by remember { mutableIntStateOf(0) }
+    val isManager = remember(refreshKey) { Natives.isManager }
+    val fullFeatured = remember(refreshKey) { isManager && !Natives.requireNewKernel() && rootAvailable() }
 
     Scaffold(
         topBar = {
             TopBar(
+                navigator = navigator,
                 scrollBehavior = scrollBehavior,
                 hazeState = hazeState,
                 hazeStyle = hazeStyle,
                 enableBlur = enableBlur,
+                fullFeatured = fullFeatured,
             )
         },
         popupHost = { },
@@ -149,10 +156,8 @@ fun HomePagerMiuix(
         ) {
             item {
                 val loadingDialog = rememberLoadingDialog()
-                var refreshKey by remember { mutableIntStateOf(0) }
                 val scope = rememberCoroutineScope()
 
-                val isManager = remember(refreshKey) { Natives.isManager }
                 val ksuVersion = remember(refreshKey) { if (isManager) Natives.version else null }
                 val lkmMode = remember(refreshKey) {
                     ksuVersion?.let {
@@ -271,10 +276,12 @@ private fun UpdateCard() {
 
 @Composable
 private fun TopBar(
+    navigator: Navigator,
     scrollBehavior: ScrollBehavior,
     hazeState: HazeState,
     hazeStyle: HazeStyle,
     enableBlur: Boolean,
+    fullFeatured: Boolean,
 ) {
     TopAppBar(
         modifier = if (enableBlur) {
@@ -289,9 +296,15 @@ private fun TopBar(
         color = if (enableBlur) Color.Transparent else colorScheme.surface,
         title = stringResource(R.string.app_name),
         actions = {
-            RebootListPopupMiuix(
-                modifier = Modifier.padding(end = 16.dp),
-            )
+            if (fullFeatured) {
+                RebootListPopupMiuix()
+            }
+            IconButton(onClick = { navigator.push(Route.Settings) }) {
+                Icon(
+                    imageVector = MiuixIcons.Settings,
+                    contentDescription = stringResource(R.string.settings)
+                )
+            }
         },
         scrollBehavior = scrollBehavior
     )


### PR DESCRIPTION
When KernelSU is not installed, the bottom navigation bar is hidden, making it impossible for users to access Settings to switch between Miuix and Material themes.

Add a settings icon button to the TopBar actions in both HomeMiuix.kt and HomeMaterial.kt, allowing users to access Settings regardless of installation status.

Change-Id: I3018e883a8a97366d85ed2f603a352eae5ac4ac3