### PR TITLE
kernel: refactor allowlist

### DIFF
--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -91,15 +91,17 @@ void ksu_show_allow_list(void)
 struct app_profile *ksu_get_app_profile(uid_t uid)
 {
     struct perm_data *p = NULL;
+    bool found = false;
 
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid) {
             // found it, override it with ours
+            found = true;
             break;
         }
     }
 
-    if (!p)
+    if (!found)
         return NULL;
 
     if (!kref_get_unless_zero(&p->ref)) {

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -70,7 +70,7 @@ void ksu_show_allow_list(void)
     pr_info("ksu_show_allow_list\n");
     rcu_read_lock();
     list_for_each_entry_rcu (p, &allow_list, list) {
-        pr_info("uid :%d, allow: %d\n", p->profile.current_uid, p->profile.allow_su);
+        pr_info("uid :%d, allow: %d\n", p->profile.curr_uid, p->profile.allow_su);
     }
     rcu_read_unlock();
 }
@@ -82,7 +82,7 @@ bool ksu_get_app_profile(struct app_profile *profile)
 
     rcu_read_lock();
     list_for_each_entry_rcu (p, &allow_list, list) {
-        bool uid_match = profile->current_uid == p->profile.current_uid;
+        bool uid_match = profile->curr_uid == p->profile.curr_uid;
         if (uid_match) {
             // found it, override it with ours
             memcpy(profile, &p->profile, sizeof(*profile));
@@ -179,10 +179,10 @@ int ksu_set_app_profile(struct app_profile *profile)
 
     list_for_each_entry (p, &allow_list, list) {
         ++count;
-        if (profile->current_uid == p->profile.current_uid) {
+        if (profile->curr_uid == p->profile.curr_uid) {
             if (strcmp(profile->key, p->profile.key) != 0) {
-                pr_warn("ksu_set_app_profile: key changed: uid=%d orig=%s new=%s\n", profile->current_uid,
-                        p->profile.key, profile->key);
+                pr_warn("ksu_set_app_profile: key changed: uid=%d orig=%s new=%s\n", profile->curr_uid, p->profile.key,
+                        profile->key);
             }
             // found it, just override it all!
             np = (struct perm_data *)kzalloc(sizeof(struct perm_data), GFP_KERNEL);
@@ -213,10 +213,10 @@ int ksu_set_app_profile(struct app_profile *profile)
 
     memcpy(&p->profile, profile, sizeof(*profile));
     if (profile->allow_su) {
-        pr_info("set root profile, key: %s, uid: %d, gid: %d, context: %s\n", profile->key, profile->current_uid,
+        pr_info("set root profile, key: %s, uid: %d, gid: %d, context: %s\n", profile->key, profile->curr_uid,
                 profile->rp_config.profile.gid, profile->rp_config.profile.selinux_domain);
     } else {
-        pr_info("set app profile, key: %s, uid: %d, umount modules: %d\n", profile->key, profile->current_uid,
+        pr_info("set app profile, key: %s, uid: %d, umount modules: %d\n", profile->key, profile->curr_uid,
                 profile->nrp_config.profile.umount_modules);
     }
 
@@ -264,7 +264,7 @@ bool __ksu_is_allow_uid(uid_t uid)
 
     rcu_read_lock();
     list_for_each_entry_rcu (p, &allow_list, list) {
-        if (uid == p->profile.current_uid && p->profile.allow_su) {
+        if (uid == p->profile.curr_uid && p->profile.allow_su) {
             rcu_read_unlock();
             return true;
         }
@@ -285,10 +285,8 @@ bool __ksu_is_allow_uid_for_current(uid_t uid)
 
 bool ksu_uid_should_umount(uid_t uid)
 {
-#ifndef CONFIG_KSU_DISABLE_POLICY
-    struct app_profile profile = { .current_uid = uid };
-#endif
-    if (unlikely(is_uid_manager(uid))) {
+    struct app_profile profile = { .curr_uid = uid };
+    if (likely(ksu_is_manager_appid_valid()) && unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
         // we should not umount on manager!
         return false;
     }
@@ -337,7 +335,7 @@ void ksu_get_root_profile(uid_t uid, struct root_profile *profile)
 
     rcu_read_lock();
     list_for_each_entry_rcu (p, &allow_list, list) {
-        if (uid == p->profile.current_uid && p->profile.allow_su) {
+        if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {
                 memcpy(profile, &p->profile.rp_config.profile, sizeof(*profile));
                 rcu_read_unlock();
@@ -360,9 +358,9 @@ bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total,
     rcu_read_lock();
     list_for_each_entry_rcu (p, &allow_list, list) {
         // pr_info("get_allow_list uid: %d allow: %d\n", p->uid, p->allow);
-        if (p->profile.allow_su == allow && !is_uid_manager(p->profile.current_uid)) {
+        if (p->profile.allow_su == allow && !is_uid_manager(p->profile.curr_uid)) {
             if (j < length) {
-                array[j++] = p->profile.current_uid;
+                array[j++] = p->profile.curr_uid;
             }
             ++i;
         }
@@ -406,7 +404,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
 
     mutex_lock(&allowlist_mutex);
     list_for_each_entry (p, &allow_list, list) {
-        pr_info("save allow list, name: %s uid :%d, allow: %d\n", p->profile.key, p->profile.current_uid,
+        pr_info("save allow list, name: %s uid :%d, allow: %d\n", p->profile.key, p->profile.curr_uid,
                 p->profile.allow_su);
 
         kernel_write(fp, &p->profile, sizeof(p->profile), &off);
@@ -488,7 +486,7 @@ void ksu_load_allow_list()
             break;
         }
 
-        pr_info("load_allow_uid, name: %s, uid: %d, allow: %d\n", profile.key, profile.current_uid, profile.allow_su);
+        pr_info("load_allow_uid, name: %s, uid: %d, allow: %d\n", profile.key, profile.curr_uid, profile.allow_su);
         ksu_set_app_profile(&profile);
     }
 
@@ -510,7 +508,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
     bool modified = false;
     mutex_lock(&allowlist_mutex);
     list_for_each_entry_safe (np, n, &allow_list, list) {
-        uid_t uid = np->profile.current_uid;
+        uid_t uid = np->profile.curr_uid;
         char *package = np->profile.key;
         // we use this uid for special cases, don't prune it!
         bool is_preserved_uid = uid == KSU_APP_PROFILE_PRESERVE_UID;

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -500,11 +500,14 @@ void ksu_persistent_allow_list()
 {
     struct task_struct *tsk;
 
+    rcu_read_lock();
     tsk = get_pid_task(find_vpid(1), PIDTYPE_PID);
     if (!tsk) {
+        rcu_read_unlock();
         pr_err("save_allow_list find init task err\n");
         return;
     }
+    rcu_read_unlock();
 
     struct callback_head *cb = kzalloc(sizeof(struct callback_head), GFP_KERNEL);
     if (!cb) {

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -15,6 +15,7 @@
 #include <linux/version.h>
 #include <linux/compiler_types.h>
 #include <linux/hashtable.h>
+#include <linux/kref.h>
 
 #include "klog.h" // IWYU pragma: keep
 #include "ksu.h"
@@ -36,6 +37,10 @@ static DEFINE_MUTEX(allowlist_mutex);
 static struct root_profile default_root_profile;
 static struct non_root_profile default_non_root_profile;
 
+// protected by rcu
+static struct root_profile *current_default_root_profile;
+static struct non_root_profile *current_default_non_root_profile;
+
 static void __init init_default_profiles()
 {
     kernel_cap_t full_cap = CAP_FULL_SET;
@@ -48,17 +53,21 @@ static void __init init_default_profiles()
            sizeof(default_root_profile.capabilities.effective));
     default_root_profile.namespaces = KSU_NS_INHERITED;
     strcpy(default_root_profile.selinux_domain, KSU_DEFAULT_SELINUX_DOMAIN);
+    current_default_root_profile = &default_root_profile;
 
     // This means that we will umount modules by default!
     default_non_root_profile.umount_modules = true;
+    current_default_non_root_profile = &default_non_root_profile;
 }
 
 struct perm_data {
     struct hlist_node list;
     struct rcu_head rcu;
+    struct kref ref;
     struct app_profile profile;
 };
 
+// protected by rcu
 #define ALLOW_LIST_BITS 8
 static DEFINE_HASHTABLE(allow_list, ALLOW_LIST_BITS);
 static u16 allow_list_count = 0;
@@ -79,25 +88,23 @@ void ksu_show_allow_list(void)
     rcu_read_unlock();
 }
 
-bool ksu_get_app_profile(struct app_profile *profile)
+struct app_profile *ksu_get_app_profile(uid_t uid)
 {
     struct perm_data *p = NULL;
-    bool found = false;
 
-    rcu_read_lock();
-    hash_for_each_possible_rcu (allow_list, p, list, profile->curr_uid) {
-        bool uid_match = profile->curr_uid == p->profile.curr_uid;
-        if (uid_match) {
+    hash_for_each_possible_rcu (allow_list, p, list, uid) {
+        if (uid == p->profile.curr_uid) {
             // found it, override it with ours
-            memcpy(profile, &p->profile, sizeof(*profile));
-            found = true;
-            goto exit;
+            break;
         }
     }
 
-exit:
-    rcu_read_unlock();
-    return found;
+    if (!p)
+        return NULL;
+
+    kref_get(&p->ref);
+
+    return &p->profile;
 }
 
 static inline bool forbid_system_uid(uid_t uid)
@@ -157,9 +164,28 @@ static bool profile_valid(struct app_profile *profile)
     return true;
 }
 
+void release_perm_data(struct kref *ref)
+{
+    struct perm_data *p = container_of(ref, struct perm_data, ref);
+    kfree(p);
+}
+
+void put_perm_data(struct perm_data *data)
+{
+    kref_put(&data->ref, release_perm_data);
+}
+
+void put_perm_data_rcu(struct rcu_head *h)
+{
+    struct perm_data *p = container_of(h, struct perm_data, rcu);
+    put_perm_data(p);
+}
+
 int ksu_set_app_profile(struct app_profile *profile)
 {
-    struct perm_data *p = NULL, *np;
+    struct perm_data *p, *np;
+    struct root_profile *old_current_default_root_profile;
+    struct non_root_profile *old_current_default_non_root_profile;
     int result = 0;
 
     if (!profile_valid(profile)) {
@@ -192,9 +218,10 @@ int ksu_set_app_profile(struct app_profile *profile)
                 result = -ENOMEM;
                 goto out_unlock;
             }
+            kref_init(&np->ref);
             memcpy(&np->profile, profile, sizeof(*profile));
             hlist_replace_rcu(&p->list, &np->list);
-            kfree_rcu(p, rcu);
+            call_rcu(&p->rcu, put_perm_data_rcu);
             goto out;
         }
     }
@@ -206,14 +233,15 @@ int ksu_set_app_profile(struct app_profile *profile)
     }
 
     // not found, alloc a new node!
-    p = (struct perm_data *)kzalloc(sizeof(struct perm_data), GFP_KERNEL);
-    if (!p) {
+    np = (struct perm_data *)kzalloc(sizeof(struct perm_data), GFP_KERNEL);
+    if (!np) {
         pr_err("ksu_set_app_profile alloc failed\n");
         result = -ENOMEM;
         goto out_unlock;
     }
 
-    memcpy(&p->profile, profile, sizeof(*profile));
+    kref_init(&np->ref);
+    memcpy(&np->profile, profile, sizeof(*profile));
     if (profile->allow_su) {
         pr_info("set root profile, key: %s, uid: %d, gid: %d, context: %s\n", profile->key, profile->curr_uid,
                 profile->rp_config.profile.gid, profile->rp_config.profile.selinux_domain);
@@ -222,24 +250,34 @@ int ksu_set_app_profile(struct app_profile *profile)
                 profile->nrp_config.profile.umount_modules);
     }
 
-    hash_add_rcu(allow_list, &p->list, p->profile.curr_uid);
+    hash_add_rcu(allow_list, &np->list, np->profile.curr_uid);
     ++allow_list_count;
 
 out:
     result = 0;
 
     // check if the default profiles is changed, cache it to a single struct to accelerate access.
-    if (unlikely(!strcmp(profile->key, "$"))) {
-#ifndef CONFIG_KSU_DISABLE_POLICY
-        // set default non root profile
-        memcpy(&default_non_root_profile, &profile->nrp_config.profile, sizeof(default_non_root_profile));
-#endif
-    } else if (unlikely(!strcmp(profile->key, "#"))) {
-#ifndef CONFIG_KSU_DISABLE_POLICY
-        // set default root profile
-        // TODO: Do we really need this?
-        memcpy(&default_root_profile, &profile->rp_config.profile, sizeof(default_root_profile));
-#endif
+    if (unlikely(profile->curr_uid == KSU_APP_PROFILE_PRESERVE_UID)) {
+        if (unlikely(!strcmp(profile->key, "$"))) {
+            // set default non root profile
+            kref_get(&np->ref);
+            old_current_default_non_root_profile = current_default_non_root_profile;
+            current_default_non_root_profile = &np->profile.nrp_config.profile;
+            if (unlikely(old_current_default_non_root_profile != &default_non_root_profile)) {
+                p = container_of(old_current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
+                call_rcu(&p->rcu, put_perm_data_rcu);
+            }
+        } else if (unlikely(!strcmp(profile->key, "#"))) {
+            // set default root profile
+            // TODO: Do we really need this?
+            kref_get(&np->ref);
+            old_current_default_root_profile = current_default_root_profile;
+            current_default_root_profile = &np->profile.rp_config.profile;
+            if (unlikely(old_current_default_root_profile != &default_root_profile)) {
+                p = container_of(old_current_default_root_profile, struct perm_data, profile.rp_config.profile);
+                call_rcu(&p->rcu, put_perm_data_rcu);
+            }
+        }
     }
 
 out_unlock:
@@ -288,7 +326,8 @@ bool __ksu_is_allow_uid_for_current(uid_t uid)
 
 bool ksu_uid_should_umount(uid_t uid)
 {
-    struct app_profile profile = { .curr_uid = uid };
+    struct app_profile *profile;
+    bool res;
     if (likely(ksu_is_manager_appid_valid()) && unlikely(ksu_get_manager_appid() == uid % PER_USER_RANGE)) {
         // we should not umount on manager!
         return false;
@@ -300,26 +339,37 @@ bool ksu_uid_should_umount(uid_t uid)
 #ifdef CONFIG_KSU_DISABLE_POLICY
     return !__ksu_is_allow_uid(uid);
 #else
-    bool found = ksu_get_app_profile(&profile);
-    if (!found) {
+    rcu_read_lock();
+    profile = ksu_get_app_profile(uid);
+    if (!profile) {
         // no app profile found, it must be non root app
-        return default_non_root_profile.umount_modules;
-    }
-    if (profile.allow_su) {
+        res = current_default_non_root_profile->umount_modules;
+    } else if (profile->allow_su) {
         // if found and it is granted to su, we shouldn't umount for it
-        return false;
+        res = false;
     } else {
         // found an app profile
-        if (profile.nrp_config.use_default) {
-            return default_non_root_profile.umount_modules;
+        if (profile->nrp_config.use_default) {
+            res = current_default_non_root_profile->umount_modules;
         } else {
-            return profile.nrp_config.profile.umount_modules;
+            res = profile->nrp_config.profile.umount_modules;
         }
     }
+    rcu_read_unlock();
+
+    if (profile)
+        ksu_put_app_profile(profile);
+    return res;
 #endif
 }
 
-void ksu_get_root_profile(uid_t uid, struct root_profile *profile)
+void ksu_put_app_profile(struct app_profile *profile)
+{
+    struct perm_data *p = container_of(profile, struct perm_data, profile);
+    put_perm_data(p);
+}
+
+struct root_profile *ksu_get_root_profile(uid_t uid)
 {
 #ifdef CONFIG_KSU_DISABLE_POLICY
     (void)uid;
@@ -327,6 +377,7 @@ void ksu_get_root_profile(uid_t uid, struct root_profile *profile)
     return;
 #else
     struct perm_data *p = NULL;
+    struct root_profile *res = NULL;
 
     if (is_uid_manager(uid)) {
         goto use_default;
@@ -340,18 +391,33 @@ void ksu_get_root_profile(uid_t uid, struct root_profile *profile)
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {
-                memcpy(profile, &p->profile.rp_config.profile, sizeof(*profile));
-                rcu_read_unlock();
-                return;
+                kref_get(&p->ref);
+                res = &p->profile.rp_config.profile;
             }
+            break;
         }
     }
-    rcu_read_unlock();
 
-use_default:
-    // use default profile
-    memcpy(profile, &default_root_profile, sizeof(*profile));
+    if (unlikely(!res)) {
+    use_default:
+        res = current_default_root_profile;
+        if (unlikely(res != &default_root_profile)) {
+            p = container_of(res, struct perm_data, profile.rp_config.profile);
+            kref_get(&p->ref);
+        }
+    }
+
+    rcu_read_unlock();
+    return res;
 #endif
+}
+
+void ksu_put_root_profile(struct root_profile *profile)
+{
+    if (likely(profile == &default_root_profile))
+        return;
+    struct perm_data *p = container_of(profile, struct perm_data, profile.rp_config.profile);
+    put_perm_data(p);
 }
 
 bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total, bool allow)
@@ -522,7 +588,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
             modified = true;
             pr_info("prune uid: %d, package: %s\n", uid, package);
             hlist_del_rcu(&np->list);
-            kfree_rcu(np, rcu);
+            call_rcu(&np->rcu, put_perm_data_rcu);
             --allow_list_count;
         }
     }
@@ -547,9 +613,17 @@ void __exit ksu_allowlist_exit(void)
 
     // free allowlist
     mutex_lock(&allowlist_mutex);
+    if (unlikely(current_default_non_root_profile != &default_non_root_profile)) {
+        np = container_of(current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
+        call_rcu(&np->rcu, put_perm_data_rcu);
+    }
+    if (unlikely(current_default_root_profile != &default_root_profile)) {
+        np = container_of(current_default_root_profile, struct perm_data, profile.rp_config.profile);
+        call_rcu(&np->rcu, put_perm_data_rcu);
+    }
     hash_for_each_safe (allow_list, i, tmp, np, list) {
         hlist_del(&np->list);
-        kfree(np);
+        call_rcu(&np->rcu, put_perm_data_rcu);
     }
     mutex_unlock(&allowlist_mutex);
 }

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -266,8 +266,9 @@ out:
         if (unlikely(!strcmp(profile->key, "$"))) {
             // set default non root profile
             kref_get(&np->ref);
-            old_current_default_non_root_profile = current_default_non_root_profile;
-            current_default_non_root_profile = &np->profile.nrp_config.profile;
+            old_current_default_non_root_profile =
+                rcu_dereference_protected(current_default_non_root_profile, lockdep_is_held(&allowlist_mutex));
+            rcu_assign_pointer(current_default_non_root_profile, &np->profile.nrp_config.profile);
             if (unlikely(old_current_default_non_root_profile != &default_non_root_profile)) {
                 p = container_of(old_current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
                 put_perm_data_rcu(p);
@@ -276,8 +277,9 @@ out:
             // set default root profile
             // TODO: Do we really need this?
             kref_get(&np->ref);
-            old_current_default_root_profile = current_default_root_profile;
-            current_default_root_profile = &np->profile.rp_config.profile;
+            old_current_default_root_profile =
+                rcu_dereference_protected(current_default_root_profile, lockdep_is_held(&allowlist_mutex));
+            rcu_assign_pointer(current_default_root_profile, &np->profile.rp_config.profile);
             if (unlikely(old_current_default_root_profile != &default_root_profile)) {
                 p = container_of(old_current_default_root_profile, struct perm_data, profile.rp_config.profile);
                 put_perm_data_rcu(p);

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -164,18 +164,18 @@ static bool profile_valid(struct app_profile *profile)
     return true;
 }
 
-void release_perm_data(struct kref *ref)
+static void release_perm_data(struct kref *ref)
 {
     struct perm_data *p = container_of(ref, struct perm_data, ref);
     kfree(p);
 }
 
-void put_perm_data(struct perm_data *data)
+static void put_perm_data(struct perm_data *data)
 {
     kref_put(&data->ref, release_perm_data);
 }
 
-void put_perm_data_rcu(struct rcu_head *h)
+static void put_perm_data_rcu(struct rcu_head *h)
 {
     struct perm_data *p = container_of(h, struct perm_data, rcu);
     put_perm_data(p);
@@ -379,6 +379,7 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
     struct perm_data *p = NULL;
     struct root_profile *res = NULL;
 
+    rcu_read_lock();
     if (is_uid_manager(uid)) {
         goto use_default;
     }
@@ -387,7 +388,6 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
         goto use_default;
     }
 
-    rcu_read_lock();
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -179,8 +179,11 @@ int ksu_set_app_profile(struct app_profile *profile)
 
     list_for_each_entry (p, &allow_list, list) {
         ++count;
-        // both uid and package must match, otherwise it will break multiple package with different user id
-        if (profile->current_uid == p->profile.current_uid && !strcmp(profile->key, p->profile.key)) {
+        if (profile->current_uid == p->profile.current_uid) {
+            if (strcmp(profile->key, p->profile.key) != 0) {
+                pr_warn("ksu_set_app_profile: key changed: uid=%d orig=%s new=%s\n", profile->current_uid,
+                        p->profile.key, profile->key);
+            }
             // found it, just override it all!
             np = (struct perm_data *)kzalloc(sizeof(struct perm_data), GFP_KERNEL);
             if (!np) {

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -167,23 +167,12 @@ static bool profile_valid(struct app_profile *profile)
 static void release_perm_data(struct kref *ref)
 {
     struct perm_data *p = container_of(ref, struct perm_data, ref);
-    kfree(p);
+    kfree_rcu(p, rcu);
 }
 
 static void put_perm_data(struct perm_data *data)
 {
     kref_put(&data->ref, release_perm_data);
-}
-
-static void release_perm_data_rcu(struct kref *ref)
-{
-    struct perm_data *p = container_of(ref, struct perm_data, ref);
-    kfree_rcu(p, rcu);
-}
-
-static void put_perm_data_rcu(struct perm_data *data)
-{
-    kref_put(&data->ref, release_perm_data_rcu);
 }
 
 int ksu_set_app_profile(struct app_profile *profile)
@@ -229,7 +218,7 @@ int ksu_set_app_profile(struct app_profile *profile)
             kref_init(&np->ref);
             memcpy(&np->profile, profile, sizeof(*profile));
             hlist_replace_rcu(&p->list, &np->list);
-            put_perm_data_rcu(p);
+            put_perm_data(p);
             goto out;
         }
     }
@@ -579,7 +568,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
             modified = true;
             pr_info("prune uid: %d, package: %s\n", uid, package);
             hlist_del_rcu(&np->list);
-            put_perm_data_rcu(np);
+            put_perm_data(np);
             --allow_list_count;
         }
     }
@@ -606,7 +595,7 @@ void __exit ksu_allowlist_exit(void)
     mutex_lock(&allowlist_mutex);
     hash_for_each_safe (allow_list, i, tmp, np, list) {
         hlist_del(&np->list);
-        put_perm_data_rcu(np);
+        put_perm_data(np);
     }
     mutex_unlock(&allowlist_mutex);
 }

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -175,10 +175,15 @@ static void put_perm_data(struct perm_data *data)
     kref_put(&data->ref, release_perm_data);
 }
 
-static void put_perm_data_rcu(struct rcu_head *h)
+static void release_perm_data_rcu(struct kref *ref)
 {
-    struct perm_data *p = container_of(h, struct perm_data, rcu);
-    put_perm_data(p);
+    struct perm_data *p = container_of(ref, struct perm_data, ref);
+    kfree_rcu(p, rcu);
+}
+
+static void put_perm_data_rcu(struct perm_data *data)
+{
+    kref_put(&data->ref, release_perm_data_rcu);
 }
 
 int ksu_set_app_profile(struct app_profile *profile)
@@ -221,7 +226,7 @@ int ksu_set_app_profile(struct app_profile *profile)
             kref_init(&np->ref);
             memcpy(&np->profile, profile, sizeof(*profile));
             hlist_replace_rcu(&p->list, &np->list);
-            call_rcu(&p->rcu, put_perm_data_rcu);
+            put_perm_data_rcu(p);
             goto out;
         }
     }
@@ -265,7 +270,7 @@ out:
             current_default_non_root_profile = &np->profile.nrp_config.profile;
             if (unlikely(old_current_default_non_root_profile != &default_non_root_profile)) {
                 p = container_of(old_current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
-                call_rcu(&p->rcu, put_perm_data_rcu);
+                put_perm_data_rcu(p);
             }
         } else if (unlikely(!strcmp(profile->key, "#"))) {
             // set default root profile
@@ -275,7 +280,7 @@ out:
             current_default_root_profile = &np->profile.rp_config.profile;
             if (unlikely(old_current_default_root_profile != &default_root_profile)) {
                 p = container_of(old_current_default_root_profile, struct perm_data, profile.rp_config.profile);
-                call_rcu(&p->rcu, put_perm_data_rcu);
+                put_perm_data_rcu(p);
             }
         }
     }
@@ -588,7 +593,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
             modified = true;
             pr_info("prune uid: %d, package: %s\n", uid, package);
             hlist_del_rcu(&np->list);
-            call_rcu(&np->rcu, put_perm_data_rcu);
+            put_perm_data_rcu(np);
             --allow_list_count;
         }
     }
@@ -615,15 +620,15 @@ void __exit ksu_allowlist_exit(void)
     mutex_lock(&allowlist_mutex);
     if (unlikely(current_default_non_root_profile != &default_non_root_profile)) {
         np = container_of(current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
-        call_rcu(&np->rcu, put_perm_data_rcu);
+        put_perm_data_rcu(np);
     }
     if (unlikely(current_default_root_profile != &default_root_profile)) {
         np = container_of(current_default_root_profile, struct perm_data, profile.rp_config.profile);
-        call_rcu(&np->rcu, put_perm_data_rcu);
+        put_perm_data_rcu(np);
     }
     hash_for_each_safe (allow_list, i, tmp, np, list) {
         hlist_del(&np->list);
-        call_rcu(&np->rcu, put_perm_data_rcu);
+        put_perm_data_rcu(np);
     }
     mutex_unlock(&allowlist_mutex);
 }

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -37,10 +37,6 @@ static DEFINE_MUTEX(allowlist_mutex);
 static struct root_profile default_root_profile;
 static struct non_root_profile default_non_root_profile;
 
-// protected by rcu
-static struct root_profile *current_default_root_profile;
-static struct non_root_profile *current_default_non_root_profile;
-
 static void __init init_default_profiles()
 {
     kernel_cap_t full_cap = CAP_FULL_SET;
@@ -53,11 +49,9 @@ static void __init init_default_profiles()
            sizeof(default_root_profile.capabilities.effective));
     default_root_profile.namespaces = KSU_NS_INHERITED;
     strcpy(default_root_profile.selinux_domain, KSU_DEFAULT_SELINUX_DOMAIN);
-    current_default_root_profile = &default_root_profile;
 
     // This means that we will umount modules by default!
     default_non_root_profile.umount_modules = true;
-    current_default_non_root_profile = &default_non_root_profile;
 }
 
 struct perm_data {
@@ -93,6 +87,7 @@ struct app_profile *ksu_get_app_profile(uid_t uid)
     struct perm_data *p = NULL;
     bool found = false;
 
+retry:
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid) {
             // found it, override it with ours
@@ -105,7 +100,7 @@ struct app_profile *ksu_get_app_profile(uid_t uid)
         return NULL;
 
     if (!kref_get_unless_zero(&p->ref)) {
-        return NULL;
+        goto retry;
     }
 
     return &p->profile;
@@ -193,8 +188,6 @@ static void put_perm_data_rcu(struct perm_data *data)
 int ksu_set_app_profile(struct app_profile *profile)
 {
     struct perm_data *p, *np;
-    struct root_profile *old_current_default_root_profile;
-    struct non_root_profile *old_current_default_non_root_profile;
     int result = 0;
 
     if (!profile_valid(profile)) {
@@ -212,6 +205,11 @@ int ksu_set_app_profile(struct app_profile *profile)
         memset(&profile->nrp_config.profile, 0, sizeof(profile->nrp_config.profile));
     }
 #endif
+
+    // only allow default non root profile
+    if (unlikely(profile->curr_uid == KSU_APP_PROFILE_PRESERVE_UID && strcmp(profile->key, "$") != 0)) {
+        return -EINVAL;
+    }
 
     mutex_lock(&allowlist_mutex);
 
@@ -265,30 +263,9 @@ int ksu_set_app_profile(struct app_profile *profile)
 out:
     result = 0;
 
-    // check if the default profiles is changed, cache it to a single struct to accelerate access.
     if (unlikely(profile->curr_uid == KSU_APP_PROFILE_PRESERVE_UID)) {
-        if (unlikely(!strcmp(profile->key, "$"))) {
-            // set default non root profile
-            kref_get(&np->ref);
-            old_current_default_non_root_profile =
-                rcu_dereference_protected(current_default_non_root_profile, lockdep_is_held(&allowlist_mutex));
-            rcu_assign_pointer(current_default_non_root_profile, &np->profile.nrp_config.profile);
-            if (unlikely(old_current_default_non_root_profile != &default_non_root_profile)) {
-                p = container_of(old_current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
-                put_perm_data_rcu(p);
-            }
-        } else if (unlikely(!strcmp(profile->key, "#"))) {
-            // set default root profile
-            // TODO: Do we really need this?
-            kref_get(&np->ref);
-            old_current_default_root_profile =
-                rcu_dereference_protected(current_default_root_profile, lockdep_is_held(&allowlist_mutex));
-            rcu_assign_pointer(current_default_root_profile, &np->profile.rp_config.profile);
-            if (unlikely(old_current_default_root_profile != &default_root_profile)) {
-                p = container_of(old_current_default_root_profile, struct perm_data, profile.rp_config.profile);
-                put_perm_data_rcu(p);
-            }
-        }
+        // set default non root profile
+        default_non_root_profile.umount_modules = profile->nrp_config.use_default;
     }
 
 out_unlock:
@@ -354,14 +331,14 @@ bool ksu_uid_should_umount(uid_t uid)
     profile = ksu_get_app_profile(uid);
     if (!profile) {
         // no app profile found, it must be non root app
-        res = current_default_non_root_profile->umount_modules;
+        res = default_non_root_profile.umount_modules;
     } else if (profile->allow_su) {
         // if found and it is granted to su, we shouldn't umount for it
         res = false;
     } else {
         // found an app profile
         if (profile->nrp_config.use_default) {
-            res = current_default_non_root_profile->umount_modules;
+            res = default_non_root_profile.umount_modules;
         } else {
             res = profile->nrp_config.profile.umount_modules;
         }
@@ -398,11 +375,14 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
         goto use_default;
     }
 
+retry:
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {
-                if (kref_get_unless_zero(&p->ref))
-                    res = &p->profile.rp_config.profile;
+                if (!kref_get_unless_zero(&p->ref)) {
+                    goto retry;
+                }
+                res = &p->profile.rp_config.profile;
             }
             break;
         }
@@ -410,11 +390,7 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
 
     if (unlikely(!res)) {
     use_default:
-        res = current_default_root_profile;
-        if (unlikely(res != &default_root_profile)) {
-            if (kref_get_unless_zero(&p->ref))
-                p = container_of(res, struct perm_data, profile.rp_config.profile);
-        }
+        res = &default_root_profile;
     }
 
     rcu_read_unlock();
@@ -626,14 +602,6 @@ void __exit ksu_allowlist_exit(void)
 
     // free allowlist
     mutex_lock(&allowlist_mutex);
-    if (unlikely(current_default_non_root_profile != &default_non_root_profile)) {
-        np = container_of(current_default_non_root_profile, struct perm_data, profile.nrp_config.profile);
-        put_perm_data_rcu(np);
-    }
-    if (unlikely(current_default_root_profile != &default_root_profile)) {
-        np = container_of(current_default_root_profile, struct perm_data, profile.rp_config.profile);
-        put_perm_data_rcu(np);
-    }
     hash_for_each_safe (allow_list, i, tmp, np, list) {
         hlist_del(&np->list);
         put_perm_data_rcu(np);

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -35,25 +35,6 @@ static DEFINE_MUTEX(allowlist_mutex);
 static struct root_profile default_root_profile;
 static struct non_root_profile default_non_root_profile;
 
-static int allow_list_arr[PAGE_SIZE / sizeof(int)] __read_mostly __aligned(PAGE_SIZE);
-static int allow_list_pointer __read_mostly = 0;
-
-static void remove_uid_from_arr(uid_t uid)
-{
-    int i;
-    for (i = 0; i < allow_list_pointer; i++) {
-        if (allow_list_arr[i] == uid) {
-            int remaining = allow_list_pointer - 1 - i;
-            if (remaining > 0) {
-                memmove(&allow_list_arr[i], &allow_list_arr[i + 1], remaining * sizeof(allow_list_arr[0]));
-            }
-            allow_list_pointer--;
-            allow_list_arr[allow_list_pointer] = -1;
-            return;
-        }
-    }
-}
-
 static void __init init_default_profiles()
 {
     kernel_cap_t full_cap = CAP_FULL_SET;
@@ -78,9 +59,6 @@ struct perm_data {
 };
 
 static struct list_head allow_list;
-
-static uint8_t allow_list_bitmap[PAGE_SIZE] __read_mostly __aligned(PAGE_SIZE);
-#define BITMAP_UID_MAX ((sizeof(allow_list_bitmap) * BITS_PER_BYTE) - 1)
 
 #define KERNEL_SU_ALLOWLIST "/data/adb/ksu/.allowlist"
 
@@ -256,26 +234,6 @@ out:
         // TODO: Do we really need this?
         memcpy(&default_root_profile, &profile->rp_config.profile, sizeof(default_root_profile));
 #endif
-    } else if (profile->current_uid <= BITMAP_UID_MAX) {
-        if (profile->allow_su)
-            allow_list_bitmap[profile->current_uid / BITS_PER_BYTE] |= 1 << (profile->current_uid % BITS_PER_BYTE);
-        else
-            allow_list_bitmap[profile->current_uid / BITS_PER_BYTE] &= ~(1 << (profile->current_uid % BITS_PER_BYTE));
-    } else {
-        if (profile->allow_su) {
-            /*
-             * 1024 apps with uid higher than BITMAP_UID_MAX
-             * registered to request superuser?
-             */
-            if (allow_list_pointer >= ARRAY_SIZE(allow_list_arr)) {
-                pr_err("too many apps registered\n");
-                WARN_ON(1);
-            } else {
-                allow_list_arr[allow_list_pointer++] = profile->current_uid;
-            }
-        } else {
-            remove_uid_from_arr(profile->current_uid);
-        }
     }
 
 out_unlock:
@@ -285,7 +243,7 @@ out_unlock:
 
 bool __ksu_is_allow_uid(uid_t uid)
 {
-    int i;
+    struct perm_data *p;
 
     if (forbid_system_uid(uid)) {
         // do not bother going through the list if it's system
@@ -301,14 +259,14 @@ bool __ksu_is_allow_uid(uid_t uid)
         return true;
     }
 
-    if (likely(uid <= BITMAP_UID_MAX)) {
-        return !!(allow_list_bitmap[uid / BITS_PER_BYTE] & (1 << (uid % BITS_PER_BYTE)));
-    } else {
-        for (i = 0; i < allow_list_pointer; i++) {
-            if (allow_list_arr[i] == uid)
-                return true;
+    rcu_read_lock();
+    list_for_each_entry_rcu (p, &allow_list, list) {
+        if (uid == p->profile.current_uid && p->profile.allow_su) {
+            rcu_read_unlock();
+            return true;
         }
     }
+    rcu_read_unlock();
 
     return false;
 }
@@ -558,10 +516,6 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
             pr_info("prune uid: %d, package: %s\n", uid, package);
             list_del_rcu(&np->list);
             kfree_rcu(np, rcu);
-            if (likely(uid <= BITMAP_UID_MAX)) {
-                allow_list_bitmap[uid / BITS_PER_BYTE] &= ~(1 << (uid % BITS_PER_BYTE));
-            }
-            remove_uid_from_arr(uid);
         }
     }
     mutex_unlock(&allowlist_mutex);
@@ -574,14 +528,6 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
 
 void __init ksu_allowlist_init(void)
 {
-    int i;
-
-    BUILD_BUG_ON(sizeof(allow_list_bitmap) != PAGE_SIZE);
-    BUILD_BUG_ON(sizeof(allow_list_arr) != PAGE_SIZE);
-
-    for (i = 0; i < ARRAY_SIZE(allow_list_arr); i++)
-        allow_list_arr[i] = -1;
-
     INIT_LIST_HEAD(&allow_list);
 
     init_default_profiles();

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -85,9 +85,10 @@ void ksu_show_allow_list(void)
 struct app_profile *ksu_get_app_profile(uid_t uid)
 {
     struct perm_data *p = NULL;
-    bool found = false;
+    bool found;
 
 retry:
+    found = false;
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid) {
             // found it, override it with ours
@@ -364,7 +365,7 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
     return &default_root_profile;
 #else
     struct perm_data *p = NULL;
-    struct root_profile *res = NULL;
+    struct root_profile *res;
 
     rcu_read_lock();
     if (is_uid_manager(uid)) {
@@ -376,6 +377,7 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
     }
 
 retry:
+    res = NULL;
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -14,6 +14,7 @@
 #include <linux/types.h>
 #include <linux/version.h>
 #include <linux/compiler_types.h>
+#include <linux/hashtable.h>
 
 #include "klog.h" // IWYU pragma: keep
 #include "ksu.h"
@@ -53,12 +54,13 @@ static void __init init_default_profiles()
 }
 
 struct perm_data {
-    struct list_head list;
+    struct hlist_node list;
     struct rcu_head rcu;
     struct app_profile profile;
 };
 
-static struct list_head allow_list;
+#define ALLOW_LIST_BITS 8
+DEFINE_HASHTABLE(allow_list, ALLOW_LIST_BITS);
 
 #define KERNEL_SU_ALLOWLIST "/data/adb/ksu/.allowlist"
 
@@ -66,10 +68,11 @@ void ksu_persistent_allow_list(void);
 
 void ksu_show_allow_list(void)
 {
+    int i;
     struct perm_data *p = NULL;
     pr_info("ksu_show_allow_list\n");
     rcu_read_lock();
-    list_for_each_entry_rcu (p, &allow_list, list) {
+    hash_for_each_rcu (allow_list, i, p, list) {
         pr_info("uid :%d, allow: %d\n", p->profile.curr_uid, p->profile.allow_su);
     }
     rcu_read_unlock();
@@ -81,7 +84,7 @@ bool ksu_get_app_profile(struct app_profile *profile)
     bool found = false;
 
     rcu_read_lock();
-    list_for_each_entry_rcu (p, &allow_list, list) {
+    hash_for_each_possible_rcu (allow_list, p, list, profile->curr_uid) {
         bool uid_match = profile->curr_uid == p->profile.curr_uid;
         if (uid_match) {
             // found it, override it with ours
@@ -177,7 +180,7 @@ int ksu_set_app_profile(struct app_profile *profile)
 
     mutex_lock(&allowlist_mutex);
 
-    list_for_each_entry (p, &allow_list, list) {
+    hash_for_each_possible (allow_list, p, list, profile->curr_uid) {
         ++count;
         if (profile->curr_uid == p->profile.curr_uid) {
             if (strcmp(profile->key, p->profile.key) != 0) {
@@ -191,7 +194,7 @@ int ksu_set_app_profile(struct app_profile *profile)
                 goto out_unlock;
             }
             memcpy(&np->profile, profile, sizeof(*profile));
-            list_replace_rcu(&p->list, &np->list);
+            hlist_replace_rcu(&p->list, &np->list);
             kfree_rcu(p, rcu);
             goto out;
         }
@@ -220,7 +223,7 @@ int ksu_set_app_profile(struct app_profile *profile)
                 profile->nrp_config.profile.umount_modules);
     }
 
-    list_add_tail_rcu(&p->list, &allow_list);
+    hash_add_rcu(allow_list, &p->list, p->profile.curr_uid);
 
 out:
     result = 0;
@@ -263,7 +266,7 @@ bool __ksu_is_allow_uid(uid_t uid)
     }
 
     rcu_read_lock();
-    list_for_each_entry_rcu (p, &allow_list, list) {
+    hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             rcu_read_unlock();
             return true;
@@ -334,7 +337,7 @@ void ksu_get_root_profile(uid_t uid, struct root_profile *profile)
     }
 
     rcu_read_lock();
-    list_for_each_entry_rcu (p, &allow_list, list) {
+    hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {
                 memcpy(profile, &p->profile.rp_config.profile, sizeof(*profile));
@@ -355,8 +358,9 @@ bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total,
 {
     struct perm_data *p = NULL;
     u16 i = 0, j = 0;
+    int iter;
     rcu_read_lock();
-    list_for_each_entry_rcu (p, &allow_list, list) {
+    hash_for_each_rcu (allow_list, iter, p, list) {
         // pr_info("get_allow_list uid: %d allow: %d\n", p->uid, p->allow);
         if (p->profile.allow_su == allow && !is_uid_manager(p->profile.curr_uid)) {
             if (j < length) {
@@ -383,6 +387,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
     u32 version = FILE_FORMAT_VERSION;
     struct perm_data *p = NULL;
     loff_t off = 0;
+    int i;
 
     const struct cred *saved = override_creds(ksu_cred);
     struct file *fp = filp_open(KERNEL_SU_ALLOWLIST, O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -403,7 +408,7 @@ static void do_persistent_allow_list(struct callback_head *_cb)
     }
 
     mutex_lock(&allowlist_mutex);
-    list_for_each_entry (p, &allow_list, list) {
+    hash_for_each (allow_list, i, p, list) {
         pr_info("save allow list, name: %s uid :%d, allow: %d\n", p->profile.key, p->profile.curr_uid,
                 p->profile.allow_su);
 
@@ -498,7 +503,8 @@ exit:
 void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data)
 {
     struct perm_data *np = NULL;
-    struct perm_data *n = NULL;
+    struct hlist_node *tmp;
+    int i;
 
     if (!ksu_boot_completed) {
         pr_info("boot not completed, skip prune\n");
@@ -507,7 +513,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
 
     bool modified = false;
     mutex_lock(&allowlist_mutex);
-    list_for_each_entry_safe (np, n, &allow_list, list) {
+    hash_for_each_safe (allow_list, i, tmp, np, list) {
         uid_t uid = np->profile.curr_uid;
         char *package = np->profile.key;
         // we use this uid for special cases, don't prune it!
@@ -515,7 +521,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
         if (!is_preserved_uid && !is_uid_valid(uid, package, data)) {
             modified = true;
             pr_info("prune uid: %d, package: %s\n", uid, package);
-            list_del_rcu(&np->list);
+            hlist_del_rcu(&np->list);
             kfree_rcu(np, rcu);
         }
     }
@@ -529,20 +535,19 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
 
 void __init ksu_allowlist_init(void)
 {
-    INIT_LIST_HEAD(&allow_list);
-
     init_default_profiles();
 }
 
 void __exit ksu_allowlist_exit(void)
 {
     struct perm_data *np = NULL;
-    struct perm_data *n = NULL;
+    struct hlist_node *tmp;
+    int i;
 
     // free allowlist
     mutex_lock(&allowlist_mutex);
-    list_for_each_entry_safe (np, n, &allow_list, list) {
-        list_del(&np->list);
+    hash_for_each_safe (allow_list, i, tmp, np, list) {
+        hlist_del(&np->list);
         kfree(np);
     }
     mutex_unlock(&allowlist_mutex);

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -179,11 +179,6 @@ int ksu_set_app_profile(struct app_profile *profile)
 #endif
 
     mutex_lock(&allowlist_mutex);
-    if (unlikely(allow_list_count == U16_MAX)) {
-        pr_err("too many app profile\n");
-        result = -E2BIG;
-        goto out_unlock;
-    }
 
     hash_for_each_possible (allow_list, p, list, profile->curr_uid) {
         if (profile->curr_uid == p->profile.curr_uid) {
@@ -202,6 +197,12 @@ int ksu_set_app_profile(struct app_profile *profile)
             kfree_rcu(p, rcu);
             goto out;
         }
+    }
+
+    if (unlikely(allow_list_count == U16_MAX)) {
+        pr_err("too many app profile\n");
+        result = -E2BIG;
+        goto out_unlock;
     }
 
     // not found, alloc a new node!

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -61,6 +61,7 @@ struct perm_data {
 
 #define ALLOW_LIST_BITS 8
 DEFINE_HASHTABLE(allow_list, ALLOW_LIST_BITS);
+u16 allow_list_count = 0;
 
 #define KERNEL_SU_ALLOWLIST "/data/adb/ksu/.allowlist"
 
@@ -160,7 +161,6 @@ int ksu_set_app_profile(struct app_profile *profile)
 {
     struct perm_data *p = NULL, *np;
     int result = 0;
-    u16 count = 0;
 
     if (!profile_valid(profile)) {
         pr_err("Failed to set app profile: invalid profile!\n");
@@ -179,9 +179,13 @@ int ksu_set_app_profile(struct app_profile *profile)
 #endif
 
     mutex_lock(&allowlist_mutex);
+    if (unlikely(allow_list_count == U16_MAX)) {
+        pr_err("too many app profile\n");
+        result = -E2BIG;
+        goto out_unlock;
+    }
 
     hash_for_each_possible (allow_list, p, list, profile->curr_uid) {
-        ++count;
         if (profile->curr_uid == p->profile.curr_uid) {
             if (strcmp(profile->key, p->profile.key) != 0) {
                 pr_warn("ksu_set_app_profile: key changed: uid=%d orig=%s new=%s\n", profile->curr_uid, p->profile.key,
@@ -198,12 +202,6 @@ int ksu_set_app_profile(struct app_profile *profile)
             kfree_rcu(p, rcu);
             goto out;
         }
-    }
-
-    if (unlikely(count == U16_MAX)) {
-        pr_err("too many app profile\n");
-        result = -E2BIG;
-        goto out_unlock;
     }
 
     // not found, alloc a new node!
@@ -224,6 +222,7 @@ int ksu_set_app_profile(struct app_profile *profile)
     }
 
     hash_add_rcu(allow_list, &p->list, p->profile.curr_uid);
+    ++allow_list_count;
 
 out:
     result = 0;
@@ -523,6 +522,7 @@ void ksu_prune_allowlist(bool (*is_uid_valid)(uid_t, char *, void *), void *data
             pr_info("prune uid: %d, package: %s\n", uid, package);
             hlist_del_rcu(&np->list);
             kfree_rcu(np, rcu);
+            --allow_list_count;
         }
     }
     mutex_unlock(&allowlist_mutex);

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -102,7 +102,9 @@ struct app_profile *ksu_get_app_profile(uid_t uid)
     if (!p)
         return NULL;
 
-    kref_get(&p->ref);
+    if (!kref_get_unless_zero(&p->ref)) {
+        return NULL;
+    }
 
     return &p->profile;
 }
@@ -398,8 +400,8 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
     hash_for_each_possible_rcu (allow_list, p, list, uid) {
         if (uid == p->profile.curr_uid && p->profile.allow_su) {
             if (!p->profile.rp_config.use_default) {
-                kref_get(&p->ref);
-                res = &p->profile.rp_config.profile;
+                if (kref_get_unless_zero(&p->ref))
+                    res = &p->profile.rp_config.profile;
             }
             break;
         }
@@ -409,8 +411,8 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
     use_default:
         res = current_default_root_profile;
         if (unlikely(res != &default_root_profile)) {
-            p = container_of(res, struct perm_data, profile.rp_config.profile);
-            kref_get(&p->ref);
+            if (kref_get_unless_zero(&p->ref))
+                p = container_of(res, struct perm_data, profile.rp_config.profile);
         }
     }
 

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -384,8 +384,7 @@ struct root_profile *ksu_get_root_profile(uid_t uid)
 {
 #ifdef CONFIG_KSU_DISABLE_POLICY
     (void)uid;
-    memcpy(profile, &default_root_profile, sizeof(*profile));
-    return;
+    return &default_root_profile;
 #else
     struct perm_data *p = NULL;
     struct root_profile *res = NULL;

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -60,8 +60,8 @@ struct perm_data {
 };
 
 #define ALLOW_LIST_BITS 8
-DEFINE_HASHTABLE(allow_list, ALLOW_LIST_BITS);
-u16 allow_list_count = 0;
+static DEFINE_HASHTABLE(allow_list, ALLOW_LIST_BITS);
+static u16 allow_list_count = 0;
 
 #define KERNEL_SU_ALLOWLIST "/data/adb/ksu/.allowlist"
 

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -265,7 +265,7 @@ out:
 
     if (unlikely(profile->curr_uid == KSU_APP_PROFILE_PRESERVE_UID)) {
         // set default non root profile
-        default_non_root_profile.umount_modules = profile->nrp_config.use_default;
+        default_non_root_profile.umount_modules = profile->nrp_config.profile.umount_modules;
     }
 
 out_unlock:

--- a/kernel/policy/allowlist.h
+++ b/kernel/policy/allowlist.h
@@ -35,7 +35,7 @@ void ksu_persistent_allow_list();
 
 // should be called with rcu read lock
 struct app_profile *ksu_get_app_profile(uid_t uid);
-// only uysed to put the app_profile returned by ksu_get_app_profile
+// only used to put the app_profile returned by ksu_get_app_profile
 void ksu_put_app_profile(struct app_profile *);
 int ksu_set_app_profile(struct app_profile *);
 

--- a/kernel/policy/allowlist.h
+++ b/kernel/policy/allowlist.h
@@ -33,11 +33,16 @@ bool ksu_get_allow_list(int *array, u16 length, u16 *out_length, u16 *out_total,
 void ksu_prune_allowlist(bool (*is_uid_exist)(uid_t, char *, void *), void *data);
 void ksu_persistent_allow_list();
 
-bool ksu_get_app_profile(struct app_profile *);
+// should be called with rcu read lock
+struct app_profile *ksu_get_app_profile(uid_t uid);
+// only uysed to put the app_profile returned by ksu_get_app_profile
+void ksu_put_app_profile(struct app_profile *);
 int ksu_set_app_profile(struct app_profile *);
 
 bool ksu_uid_should_umount(uid_t uid);
-void ksu_get_root_profile(uid_t uid, struct root_profile *);
+struct root_profile *ksu_get_root_profile(uid_t uid);
+// only used to put the root_profile returned by ksu_get_root_profile
+void ksu_put_root_profile(struct root_profile *);
 
 static inline bool is_appuid(uid_t uid)
 {

--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -108,7 +108,7 @@ int escape_with_root_profile(void)
     struct cred *cred;
     struct task_struct *p = current;
     struct task_struct *t;
-    struct root_profile profile;
+    struct root_profile *profile;
     struct user_struct *new_user;
 
     cred = prepare_creds();
@@ -122,20 +122,20 @@ int escape_with_root_profile(void)
         goto out_abort_creds;
     }
 
-    ksu_get_root_profile(cred->uid.val, &profile);
+    profile = ksu_get_root_profile(cred->uid.val);
 
-    cred->uid.val = profile.uid;
-    cred->suid.val = profile.uid;
-    cred->euid.val = profile.uid;
-    cred->fsuid.val = profile.uid;
+    cred->uid.val = profile->uid;
+    cred->suid.val = profile->uid;
+    cred->euid.val = profile->uid;
+    cred->fsuid.val = profile->uid;
 
-    cred->gid.val = profile.gid;
-    cred->fsgid.val = profile.gid;
-    cred->sgid.val = profile.gid;
-    cred->egid.val = profile.gid;
+    cred->gid.val = profile->gid;
+    cred->fsgid.val = profile->gid;
+    cred->sgid.val = profile->gid;
+    cred->egid.val = profile->gid;
     cred->securebits = 0;
 
-    BUILD_BUG_ON(sizeof(profile.capabilities.effective) != sizeof(kernel_cap_t));
+    BUILD_BUG_ON(sizeof(profile->capabilities.effective) != sizeof(kernel_cap_t));
 
     /*
      * Mirror the kernel set*uid path: update cred->user first, then
@@ -169,13 +169,13 @@ int escape_with_root_profile(void)
     // setup capabilities
     // we need CAP_DAC_READ_SEARCH becuase `/data/adb/ksud` is not accessible for non root process
     // we add it here but don't add it to cap_inhertiable, it would be dropped automaticly after exec!
-    u64 cap_for_ksud = profile.capabilities.effective | CAP_DAC_READ_SEARCH;
+    u64 cap_for_ksud = profile->capabilities.effective | CAP_DAC_READ_SEARCH;
     memcpy(&cred->cap_effective, &cap_for_ksud, sizeof(cred->cap_effective));
-    memcpy(&cred->cap_permitted, &profile.capabilities.effective, sizeof(cred->cap_permitted));
-    memcpy(&cred->cap_bset, &profile.capabilities.effective, sizeof(cred->cap_bset));
+    memcpy(&cred->cap_permitted, &profile->capabilities.effective, sizeof(cred->cap_permitted));
+    memcpy(&cred->cap_bset, &profile->capabilities.effective, sizeof(cred->cap_bset));
 
-    setup_groups(&profile, cred);
-    setup_selinux(profile.selinux_domain, cred);
+    setup_groups(profile, cred);
+    setup_selinux(profile->selinux_domain, cred);
 
     commit_creds(cred);
 
@@ -185,7 +185,8 @@ int escape_with_root_profile(void)
         ksu_set_task_tracepoint_flag(t);
     }
 
-    setup_mount_ns(profile.namespaces);
+    setup_mount_ns(profile->namespaces);
+    ksu_put_root_profile(profile);
     return 0;
 
 out_abort_creds:

--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -108,7 +108,7 @@ int escape_with_root_profile(void)
     struct cred *cred;
     struct task_struct *p = current;
     struct task_struct *t;
-    struct root_profile *profile;
+    struct root_profile *profile = NULL;
     struct user_struct *new_user;
 
     cred = prepare_creds();
@@ -190,6 +190,8 @@ int escape_with_root_profile(void)
     return 0;
 
 out_abort_creds:
+    if (profile)
+        ksu_put_root_profile(profile);
     abort_creds(cred);
     return ret;
 }

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -297,24 +297,29 @@ static int do_get_app_profile(void __user *arg)
 #ifdef CONFIG_KSU_DISABLE_POLICY
     return -EOPNOTSUPP;
 #endif
+    uid_t uid;
+    struct app_profile *profile;
+    int ret = 0;
 
-    struct ksu_get_app_profile_cmd cmd;
-
-    if (copy_from_user(&cmd, arg, sizeof(cmd))) {
+    if (copy_from_user(&uid, arg + offsetof(struct ksu_get_app_profile_cmd, profile.curr_uid), sizeof(uid_t))) {
         pr_err("get_app_profile: copy_from_user failed\n");
         return -EFAULT;
     }
 
-    if (!ksu_get_app_profile(&cmd.profile)) {
-        return -ENOENT;
+    rcu_read_lock();
+    profile = ksu_get_app_profile(uid);
+    rcu_read_unlock();
+    if (!profile) {
+        ret = -ENOENT;
+    } else {
+        if (copy_to_user(arg + offsetof(struct ksu_get_app_profile_cmd, profile), profile,
+                         sizeof(struct app_profile))) {
+            pr_err("get_app_profile: copy_to_user failed\n");
+            ret = -EFAULT;
+        }
+        ksu_put_app_profile(profile);
     }
-
-    if (copy_to_user(arg, &cmd, sizeof(cmd))) {
-        pr_err("get_app_profile: copy_to_user failed\n");
-        return -EFAULT;
-    }
-
-    return 0;
+    return ret;
 }
 
 static int do_set_app_profile(void __user *arg)

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -301,7 +301,8 @@ static int do_get_app_profile(void __user *arg)
     struct app_profile *profile;
     int ret = 0;
 
-    if (copy_from_user(&uid, arg + offsetof(struct ksu_get_app_profile_cmd, profile.curr_uid), sizeof(uid_t))) {
+    if (copy_from_user(&uid, (char __user *)arg + offsetof(struct ksu_get_app_profile_cmd, profile.curr_uid),
+                       sizeof(uid_t))) {
         pr_err("get_app_profile: copy_from_user failed\n");
         return -EFAULT;
     }
@@ -312,7 +313,7 @@ static int do_get_app_profile(void __user *arg)
     if (!profile) {
         ret = -ENOENT;
     } else {
-        if (copy_to_user(arg + offsetof(struct ksu_get_app_profile_cmd, profile), profile,
+        if (copy_to_user((char __user *)arg + offsetof(struct ksu_get_app_profile_cmd, profile), profile,
                          sizeof(struct app_profile))) {
             pr_err("get_app_profile: copy_to_user failed\n");
             ret = -EFAULT;

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -136,7 +136,7 @@ Java_me_weishu_kernelsu_Natives_getAppProfile(JNIEnv *env, jobject, jstring pkg,
     profile.version = KSU_APP_PROFILE_VER;
 
     strcpy(profile.key, key);
-    profile.current_uid = uid;
+    profile.curr_uid = uid;
 
     bool useDefaultProfile = get_app_profile(&profile) != 0;
 
@@ -161,7 +161,7 @@ Java_me_weishu_kernelsu_Natives_getAppProfile(JNIEnv *env, jobject, jstring pkg,
     auto umountModulesField = env->GetFieldID(cls, "umountModules", "Z");
 
     env->SetObjectField(obj, keyField, env->NewStringUTF(profile.key));
-    env->SetIntField(obj, currentUidField, profile.current_uid);
+    env->SetIntField(obj, currentUidField, profile.curr_uid);
 
     if (useDefaultProfile) {
         // no profile found, so just use default profile:
@@ -266,7 +266,7 @@ Java_me_weishu_kernelsu_Natives_setAppProfile(JNIEnv *env, jobject clazz, jobjec
 
     strcpy(p.key, p_key);
     p.allow_su = allowSu;
-    p.current_uid = currentUid;
+    p.curr_uid = currentUid;
 
     if (allowSu) {
         p.rp_config.use_default = env->GetBooleanField(profile, rootUseDefaultField);

--- a/uapi/app_profile.h
+++ b/uapi/app_profile.h
@@ -41,7 +41,7 @@ struct app_profile {
 
     /* this is usually the package of the app, but can be other value for special apps */
     char key[KSU_MAX_PACKAGE_NAME];
-    __s32 current_uid;
+    __s32 curr_uid;
     bool allow_su;
 
     union {


### PR DESCRIPTION
- Remove allow_list_arr and allow_list_bitmap
- Make current_uid as the only key of app profile
- Use hash table to store allowlist
- Remove the usage of directly allocating app_profile/root_profile on kernel stack
- Rename `current_uid` to `curr_uid` to avoid ambiguity with kernel macro