### PR TITLE
feat: add long-click to create module shortcut

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SearchStatus.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/SearchStatus.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeState
@@ -68,7 +68,7 @@ data class SearchStatus(
             )
             Box(
                 modifier = Modifier
-                    .alpha(topAppBarAlpha.value)
+                    .graphicsLayer { alpha = topAppBarAlpha.value }
             ) { content() }
         }
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/miuix/SuperSearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/miuix/SuperSearchBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -182,12 +183,13 @@ fun SearchStatus.SearchPager(
         animationSpec = tween(200, easing = FastOutSlowInEasing),
         label = "SearchPagerSurfaceAlpha"
     )
+    val surfaceColor = colorScheme.surface
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .zIndex(5f)
-            .background(colorScheme.surface.copy(alpha = surfaceAlpha))
+            .drawBehind { drawRect(surfaceColor.copy(alpha = surfaceAlpha)) }
             .semantics { onClick { false } }
             .then(
                 if (!searchStatus.isCollapsed()) Modifier.pointerInput(Unit) { } else Modifier

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
@@ -20,9 +20,11 @@ import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,6 +41,7 @@ import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
@@ -85,6 +88,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kyant.capsule.ContinuousRoundedRectangle
@@ -134,10 +138,6 @@ import top.yukonga.miuix.kmp.icon.extended.UploadCloud
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
-
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
-
 
 @SuppressLint("StringFormatInvalid", "LocalContextGetResourceValueCall")
 @Composable
@@ -389,7 +389,9 @@ fun ModulePagerMiuix(
                 }
                 FloatingActionButton(
                     modifier = Modifier
-                        .offset(y = offsetHeight)
+                        .offset {
+                            IntOffset(x = 0, y = offsetHeight.roundToPx())
+                        }
                         .padding(bottom = bottomInnerPadding + 20.dp, end = 20.dp)
                         .border(0.05.dp, colorScheme.outline.copy(alpha = 0.5f), CircleShape),
                     shadowElevation = 0.dp,
@@ -927,43 +929,65 @@ fun ModuleItem(
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     if (module.hasActionScript) {
-                        Box(
+                        Row(
                             modifier = Modifier
-                                .size(35.dp)
+                                .heightIn(min = 35.dp)
                                 .clip(CircleShape)
                                 .background(secondaryContainer)
                                 .combinedClickable(
                                     onClick = onExecuteAction,
                                     onLongClick = { onAddActionShortcut(ShortcutType.Action) }
-                                ),
-                            contentAlignment = Alignment.Center
+                                )
+                                .padding(start = 6.dp, end = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
                         ) {
                             Icon(
-                                modifier = Modifier.size(20.dp),
+                                modifier = Modifier.size(24.dp),
                                 imageVector = Icons.Rounded.PlayArrow,
                                 tint = actionIconTint,
                                 contentDescription = stringResource(R.string.action)
                             )
+                            if (!module.hasWebUi && !hasUpdate) {
+                                Text(
+                                    modifier = Modifier.padding(start = 3.dp, end = 4.dp),
+                                    text = stringResource(R.string.action),
+                                    color = actionIconTint,
+                                    fontWeight = FontWeight.Medium,
+                                    fontSize = 15.sp,
+                                )
+                            }
                         }
                     }
                     if (module.hasWebUi) {
-                        Box(
+                        Row(
                             modifier = Modifier
-                                .size(35.dp)
+                                .heightIn(min = 35.dp)
                                 .clip(CircleShape)
                                 .background(secondaryContainer)
                                 .combinedClickable(
                                     onClick = onOpenWebUi,
                                     onLongClick = { onAddActionShortcut(ShortcutType.WebUI) }
-                                ),
-                            contentAlignment = Alignment.Center
+                                )
+                                .padding(horizontal = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
                         ) {
                             Icon(
-                                modifier = Modifier.size(20.dp),
+                                modifier = Modifier.size(22.dp),
                                 imageVector = Icons.Rounded.Code,
                                 tint = actionIconTint,
                                 contentDescription = stringResource(R.string.open)
                             )
+                            if (!module.hasActionScript && !hasUpdate) {
+                                Text(
+                                    modifier = Modifier.padding(start = 4.dp, end = 2.dp),
+                                    text = stringResource(R.string.open),
+                                    color = actionIconTint,
+                                    fontWeight = FontWeight.Medium,
+                                    fontSize = 15.sp,
+                                )
+                            }
                         }
                     }
                 }
@@ -996,7 +1020,7 @@ fun ModuleItem(
                             contentDescription = stringResource(R.string.module_update),
                         )
                         Text(
-                            modifier = Modifier.padding(start = 4.dp, end = 2.dp),
+                            modifier = Modifier.padding(start = 4.dp, end = 3.dp),
                             text = stringResource(R.string.module_update),
                             color = updateTint,
                             fontWeight = FontWeight.Medium,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMiuix.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -165,7 +166,9 @@ fun AppProfileTemplateScreenMiuix(
                 shadowElevation = 0.dp,
                 onClick = actions.onCreateTemplate,
                 modifier = Modifier
-                    .offset(y = offsetHeight)
+                    .offset {
+                        IntOffset(x = 0, y = offsetHeight.roundToPx())
+                    }
                     .padding(
                         bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() +
                                 WindowInsets.captionBar.asPaddingValues().calculateBottomPadding() + 20.dp,

--- a/manager/app/src/main/res/values-fr/strings.xml
+++ b/manager/app/src/main/res/values-fr/strings.xml
@@ -179,7 +179,6 @@
     <string name="module_shortcut_title">Créer un raccourci</string>
     <string name="module_shortcut_name_label">Nom du raccourci</string>
     <string name="module_shortcut_icon_pick">Choisir une icône personnalisée</string>
-    <string name="module_shortcut_add">Ajouter le raccourci</string>
     <string name="module_shortcut_not_supported">Le lanceur d\'application ne prend pas en charge les raccourcis.</string>
     <string name="module_shortcut_created">Raccourci créé sur le bureau.</string>
     <string name="module_shortcut_updated">Raccourci mis à jour.</string>

--- a/manager/app/src/main/res/values-in/strings.xml
+++ b/manager/app/src/main/res/values-in/strings.xml
@@ -180,7 +180,6 @@
     <string name="module_shortcut_title">Buat pintasan</string>
     <string name="module_shortcut_name_label">Nama pintasan</string>
     <string name="module_shortcut_icon_pick">Pilih ikon khusus</string>
-    <string name="module_shortcut_add">Tambahkan pintasan</string>
     <string name="module_shortcut_not_supported">Launcher tidak mendukung pintasan layar utama.</string>
     <string name="module_shortcut_created">Pintasan dibuat di layar utama.</string>
     <string name="module_shortcut_updated">Pintasan diperbarui.</string>

--- a/manager/app/src/main/res/values-ja/strings.xml
+++ b/manager/app/src/main/res/values-ja/strings.xml
@@ -180,7 +180,6 @@
     <string name="module_shortcut_title">ショートカットを作成</string>
     <string name="module_shortcut_name_label">ショートカット名</string>
     <string name="module_shortcut_icon_pick">カスタムアイコンを選択</string>
-    <string name="module_shortcut_add">ショートカットを追加</string>
     <string name="module_shortcut_not_supported">ランチャーはホーム画面ショートカットをサポートしていません。</string>
     <string name="module_shortcut_created">ホーム画面にショートカットを作成しました。</string>
     <string name="module_shortcut_updated">ショートカットが更新されました。</string>

--- a/manager/app/src/main/res/values-ru/strings.xml
+++ b/manager/app/src/main/res/values-ru/strings.xml
@@ -185,7 +185,6 @@
     <string name="module_shortcut_title">Создать ярлык</string>
     <string name="module_shortcut_name_label">Название ярлыка</string>
     <string name="module_shortcut_icon_pick">Выбрать пользовательскую иконку</string>
-    <string name="module_shortcut_add">Добавить ярлык</string>
     <string name="module_shortcut_not_supported">Лаунчер не поддерживает ярлыки на рабочем столе.</string>
     <string name="module_shortcut_created">Ярлык создан на рабочем столе.</string>
     <string name="module_shortcut_updated">Ярлык обновлен.</string>

--- a/manager/app/src/main/res/values-vi/strings.xml
+++ b/manager/app/src/main/res/values-vi/strings.xml
@@ -179,7 +179,6 @@
     <string name="module_shortcut_title">Tạo shortcut</string>
     <string name="module_shortcut_name_label">Tên shortcut</string>
     <string name="module_shortcut_icon_pick">Chọn icon tuỳ chỉnh</string>
-    <string name="module_shortcut_add">Thêm shortcut</string>
     <string name="module_shortcut_not_supported">Launcher không hỗ trợ shortcut.</string>
     <string name="module_shortcut_created">Shortcut đã được tạo.</string>
     <string name="module_shortcut_updated">Shortcut đã được cập nhật.</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -202,7 +202,6 @@
     <string name="module_shortcut_title">创建快捷方式</string>
     <string name="module_shortcut_name_label">快捷方式名称</string>
     <string name="module_shortcut_icon_pick">选择自定义图标</string>
-    <string name="module_shortcut_add">添加快捷方式</string>
     <string name="module_shortcut_not_supported">启动器不支持桌面快捷方式</string>
     <string name="module_shortcut_created">已在桌面创建快捷方式。</string>
     <string name="module_shortcut_updated">快捷方式已更新。</string>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -121,7 +121,6 @@
     <string name="module_shortcut_title">建立捷徑</string>
     <string name="module_shortcut_name_label">捷徑名稱</string>
     <string name="module_shortcut_icon_pick">選擇自訂圖示</string>
-    <string name="module_shortcut_add">新增捷徑</string>
     <string name="module_shortcut_not_supported">啟動器不支援桌面捷徑。</string>
     <string name="module_shortcut_created">已在桌面建立捷徑。</string>
     <string name="module_shortcut_updated">捷徑已更新。</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -147,7 +147,6 @@
     <string name="module_shortcut_title">建立捷徑</string>
     <string name="module_shortcut_name_label">捷徑名稱</string>
     <string name="module_shortcut_icon_pick">選擇自訂圖示</string>
-    <string name="module_shortcut_add">新增捷徑</string>
     <string name="module_shortcut_not_supported">啟動器不支援桌面捷徑。</string>
     <string name="module_shortcut_created">已在桌面建立捷徑。</string>
     <string name="module_shortcut_updated">捷徑已更新。</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -205,7 +205,6 @@
     <string name="module_shortcut_title">Create shortcut</string>
     <string name="module_shortcut_name_label">Shortcut name</string>
     <string name="module_shortcut_icon_pick">Choose custom icon</string>
-    <string name="module_shortcut_add">Add shortcut</string>
     <string name="module_shortcut_not_supported">Launcher does not support desktop shortcuts.</string>
     <string name="module_shortcut_created">Shortcut created on desktop.</string>
     <string name="module_shortcut_updated">Shortcut updated.</string>


### PR DESCRIPTION
This PR adds long-click support to module action buttons for creating shortcuts directly.

## Changes
- Replaced IconButton with Box + combinedClickable for action/WebUI buttons
- Short click: execute action / open WebUI (unchanged)
- Long click: create shortcut of corresponding type
- Removed redundant 'add shortcut' button

## Benefits
- More intuitive UX: long-press on the button you want to create shortcut for
- Cleaner UI: no extra button needed
- Consistent with common mobile interaction patterns

## Demo
Long-click on action button → creates action shortcut
Long-click on WebUI button → creates WebUI shortcut