### PR TITLE
ksud: magica: Delete ro.boot.selinux and compact after run

### DIFF
--- a/userspace/ksud/src/magica.rs
+++ b/userspace/ksud/src/magica.rs
@@ -101,7 +101,11 @@ pub fn disable_adb_root() -> Result<()> {
     rp.set("ro.adb.secure", "1")
         .context("Failed to set ro.adb.secure")?;
 
-    for prop in &["service.adb.root", "service.adb.tcp.port", "ro.boot.selinux"] {
+    for prop in &[
+        "service.adb.root",
+        "service.adb.tcp.port",
+        "ro.boot.selinux",
+    ] {
         info!("Restoring: resetprop --delete {prop}");
         let _ = rp.delete(prop);
         if let Ok(ctx) = sys_prop::get_context(prop) {


### PR DESCRIPTION
It comes from the cmdline exploit and get set by init. After we have a resetprop with compact support, this can be properly deleted.