### PR TITLE
Fix include paths in kernel Kbuild file, fix GKI build

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -44,7 +44,7 @@ kernelsu-objs += supercall/supercall.o
 
 ccflags-y += -I$(srctree)/security/selinux -I$(srctree)/security/selinux/include
 ccflags-y += -I$(objtree)/security/selinux -include $(srctree)/include/uapi/asm-generic/errno.h
-ccflags-y += -I$(src) -I$(src)/include
+ccflags-y += -I$(srctree)/$(src) -I$(srctree)/$(src)/include
 
 obj-$(CONFIG_KSU) += kernelsu.o
 


### PR DESCRIPTION
fix the wrong include path which causes Clang cannot find correct .h include path while building KernelSU for Android GKI

在编译内核时因为Kbuild中错误的.h文件导入路径而导致问题: #3356 
该PR可解决此问题, 已在Android Clang r584948b分支的Clang测试通过