### PR TITLE
fix: restore SELinux state during post-magica cleanup

### DIFF
--- a/userspace/ksud/src/magica.rs
+++ b/userspace/ksud/src/magica.rs
@@ -79,6 +79,8 @@ pub fn disable_adb_root() -> Result<()> {
     let resetprop_path = "/dev/resetprop";
 
     let commands: &[(&str, &[&str])] = &[
+        (resetprop_path, &["-n", "ro.boot.selinux", "enforcing"]),
+        ("setenforce", &["1"]),
         (resetprop_path, &["-n", "ro.debuggable", "0"]),
         (resetprop_path, &["-n", "ro.adb.secure", "1"]),
         (resetprop_path, &["--delete", "service.adb.root"]),


### PR DESCRIPTION
Magica jailbreak leaves the system in a state that triggers warnings from anti-cheat tools . Key anomalies include:

* `ro.boot.selinux` set to `permissive`
* `MLS_ANOMALY` detection

This commit adds cleanup commands to `disable_adb_root` during the post-magica phase to properly restore the environment:

1. Executes `setenforce 1`.
2. Resets `ro.boot.selinux` to `enforcing`.
#https://github.com/tiann/KernelSU/commit/b98c05eb129ec923dafef2c219b5a38c0f0ecb20#commitcomment-179373863