### PR TITLE
kernel: don't call path_put when kern_path failed

### DIFF
--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -57,6 +57,7 @@ static long is_libadbroot_ok()
         } else {
             pr_err("access libadbroot.so failed: %ld, skip adb root\n", ret);
         }
+        return ret;
     } else {
         ret = 1;
     }


### PR DESCRIPTION
We shouldn't call path_put when kern_path failed,
because kern_path failed, we will use an uninitialized memory for path
```c
int kern_path(const char *name, unsigned int flags, struct path *path)
{
	struct nameidata nd;
	int res = do_path_lookup(AT_FDCWD, name, flags, &nd);
	if (!res)
		*path = nd.path;
	return res;
}
```
and, path_put function will directly call dput for "path"
```c
/**
 * path_put - put a reference to a path
 * @path: path to put the reference to
 *
 * Given a path decrement the reference count to the dentry and the vfsmount.
 */
void path_put(struct path *path)
{
	dput(path->dentry);
	mntput(path->mnt);
}
EXPORT_SYMBOL(path_put);
```
But because "path" is uninitialized, so we will do undefined behavior or directly let kernel crash for example, here is an kernel panic dump
```panic
[    9.013980]  (0)[796:init]KernelSU: libadbroot.so not exists, skip adb root. Please run ksud install
[    9.014009]  (0)[796:init]Unable to handle kernel paging request at virtual address c058fea4
[   10.016421] -(0)[796:init][<c021dfe0>] (__do_kernel_fault.part.0) from [<c02183ac>] (do_translation_fault+0x0/0x198)
[   10.016426] -(0)[796:init] r7:00000a0e r3:d6541e40
[   10.016434] -(0)[796:init][<c0217fb8>] (do_page_fault) from [<c0201360>] (do_DataAbort+0x84/0x158)
[   10.016441] -(0)[796:init] r10:c181223c r9:c058fea4 r8:00000a0e r7:d6541e40 r6:c181215c r5:c1804548
[   10.016445] -(0)[796:init] r4:d6540000
[   10.016451] -(0)[796:init][<c02012dc>] (do_DataAbort) from [<c020ea70>] (__dabt_svc+0x50/0x80)
[   10.016456] -(0)[796:init]Exception stack(0xd6541e40 to 0xd6541e88)
[   10.016463] -(0)[796:init]1e40: c058fea4 de72adbc e5a8e004 e5a7e004 c058fe54 c058fea4 00080040 b6ed60a0
[   10.016470] -(0)[796:init]1e60: c0209524 d6540000 00000000 d6541e9c d6541ea0 d6541e90 c03cc39c c0ef4ba0
[   10.016474] -(0)[796:init]1e80: a00f0013 ffffffff
[   10.016481] -(0)[796:init] r10:00000000 r9:d6540000 r8:c0209524 r7:d6541e74 r6:ffffffff r5:a00f0013
[   10.016485] -(0)[796:init] r4:c0ef4ba0
[   10.016493] -(0)[796:init][<c0ef4b70>] (_raw_spin_lock) from [<c03cc39c>] (dput+0x118/0x2b4)
[   10.016500] -(0)[796:init][<c03cc284>] (dput) from [<c03bce34>] (path_put+0x18/0x24)
[   10.016507] -(0)[796:init] r9:d6540000 r8:c0209524 r7:b6ed60a0 r6:d95e7010 r5:d6541f80 r4:d6541efc
[   10.016516] -(0)[796:init][<c03bce1c>] (path_put) from [<c0c44400>] (ksu_adb_root_handle_execve_manual+0x10c/0x4c8)
[   10.016521] -(0)[796:init] r4:c1804548 r3:00040975
[   10.016528] -(0)[796:init][<c0c442f4>] (ksu_adb_root_handle_execve_manual) from [<c0c43b30>] (ksu_handle_execve+0x108/0x18c)

(removed unrelated panic dumps)
```