### PR TITLE
manager: keep commonmark resources

### DIFF
--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -148,7 +148,7 @@ android {
 
 androidComponents {
     onVariants(selector().withBuildType("release")) {
-        it.packaging.resources.excludes.addAll(listOf("META-INF/**", "kotlin/**", "org/**", "**.bin"))
+        it.packaging.resources.excludes.addAll(listOf("META-INF/**", "kotlin/**", "**.bin"))
     }
 }
 


### PR DESCRIPTION
commonmark reads its named HTML entity table from
org/commonmark/internal/util/entities.properties.
Excluding org/** removed that runtime resource from release
artifacts, which made markdown initialization crash in
shrunk builds. Preserve the resource to keep release markdown
rendering working.

Signed-off-by: qwq233 <qwq233@qwq2333.top>