### PR TITLE
kernel: Fix RLIMIT_NPROC leak on root escape

### DIFF
--- a/kernel/app_profile.c
+++ b/kernel/app_profile.c
@@ -120,7 +120,6 @@ void escape_with_root_profile(void)
     if (cred->euid.val == 0) {
         pr_warn("Already root, don't escape!\n");
         goto out_abort_creds;
-        return;
     }
 
     ksu_get_root_profile(cred->uid.val, &profile);


### PR DESCRIPTION
After `escape_to_root`, `cred->uid` changes, but `cred->user` and `cred->ucounts` remain unchanged. Because `cred->user` does not change, `commit_creds()` does not decrement the `ucounts` associated with the original UID.

When `execve` is executed afterwards, `cred->user` still does not change, but `cred->ucounts` changes. This happens because `cred->uid` is now different from `cred->ucounts->uid`. However, since `cred->user` is still unchanged, `commit_creds()` still does not decrement the original `ucounts`. After this point, it can never be decremented anymore, because `exit` will only decrease the `ucounts` of the new UID.

Since the original UID’s `ucounts` increases every time `su` is executed, it will eventually exceed the limit until it reaches the `rlimit` threshold.

This fixes https://github.com/tiann/KernelSU/issues/3214.