### PR TITLE
syscall_hook: Fix building on kernel 6.6 and below

### DIFF
--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -7,6 +7,12 @@
 #include <linux/slab.h>
 #include <trace/events/syscalls.h>
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
+#include <linux/compat.h>
+#include <linux/sched/task_stack.h>
+#endif
+
 #include "arch.h"
 #include "klog.h" // IWYU pragma: keep
 #include "hook/syscall_hook_manager.h"


### PR DESCRIPTION
Add some headers to fix the following errors:
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/hook/syscall_hook_manager.c:93:18: error: call to undeclared function 'in_compat_syscall'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   93 |     if (unlikely(in_compat_syscall()))
      |                  ^
make[5]: cannot enforce load limit: getloadavg: No such file or directory
  CC [M]  drivers/pcmcia/socket_sysfs.o
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/hook/syscall_hook_manager.c:103:40: error: call to undeclared function 'task_stack_page'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  103 |         struct pt_regs *current_regs = task_pt_regs(current);
      |                                        ^
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/arch/x86/include/asm/processor.h:651:39: note: expanded from macro 'task_pt_regs'
  651 |         unsigned long __ptr = (unsigned long)task_stack_page(task);     \
      |                                              ^
2 errors generated.