### PR TITLE
kernel: fix compile for x86-64 linux kernel v6.13-

### DIFF
--- a/kernel/hook/patch_memory.h
+++ b/kernel/hook/patch_memory.h
@@ -9,12 +9,18 @@
 #include <linux/types.h>
 #include "linux/version.h"
 
+#ifdef __aarch64__
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 #include "asm/text-patching.h" // IWYU pragma: keep
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
 #include "asm/patching.h" // IWYU pragma: keep
 #else
 #include "asm/insn.h" // IWYU pragma: keep
+#endif
+#elif __x86_64__
+#include "asm/text-patching.h" // IWYU pragma: keep
+#else
+#error "Unsupported arch"
 #endif
 
 #define KSU_PATCH_TEXT_FLUSH_DCACHE 1


### PR DESCRIPTION
patch_memory.h trying include
asm/text-patching.h when kernel version 6.13+
asm/patching.h when kernel version 6.13 - 5.14,
asm/insn.h when kernel version 5.14-

But their are aarch64 only headers,
in x86-64, we should always use asm/text-patching.h Or you will receive

In file included from drivers/kernelsu/hook/x86_64/syscall_hook.c:8: drivers/kernelsu/hook/x86_64/../patch_memory.h:15:10: fatal error: 'asm/patching.h' file not found
   15 | #include "asm/patching.h" // IWYU pragma: keep
      |          ^~~~~~~~~~~~~~~~
1 error generated.

when you are build Linux kernel 6.13- x86-64

Ref:
https://github.com/torvalds/linux/commit/0c3beacf681ec897e0b36685a9b49d01f5cb2dfb