### PR TITLE
ksud: fix the abnormal zygote PID after a soft reboot

### DIFF
--- a/userspace/ksud/Cargo.lock
+++ b/userspace/ksud/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "log",
  "nom",
  "prop-rs-android",
+ "rand",
  "regex-lite",
  "rust-embed",
  "rustix 1.1.4",

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -54,6 +54,7 @@ getopts = "0.2"
 ksuinit = { path = "../ksuinit" }
 adb_client = { git = "https://github.com/Kernel-SU/adb_client" }
 prop-rs-android = { git = "https://github.com/Kernel-SU/ksu_props" }
+rand = "0.10.0"
 
 [profile.release]
 strip = true

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -1,5 +1,5 @@
 use crate::module::{handle_updated_modules, prune_modules};
-use crate::utils::{is_safe_mode, switch_cgroups, switch_mnt_ns};
+use crate::utils::{is_safe_mode, switch_cgroups, switch_mnt_ns, set_next_pid};
 use crate::{
     assets, defs, ksucalls, metamodule, restorecon,
     utils::{self},
@@ -14,6 +14,7 @@ use rustix::process::{chdir, setpgid};
 use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout};
 use std::path::Path;
 use std::process::Command;
+use rand::RngExt;
 
 pub fn on_post_data_fs() -> Result<()> {
     ksucalls::report_post_fs_data();
@@ -275,6 +276,8 @@ pub fn soft_reboot() -> Result<()> {
     }
     info!("post-fs-data");
     on_post_data_fs()?;
+    info!("set zygote pid");
+    set_next_pid(rand::rng().random_range(1720..=1780));
     info!("start");
     let status = Command::new("start").status().context("start failed")?;
     if !status.success() {

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -233,3 +233,38 @@ pub fn uninstall(magiskboot_path: Option<PathBuf>) -> Result<()> {
     Command::new("reboot").spawn()?;
     Ok(())
 }
+
+pub fn get_latest_pid() -> i32 {
+    let handle = std::thread::spawn(|| unsafe {
+        libc::syscall(libc::SYS_gettid) as i32
+    });
+    
+    handle.join().unwrap_or_else(|_| unsafe { 
+        libc::syscall(libc::SYS_gettid) as i32 
+    })
+}
+
+pub fn set_next_pid(target_pid: i32) {
+    let mut last_pid = get_latest_pid();
+    let mut wrapped = target_pid > last_pid;
+    loop {
+        let handle = std::thread::spawn(|| unsafe {
+            libc::syscall(libc::SYS_gettid) as i32
+        });
+        match handle.join() {
+            Result::Ok(current_pid) => {
+                if current_pid < last_pid {
+                    wrapped = true;
+                }
+
+                if wrapped && current_pid >= target_pid - 1 {
+                    break;
+                }
+                last_pid = current_pid;
+            }
+            Result::Err(_) => {
+                std::thread::sleep(std::time::Duration::from_micros(500));
+            }
+        }
+    }
+}


### PR DESCRIPTION
`set_next_pid` simulates the behavior of writing to `/proc/sys/kernel/ns_last_pid` in user space