### PR TITLE
userspace: improve module loading and ksud CLI

### DIFF
--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -458,7 +458,7 @@ pub struct BootPatchArgs {
     pub module: Option<PathBuf>,
 
     /// init to be replaced
-    #[arg(short, long, requires("module"))]
+    #[arg(short, long)]
     pub init: Option<PathBuf>,
 
     /// will use another slot when boot image is not specified

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -199,6 +199,9 @@ enum Debug {
         module: PathBuf,
     },
 
+    /// Benchmark parsing /proc/kallsyms
+    Kallsyms,
+
     /// Process mark management
     Mark {
         #[command(subcommand)]
@@ -684,6 +687,7 @@ pub fn run() -> Result<()> {
                 utils::ensure_binary(&path, &data, false)
             }
             Debug::Insmod { module } => debug::insmod(&module),
+            Debug::Kallsyms => debug::kallsyms(),
             Debug::Mark { command } => match command {
                 MarkCommand::Get { pid } => debug::mark_get(pid),
                 MarkCommand::Mark { pid } => debug::mark_set(pid),

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -45,6 +45,10 @@ enum Commands {
         #[arg(long, default_missing_value = "5555", num_args = 0..=1)]
         magica: Option<u16>,
 
+        /// Pass allow_shell=1 when loading kernelsu.ko
+        #[arg(long)]
+        allow_shell: bool,
+
         /// Restore adb properties after magica late-load
         #[arg(long)]
         post_magica: bool,
@@ -60,6 +64,15 @@ enum Commands {
 
     /// Emulate system reboot
     SoftReboot,
+
+    /// Load a kernel module with kallsyms access
+    Insmod {
+        /// kernel module path
+        module: PathBuf,
+        /// module load parameters (e.g. key=val key2=val2)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        params: Vec<String>,
+    },
 
     /// Install KernelSU userspace component to system
     Install {
@@ -192,15 +205,6 @@ enum Debug {
         /// destination file path
         path: PathBuf,
     },
-
-    /// Load a kernel module from disk
-    Insmod {
-        /// kernel module path
-        module: PathBuf,
-    },
-
-    /// Benchmark parsing /proc/kallsyms
-    Kallsyms,
 
     /// Process mark management
     Mark {
@@ -494,6 +498,8 @@ pub fn run() -> Result<()> {
 
         Commands::SoftReboot => init_event::soft_reboot(),
 
+        Commands::Insmod { module, params } => debug::insmod(&module, &params),
+
         Commands::Module { command } => {
             utils::switch_mnt_ns(1)?;
             match command {
@@ -612,17 +618,18 @@ pub fn run() -> Result<()> {
         },
         Commands::LateLoad {
             magica,
+            allow_shell,
             post_magica,
             kmi,
             package_name,
         } => {
             if let Some(port) = magica {
-                return crate::magica::run(port, &package_name).map_err(|e| {
+                return crate::magica::run(port, &package_name, allow_shell).map_err(|e| {
                     error!("Error running magica: {e}");
                     e
                 });
             }
-            let result = crate::late_load::run(&package_name, kmi);
+            let result = crate::late_load::run(&package_name, kmi, allow_shell);
             if post_magica {
                 info!("Restoring adb properties (post-magica cleanup)...");
                 if let Err(e) = crate::magica::disable_adb_root() {
@@ -686,8 +693,6 @@ pub fn run() -> Result<()> {
                 let data = assets::get_asset_data(&name)?;
                 utils::ensure_binary(&path, &data, false)
             }
-            Debug::Insmod { module } => debug::insmod(&module),
-            Debug::Kallsyms => debug::kallsyms(),
             Debug::Mark { command } => match command {
                 MarkCommand::Get { pid } => debug::mark_get(pid),
                 MarkCommand::Mark { pid } => debug::mark_set(pid),

--- a/userspace/ksud/src/debug.rs
+++ b/userspace/ksud/src/debug.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Ok, Result, bail, ensure};
 use std::{
+    ffi::CString,
     fs,
     path::{Path, PathBuf},
     process::Command,
-    time::Instant,
 };
 
 use crate::ksucalls;
@@ -51,33 +51,18 @@ pub fn set_manager(pkg: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn insmod(module: &Path) -> Result<()> {
+pub fn insmod(module: &Path, params: &[String]) -> Result<()> {
     let module = module
         .canonicalize()
         .with_context(|| format!("resolve module path failed: {}", module.display()))?;
     let module_data =
         fs::read(&module).with_context(|| format!("read module failed: {}", module.display()))?;
+    let cparams = CString::new(params.join(" "))?;
 
-    ksuinit::load_module(&module_data)
+    ksuinit::load_module(&module_data, &cparams)
         .with_context(|| format!("load module failed: {}", module.display()))?;
 
     println!("Loaded kernel module: {}", module.display());
-    Ok(())
-}
-
-pub fn kallsyms() -> Result<()> {
-    let started = Instant::now();
-    let symbols = ksuinit::parse_kallsyms().context("parse kallsyms failed")?;
-    let elapsed = started.elapsed();
-
-    println!("kallsyms parse result:");
-    println!(
-        "  elapsed: {}.{:03} ms",
-        elapsed.as_millis(),
-        elapsed.subsec_micros() % 1000
-    );
-    println!("  symbol_count: {}", symbols.len());
-
     Ok(())
 }
 

--- a/userspace/ksud/src/debug.rs
+++ b/userspace/ksud/src/debug.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Command,
+    time::Instant,
 };
 
 use crate::ksucalls;
@@ -61,6 +62,22 @@ pub fn insmod(module: &Path) -> Result<()> {
         .with_context(|| format!("load module failed: {}", module.display()))?;
 
     println!("Loaded kernel module: {}", module.display());
+    Ok(())
+}
+
+pub fn kallsyms() -> Result<()> {
+    let started = Instant::now();
+    let symbols = ksuinit::parse_kallsyms().context("parse kallsyms failed")?;
+    let elapsed = started.elapsed();
+
+    println!("kallsyms parse result:");
+    println!(
+        "  elapsed: {}.{:03} ms",
+        elapsed.as_millis(),
+        elapsed.subsec_micros() % 1000
+    );
+    println!("  symbol_count: {}", symbols.len());
+
     Ok(())
 }
 

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use log::{info, warn};
+use rustix::cstr;
 use std::process::Command;
 
 use crate::module::{handle_updated_modules, prune_modules};
@@ -34,7 +35,7 @@ fn dump_process_info(label: &str) {
     );
 }
 
-pub fn run(package_name: &String, kmi: Option<String>) -> Result<()> {
+pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Result<()> {
     utils::daemonize(false)?;
     info!("late-load command triggered!");
     dump_process_info("late-load start");
@@ -57,7 +58,12 @@ pub fn run(package_name: &String, kmi: Option<String>) -> Result<()> {
 
         // 4. Load kernelsu.ko from memory with manual relocation
         info!("Loading kernelsu.ko for KMI {kmi}...");
-        ksuinit::load_module(&ko_data).context("Failed to load kernelsu.ko")?;
+        let params = if allow_shell {
+            cstr!("allow_shell=1")
+        } else {
+            cstr!("")
+        };
+        ksuinit::load_module(&ko_data, params).context("Failed to load kernelsu.ko")?;
         info!("kernelsu.ko loaded successfully!");
         dump_process_info("after load_module");
     }

--- a/userspace/ksud/src/magica.rs
+++ b/userspace/ksud/src/magica.rs
@@ -136,7 +136,7 @@ fn connect_to_device(port: u16) -> Result<ADBTcpDevice> {
     bail!("Failed to connect to ADB device after {MAX_RETRIES} attempts")
 }
 
-pub fn run(port: u16, package_name: &String) -> Result<()> {
+pub fn run(port: u16, package_name: &String, allow_shell: bool) -> Result<()> {
     enable_adb_root(port)?;
 
     let mut device = connect_to_device(port)?;
@@ -147,10 +147,12 @@ pub fn run(port: u16, package_name: &String) -> Result<()> {
     // The late-load process has full root + su domain and will:
     // 1. Load kernelsu.ko, enforce SELinux, run stage scripts
     // 2. Restore adb properties (disable adb root/tcp mode)
+    let allow_shell_arg = if allow_shell { " --allow-shell" } else { "" };
     let cmd = format!(
-        "{} late-load --post-magica --package-name {}",
+        "{} late-load --post-magica --package-name {}{}",
         self_path.display(),
-        package_name
+        package_name,
+        allow_shell_arg
     );
     info!("Executing '{cmd}' via adb shell...");
     let mut stdout = Vec::new();

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -1,6 +1,7 @@
 use std::io::{ErrorKind, Write};
 
 use anyhow::{Context, Result};
+use rustix::cstr;
 use rustix::fs::{Mode, symlink, unlink};
 use rustix::{
     fd::AsFd,
@@ -134,5 +135,11 @@ pub fn init() -> Result<()> {
 fn load_module_from_path(path: &str) -> Result<()> {
     anyhow::ensure!(rustix::process::getpid().is_init(), "Invalid process");
     let buffer = std::fs::read(path).with_context(|| format!("Cannot read file {}", path))?;
-    ksuinit::load_module(&buffer)
+    let params = if std::fs::exists("/ksu_allow_shell").unwrap_or(false) {
+        log::warn!("ksu allow shell at init!");
+        cstr!("allow_shell=1")
+    } else {
+        cstr!("")
+    };
+    ksuinit::load_module(&buffer, params)
 }

--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -3,7 +3,8 @@ use goblin::elf::{Elf, section_header, sym::Sym};
 use rustix::{cstr, system::init_module};
 use scroll::{Pwrite, ctx::SizeWith};
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
 
 struct Kptr {
     value: String,
@@ -23,31 +24,66 @@ impl Drop for Kptr {
     }
 }
 
-fn parse_kallsyms() -> Result<HashMap<String, u64>> {
-    let _dontdrop = Kptr::new()?;
+pub struct KptrOwnedIter<I> {
+    _kptr: Kptr,
+    iter: I,
+}
 
-    let allsyms = fs::read_to_string("/proc/kallsyms")?
+impl<I: Iterator> Iterator for KptrOwnedIter<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+pub fn kernel_symbols_iter() -> Result<impl Iterator<Item = (String, u64)>> {
+    let kptr = Kptr::new()?;
+
+    let iter = BufReader::new(File::open("/proc/kallsyms")?)
         .lines()
-        .map(|line| line.split_whitespace())
-        .filter_map(|mut splits| {
-            splits
-                .next()
-                .and_then(|addr| u64::from_str_radix(addr, 16).ok())
-                .and_then(|addr| splits.nth(1).map(|symbol| (symbol, addr)))
-        })
-        .map(|(symbol, addr)| {
-            (
-                symbol
-                    .find("$")
-                    .or_else(|| symbol.find(".llvm."))
-                    .map_or(symbol, |pos| &symbol[0..pos])
-                    .to_owned(),
-                addr,
-            )
-        })
-        .collect::<HashMap<_, _>>();
+        // https://github.com/torvalds/linux/blob/7f87a5ea75f011d2c9bc8ac0167e5e2d1adb1594/kernel/kallsyms.c#L727
+        // We can stop read as soon as we read all kernel symbols
+        .map_while(|line| {
+            line.ok().and_then(|line| {
+                let mut splits = line.split_whitespace();
+                splits
+                    .next()
+                    .and_then(|addr| u64::from_str_radix(addr, 16).ok())
+                    .and_then(|addr| {
+                        splits
+                            .nth(1)
+                            .take_if(|_| splits.next().is_none()) // stop at module symbols
+                            .map(|symbol| {
+                                (
+                                    symbol
+                                        .find("$")
+                                        .or_else(|| symbol.find(".llvm."))
+                                        .map(|pos| &symbol[0..pos])
+                                        .unwrap_or(symbol)
+                                        .to_owned(),
+                                    addr,
+                                )
+                            })
+                    })
+            })
+        });
 
-    Ok(allsyms)
+    Ok(KptrOwnedIter { _kptr: kptr, iter })
+}
+
+pub fn for_each_kernel_symbols<F: FnMut(&(String, u64)) -> Result<bool>>(mut f: F) -> Result<()> {
+    for item in kernel_symbols_iter()? {
+        if !f(&item)? {
+            break;
+        }
+    }
+    Ok(())
+}
+
+/// Parse `/proc/kallsyms` and return a symbol -> address map.
+pub fn parse_kallsyms() -> Result<HashMap<String, u64>> {
+    Ok(kernel_symbols_iter()?.collect::<HashMap<_, _>>())
 }
 
 /// Relocate undefined symbols in an ELF kernel module buffer using /proc/kallsyms,
@@ -55,11 +91,10 @@ fn parse_kallsyms() -> Result<HashMap<String, u64>> {
 pub fn load_module(data: &[u8]) -> Result<()> {
     let mut buffer = data.to_vec();
     let elf = Elf::parse(&buffer)?;
+    let ctx = *elf.syms.ctx();
 
-    let kernel_symbols = parse_kallsyms().context("Cannot parse kallsyms")?;
-
-    let mut modifications = Vec::new();
-    for (index, mut sym) in elf.syms.iter().enumerate() {
+    let mut unresolved_symbols: HashMap<String, (Sym, usize)> = HashMap::new();
+    for (index, sym) in elf.syms.iter().enumerate() {
         if index == 0 {
             continue;
         }
@@ -73,19 +108,27 @@ pub fn load_module(data: &[u8]) -> Result<()> {
         };
 
         let offset = elf.syms.offset() + index * Sym::size_with(elf.syms.ctx());
-        let Some(real_addr) = kernel_symbols.get(name) else {
-            log::warn!("Cannot find symbol: {}", &name);
-            continue;
-        };
-        sym.st_shndx = section_header::SHN_ABS as usize;
-        sym.st_value = *real_addr;
-        modifications.push((sym, offset));
+        unresolved_symbols.insert(name.to_owned(), (sym, offset));
     }
 
-    let ctx = *elf.syms.ctx();
-    for ele in modifications {
-        buffer.pwrite_with(ele.0, ele.1, ctx)?;
+    if !unresolved_symbols.is_empty() {
+        for_each_kernel_symbols(|(symbol, addr)| {
+            if let Some((mut sym, offset)) = unresolved_symbols.remove(symbol) {
+                sym.st_shndx = section_header::SHN_ABS as usize;
+                sym.st_value = *addr;
+                log::debug!("{} -> {:x}", symbol, *addr);
+                buffer.pwrite_with(sym, offset, ctx)?;
+            }
+
+            Ok(!unresolved_symbols.is_empty())
+        })
+        .context("Cannot parse kallsyms")?;
     }
+
+    for name in unresolved_symbols.keys() {
+        log::warn!("Cannot find symbol: {}", name);
+    }
+
     let param = if fs::exists("/ksu_allow_shell").unwrap_or(false) {
         log::warn!("ksu allow shell at init!");
         cstr!("allow_shell=1")

--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
 use goblin::elf::{Elf, section_header, sym::Sym};
-use rustix::{cstr, system::init_module};
+use rustix::system::init_module;
 use scroll::{Pwrite, ctx::SizeWith};
 use std::collections::HashMap;
+use std::ffi::CStr;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 
@@ -81,14 +82,9 @@ pub fn for_each_kernel_symbols<F: FnMut(&(String, u64)) -> Result<bool>>(mut f: 
     Ok(())
 }
 
-/// Parse `/proc/kallsyms` and return a symbol -> address map.
-pub fn parse_kallsyms() -> Result<HashMap<String, u64>> {
-    Ok(kernel_symbols_iter()?.collect::<HashMap<_, _>>())
-}
-
 /// Relocate undefined symbols in an ELF kernel module buffer using /proc/kallsyms,
 /// then load it via init_module syscall.
-pub fn load_module(data: &[u8]) -> Result<()> {
+pub fn load_module(data: &[u8], params: &CStr) -> Result<()> {
     let mut buffer = data.to_vec();
     let elf = Elf::parse(&buffer)?;
     let ctx = *elf.syms.ctx();
@@ -129,13 +125,7 @@ pub fn load_module(data: &[u8]) -> Result<()> {
         log::warn!("Cannot find symbol: {}", name);
     }
 
-    let param = if fs::exists("/ksu_allow_shell").unwrap_or(false) {
-        log::warn!("ksu allow shell at init!");
-        cstr!("allow_shell=1")
-    } else {
-        cstr!("")
-    };
-    init_module(&buffer, param).context("init_module failed.")?;
+    init_module(&buffer, params).context("init_module failed.")?;
     Ok(())
 }
 

--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -112,7 +112,6 @@ pub fn load_module(data: &[u8], params: &CStr) -> Result<()> {
             if let Some((mut sym, offset)) = unresolved_symbols.remove(symbol) {
                 sym.st_shndx = section_header::SHN_ABS as usize;
                 sym.st_value = *addr;
-                log::debug!("{} -> {:x}", symbol, *addr);
                 buffer.pwrite_with(sym, offset, ctx)?;
             }
 


### PR DESCRIPTION
- speed up manual relocation by scanning `/proc/kallsyms` only once, resolving only the undefined symbols actually needed by the module and stop kallsyms iteration early
- move `ksud debug insmod` to top-level `ksud insmod` and making it accept trailing module parameters
- add `--allow-shell` to `ksud late-load` and `ksud magica`
- boot-patch: `-i` no longer requires `-m`
