### PR TITLE
manager: adb_root: load our ksurc if possible

### DIFF
--- a/manager/app/src/main/cpp/adbroot.cc
+++ b/manager/app/src/main/cpp/adbroot.cc
@@ -1,6 +1,8 @@
 #include <string>
 #include <dlfcn.h>
 #include <cstdlib>
+#include <unistd.h>
+#include <vector>
 
 // Skip drop privileges
 // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/main.cpp;l=123;drc=3b74954ec50836e0c8faeed1877fefb1dc2de006
@@ -32,6 +34,55 @@ std::string GetProperty(const std::string &key, const std::string &default_value
     }
 
     return orig_fn(key, default_value);
+}
+
+// If user create ksurc, use ksurc instead of mkshrc
+// https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/shell_service.cpp;l=389-394
+extern "C" [[gnu::visibility("default"), gnu::used]]
+int execle(const char *pathname, const char *arg, ...) {
+    std::vector<const char *> argv_list;
+    va_list va;
+    va_start(va, arg);
+
+    // start dump argv
+    if (arg != nullptr) {
+        argv_list.push_back(arg);
+        const char *next;
+        while ((next = va_arg(va, const char*)) != nullptr) {
+            argv_list.push_back(next);
+        }
+    }
+    argv_list.push_back(nullptr);
+
+    char *const *old_envp = va_arg(va, char* const*);
+    va_end(va);
+
+    // start dump envp
+    std::vector<const char *> env_list;
+    bool ksurc_exists = (access("/data/adb/ksu/.ksurc", F_OK) == 0);
+    const char *ksu_env_str = "ENV=/data/adb/ksu/.ksurc";
+
+    if (old_envp != nullptr) {
+        for (size_t i = 0; old_envp[i] != nullptr; ++i) {
+            // skip original ENV in envp
+            // even there shouldn't exists in normal android, but let's still check it, avoid newer android/custom rom modify there
+            if (ksurc_exists && strncmp(old_envp[i], "ENV=", 4) == 0) {
+                continue;
+            }
+            env_list.push_back(old_envp[i]);
+        }
+    }
+
+    if (ksurc_exists) {
+        // push our ENV in here!!!
+        env_list.push_back(ksu_env_str);
+    }
+    env_list.push_back(nullptr);
+
+    // skip origin execle, because we already completed everything of execle
+    return execve(pathname,
+                  const_cast<char *const *>(argv_list.data()),
+                  const_cast<char *const *>(env_list.data()));
 }
 
 // skip setcon

--- a/manager/app/src/main/cpp/adbroot.cc
+++ b/manager/app/src/main/cpp/adbroot.cc
@@ -36,7 +36,7 @@ std::string GetProperty(const std::string &key, const std::string &default_value
     return orig_fn(key, default_value);
 }
 
-// If user create ksurc, use ksurc instead of mkshrc
+// If the user creates ksurc, use ksurc instead of mkshrc
 // https://cs.android.com/android/platform/superproject/+/android-latest-release:packages/modules/adb/daemon/shell_service.cpp;l=389-394
 extern "C" [[gnu::visibility("default"), gnu::used]]
 int execle(const char *pathname, const char *arg, ...) {


### PR DESCRIPTION
According from the [document](https://kernelsu.org/guide/hidden-features.html#ksurc), ksurc file is an way to customized rc file
I use this file to let root programs, (for example: my terminal app) using bash (/data/data/com.termux/files/usr/bin/bash)

But adb root feature don't load this file, it still using mkshrc file
So, it let me can't use bash, still using sh + mkshrc, i need to manually run su command to switch to bash context

here is my rc files:

/data/adb/ksu/.ksurc file
```sh
[ -f /data/data/com.termux/files/usr/bin/bash ] && /data/data/com.termux/files/usr/bin/bash --rcfile /data/adb/ksu/.bashrc
if [ $? -eq 0 ]; then exit; fi;
export ENV=/system/etc/mkshrc
sh
exit
```

/data/adb/ksu/.bashrc file
```sh
export PATH=$PATH:/data/data/com.termux/files/usr/bin
export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w \$\[\033[00m\] '
HOME=/data/adb/bashroot
cd $HOME
```