### PR TITLE
kernel: Fix building sulog on kernel 6.1 & x86_64

### DIFF
--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -9,6 +9,11 @@
 #include <linux/string.h>
 #include <linux/uaccess.h>
 
+#include <linux/version.h>
+#if defined(__x86_64__) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+#include <linux/mm.h>
+#endif
+
 #include "feature/sulog.h"
 #include "infra/event_queue.h"
 #include "klog.h" // IWYU pragma: keep


### PR DESCRIPTION
untagged_addr used to be a marco on mm.h for x86

Fix the following error:

/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/sulog/event.c:124:63: error: call to undeclared function 'untagged_addr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  124 |     ret = strncpy_from_user_nofault(dst, (const void __user *)untagged_addr((unsigned long)filename_user), dst_len)  LD [M]  drivers/dca/dca.o
;
      |                                                               ^
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/sulog/event.c:124:42: warning: cast to 'const void *' from smaller integer type 'int' [-Wint-to-void-pointer-cast]
  124 |     ret = strncpy_from_user_nofault(dst, (const void __user *)untagged_addr((unsigned long)filename_user), dst_len);
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CC [M]  drivers/hwmon/lm85.o
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/sulog/event.c:164:65: error: call to undeclared function 'untagged_addr'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  164 |             strncpy_from_user_nofault(arg, (const void __user *)untagged_addr((unsigned long)arg_user), sizeof(arg));
      |                                                                 ^
/bbd007/hmtheboy154/lineage21-tv/kernel/x86/common/drivers/kernelsu/sulog/event.c:164:44: warning: cast to 'const void *' from smaller integer type 'int' [-Wint-to-void-pointer-cast]
  164 |             strncpy_from_user_nofault(arg, (const void __user *)untagged_addr((unsigned long)arg_user), sizeof(arg));
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings and 2 errors generated.