### PR TITLE
manager: Change jailbreak mode tag color to errorContainer for better…

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -222,8 +222,8 @@ private fun StatusCard(
                                     Spacer(Modifier.width(8.dp))
                                     StatusTag(
                                         label = stringResource(id = R.string.jailbreak_mode),
-                                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
-                                        backgroundColor = MaterialTheme.colorScheme.tertiaryContainer
+                                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                        backgroundColor = MaterialTheme.colorScheme.errorContainer
                                     )
                                 }
                             }


### PR DESCRIPTION
… visibility

The previous tertiaryContainer color was too subtle and blended with the working status card background. 
![IMG_20260314_213220](https://github.com/user-attachments/assets/a9f00168-3b2f-42eb-85c6-e33c831fb696)

Using errorContainer makes it more prominent and aligns with the temporary root nature of jailbreak mode, consistent with the warning semantics in the string resources.