### PR TITLE
manager: Skip service start if root is available

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/magica/BootCompletedReceiver.java
+++ b/manager/app/src/main/java/me/weishu/kernelsu/magica/BootCompletedReceiver.java
@@ -7,6 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import me.weishu.kernelsu.ui.util.KsuCliKt;
+
 public class BootCompletedReceiver extends BroadcastReceiver {
 
     @Override
@@ -20,6 +22,7 @@ public class BootCompletedReceiver extends BroadcastReceiver {
                 && !"me.weishu.kernelsu.magica.LAUNCH".equals(action)) {
             return;
         }
+        if (KsuCliKt.rootAvailable()) return;
         try {
             context.startService(new Intent(context, MagicaService.class));
             Log.i(TAG, "MagicaService started from boot action: " + action);


### PR DESCRIPTION
This prevents magica gets accidentally run on soft reboot.