### PR TITLE
Kconfig: clarify ARM64-only support

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -1,8 +1,15 @@
 menu "KernelSU"
 
+if !ARM64
+comment "-------------------------------------------------------"
+comment "Please note:                                           "
+comment "KernelSU only supports ARM64 architecture now.         "
+comment "-------------------------------------------------------"
+endif
+
 config KSU
 	tristate "KernelSU function support"
-	depends on KPROBES && EXT4_FS
+	depends on KPROBES && EXT4_FS && ARM64
 	default y
 	help
 	  Enable kernel-level root privileges on Android System.


### PR DESCRIPTION
Add a clear notice in Kconfig to indicate that KernelSU currently only supports ARM64 architecture.

This helps prevent confusion when building on unsupported architectures. No functional changes are introduced, and no architecture-specific code paths are modified.