### PR TITLE
fix: add CORS header to ksu://icon/ responses to allow programmatic image loading

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewHelper.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebViewHelper.kt
@@ -111,7 +111,11 @@ internal suspend fun prepareWebView(
                             if (icon != null) {
                                 val stream = java.io.ByteArrayOutputStream()
                                 icon.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, stream)
-                                return WebResourceResponse("image/png", null, java.io.ByteArrayInputStream(stream.toByteArray()))
+                                return WebResourceResponse(
+                                    "image/png", null, 200, "OK",
+                                    mapOf("Access-Control-Allow-Origin" to "*"),
+                                    java.io.ByteArrayInputStream(stream.toByteArray())
+                                )
                             }
                         }
                     }


### PR DESCRIPTION
## Problem

Module WebUIs built with Kotlin/Wasm (or any framework that needs to fetch `ksu://icon/` programmatically via `XMLHttpRequest`) cannot load app icons due to CORS policy:

```
Access to XMLHttpRequest at 'ksu://icon/com.example.app' from origin
'https://mui.kernelsu.org' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

This means Kotlin/Wasm-based WebUIs currently have **no way to display app icons** — the only workaround is a text-based placeholder.

## Root Cause

Per [Chromium's WebView CORS documentation](https://github.com/chromium/chromium/blob/main/android_webview/docs/cors-and-webview-api.md), custom URL schemes are treated as opaque origins. Resources served via `shouldInterceptRequest` over a custom scheme require `Access-Control-Allow-Origin: *` in the response for programmatic access (XHR, canvas `toDataURL`, etc.) to work.

Note: `<img src="ksu://icon/...">` for pure display still works without this header.

## Fix

Add `Access-Control-Allow-Origin: *` to the `WebResourceResponse` for `ksu://icon/` requests.

## Security

`ksu://icon/` only serves read-only PNG image data. Given that `ksu.exec()` already grants arbitrary root command execution to the WebUI, this change poses no meaningful security risk.