### PR TITLE
supercall: perform free_pid() calls for kernel 6.15+

### DIFF
--- a/kernel/supercalls.c
+++ b/kernel/supercalls.c
@@ -629,6 +629,10 @@ static int add_try_umount(void __user *arg)
 static int do_set_init_pgrp(void __user *arg)
 {
     int err;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    struct pid *pids[PIDTYPE_MAX] = { 0 };
+#endif
+
     write_lock_irq(&tasklist_lock);
     struct task_struct *p = current->group_leader;
     struct pid *init_group = task_pgrp(&init_task);
@@ -638,11 +642,20 @@ static int do_set_init_pgrp(void __user *arg)
         goto out;
 
     err = 0;
-    if (task_pgrp(p) != init_group)
+    if (task_pgrp(p) != init_group) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+        change_pid(pids, p, PIDTYPE_PGID, init_group);
+#else
         change_pid(p, PIDTYPE_PGID, init_group);
+#endif
+    }
 
 out:
     write_unlock_irq(&tasklist_lock);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    free_pids(pids);
+#endif
+
     return err;
 }
 


### PR DESCRIPTION
This is required to be able to build on kernel 6.15+, based on this commit:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.15&id=7903f907a226058ed99f86e9924e082aea57fc45