### PR TITLE
manager: add Wear OS UI support

### DIFF
--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -167,6 +167,12 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.wear.compose.foundation)
+    implementation(libs.androidx.wear.compose.material3)
+    implementation(libs.androidx.wear.compose.navigation3) {
+        exclude(group = "androidx.navigation3", module = "navigation3-ui")
+    }
+    implementation(libs.androidx.wear.compose.ui.tooling)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -172,7 +172,7 @@ dependencies {
     implementation(libs.androidx.wear.compose.navigation3) {
         exclude(group = "androidx.navigation3", module = "navigation3-ui")
     }
-    implementation(libs.androidx.wear.compose.ui.tooling)
+    debugImplementation(libs.androidx.wear.compose.ui.tooling)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -8,8 +8,13 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="com.google.android.wearable.permission.URI_REDIRECT_TO_REMOTE" />
 
     <uses-sdk tools:overrideLibrary="top.yukonga.miuix.kmp.blur" />
+
+    <uses-feature
+        android:name="android.hardware.type.watch"
+        android:required="false" />
 
     <application
         android:name=".KernelSUApplication"
@@ -24,6 +29,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.KernelSU"
         android:zygotePreloadName="me.weishu.kernelsu.magica.AppZygotePreload">
+        <meta-data
+                android:name="com.google.android.wearable.standalone"
+                android:value="true" />
+
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"

--- a/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepository.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepository.kt
@@ -17,6 +17,7 @@ interface SettingsRepository {
     var enableWebDebugging: Boolean
     var enableSmoothCorner: Boolean
     var autoJailbreak: Boolean
+    var screenShape: String
 
     suspend fun getSuCompatStatus(): String
     suspend fun getSuCompatPersistValue(): Long?

--- a/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepositoryImpl.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepositoryImpl.kt
@@ -99,6 +99,11 @@ class SettingsRepositoryImpl : SettingsRepository {
             }
         }
 
+    override var screenShape: String
+        get() = prefs.getString("screen_shape", null)
+            ?: if (ksuApp.resources.configuration.isScreenRound) "round" else "square"
+        set(value) = prefs.edit { putString("screen_shape", value) }
+
     override suspend fun getSuCompatStatus(): String = getFeatureStatus("su_compat")
 
     override suspend fun getSuCompatPersistValue(): Long? = getFeaturePersistValue("su_compat")

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.annotation.StringRes
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -42,8 +43,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,6 +57,7 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
+import androidx.wear.compose.material3.TimeText
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -98,9 +102,13 @@ import me.weishu.kernelsu.ui.util.rememberContentReady
 import me.weishu.kernelsu.ui.util.rootAvailable
 import me.weishu.kernelsu.ui.viewmodel.MainActivityViewModel
 import me.weishu.kernelsu.ui.viewmodel.MainPagerConfig
+import me.weishu.kernelsu.ui.wear.WearInstallRequiredScreen
+import me.weishu.kernelsu.ui.wear.WearMainScreen
+import me.weishu.kernelsu.ui.wear.WearPlaceholderScreen
 import me.weishu.kernelsu.ui.webui.WebUIActivity
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.theme.MiuixTheme
+import androidx.wear.compose.material3.MaterialTheme as WearMaterialTheme
 import top.yukonga.miuix.kmp.blur.layerBackdrop as miuixLayerBackdrop
 
 class MainActivity : ComponentActivity() {
@@ -120,6 +128,9 @@ class MainActivity : ComponentActivity() {
             val selectedMainPage by viewModel.selectedMainPage.collectAsStateWithLifecycle()
             val appSettings = uiState.appSettings
             val uiMode = uiState.uiMode
+            val hasKsu = isManager && Natives.version != -1
+            val canUseKernelFeatures = hasKsu && !Natives.requireNewKernel() && rootAvailable()
+            val canInstallKsu = !hasKsu && !Natives.isLateLoadMode
             val darkMode = appSettings.colorMode.isDark || (appSettings.colorMode.isSystem && isSystemInDarkTheme())
 
             DisposableEffect(darkMode) {
@@ -152,17 +163,66 @@ class MainActivity : ComponentActivity() {
                 LocalEnableFloatingBottomBar provides uiState.enableFloatingBottomBar,
                 LocalEnableFloatingBottomBarBlur provides uiState.enableFloatingBottomBarBlur,
                 LocalUiMode provides uiMode,
+                LocalScreenShape provides uiState.screenShape,
                 LocalSnackbarHost provides snackBarHostState
             ) {
                 KernelSUTheme(appSettings = appSettings, uiMode = uiMode) {
                     HandleDeepLink(intentState = intentState.collectAsStateWithLifecycle())
                     ZipFileIntentHandler(intentState = intentState, isManager = isManager)
-                    ShortcutIntentHandler(intentState = intentState)
+                    ShortcutIntentHandler(
+                        intentState = intentState,
+                        canUseKernelFeatures = canUseKernelFeatures
+                    )
                     val mainScreenEntry = @Composable {
-                        MainScreen(
-                            initialPage = selectedMainPage,
-                            onPageChanged = viewModel::setSelectedMainPage,
-                        )
+                        if (uiMode == UiMode.Wear) {
+                            WearMainScreen(
+                                navigator = navigator,
+                                canUseKernelFeatures = canUseKernelFeatures,
+                            )
+                        } else {
+                            MainScreen(
+                                initialPage = selectedMainPage,
+                                onPageChanged = viewModel::setSelectedMainPage,
+                            )
+                        }
+                    }
+
+                    @Composable
+                    fun WearProtectedScreen(
+                        @StringRes title: Int,
+                        showMainScreenOnNonWear: Boolean = false,
+                        content: @Composable () -> Unit,
+                    ) {
+                        if (uiMode == UiMode.Wear) {
+                            if (canUseKernelFeatures) {
+                                content()
+                            } else {
+                                WearInstallRequiredScreen(
+                                    title = title,
+                                    canInstall = canInstallKsu,
+                                    onInstallClick = { navigator.push(Route.Install) },
+                                )
+                            }
+                        } else if (showMainScreenOnNonWear) {
+                            mainScreenEntry()
+                        } else {
+                            content()
+                        }
+                    }
+
+                    @Composable
+                    fun WearModuleInstallProtectedScreen(
+                        @StringRes title: Int,
+                        content: @Composable () -> Unit,
+                    ) {
+                        if (uiMode == UiMode.Wear && Natives.isSafeMode) {
+                            WearPlaceholderScreen(
+                                title = title,
+                                message = stringResource(R.string.safe_mode_module_disabled),
+                            )
+                        } else {
+                            WearProtectedScreen(title = title, content = content)
+                        }
                     }
 
                     val navDisplay = @Composable {
@@ -188,20 +248,74 @@ class MainActivity : ComponentActivity() {
                             entryProvider = entryProvider {
                                 entry<Route.Main> { mainScreenEntry() }
                                 entry<Route.About> { AboutScreen() }
-                                entry<Route.Sulog> { SulogScreen() }
+                                entry<Route.Sulog> { WearProtectedScreen(R.string.settings_sulog) { SulogScreen() } }
                                 entry<Route.ColorPalette> { ColorPaletteScreen() }
-                                entry<Route.AppProfileTemplate> { AppProfileTemplateScreen() }
-                                entry<Route.TemplateEditor> { key -> TemplateEditorScreen(key.template, key.readOnly) }
-                                entry<Route.AppProfile> { key -> AppProfileScreen(key.uid) }
-                                entry<Route.ModuleRepo> { ModuleRepoScreen() }
-                                entry<Route.ModuleRepoDetail> { key -> ModuleRepoDetailScreen(key.module) }
+                                entry<Route.AppProfileTemplate> {
+                                    WearProtectedScreen(R.string.settings_profile_template) { AppProfileTemplateScreen() }
+                                }
+                                entry<Route.TemplateEditor> { key ->
+                                    WearProtectedScreen(R.string.settings_profile_template) {
+                                        TemplateEditorScreen(key.template, key.readOnly)
+                                    }
+                                }
+                                entry<Route.AppProfile> { key ->
+                                    WearProtectedScreen(R.string.profile) { AppProfileScreen(key.uid) }
+                                }
+                                entry<Route.ModuleRepo> {
+                                    WearModuleInstallProtectedScreen(R.string.module_repos) { ModuleRepoScreen() }
+                                }
+                                entry<Route.ModuleRepoDetail> { key ->
+                                    WearModuleInstallProtectedScreen(R.string.module_repos) {
+                                        ModuleRepoDetailScreen(
+                                            key.module
+                                        )
+                                    }
+                                }
                                 entry<Route.Install> { InstallScreen() }
-                                entry<Route.Flash> { key -> FlashScreen(key.flashIt) }
-                                entry<Route.ExecuteModuleAction> { key -> ExecuteModuleActionScreen(key.moduleId, key.fromShortcut) }
-                                entry<Route.Home> { mainScreenEntry() }
-                                entry<Route.SuperUser> { mainScreenEntry() }
-                                entry<Route.Module> { mainScreenEntry() }
-                                entry<Route.Settings> { mainScreenEntry() }
+                                entry<Route.Flash> { key ->
+                                    if (key.flashIt is FlashIt.FlashModules) {
+                                        WearModuleInstallProtectedScreen(R.string.module) {
+                                            FlashScreen(
+                                                key.flashIt
+                                            )
+                                        }
+                                    } else {
+                                        FlashScreen(key.flashIt)
+                                    }
+                                }
+                                entry<Route.ExecuteModuleAction> { key ->
+                                    WearProtectedScreen(R.string.module_action) {
+                                        ExecuteModuleActionScreen(key.moduleId, key.fromShortcut)
+                                    }
+                                }
+                                entry<Route.Home> {
+                                    if (uiMode == UiMode.Wear) HomePager(
+                                        navigator,
+                                        0.dp
+                                    ) else mainScreenEntry()
+                                }
+                                entry<Route.SuperUser> {
+                                    WearProtectedScreen(
+                                        R.string.superuser,
+                                        showMainScreenOnNonWear = true
+                                    ) {
+                                        SuperUserPager(navigator, 0.dp)
+                                    }
+                                }
+                                entry<Route.Module> {
+                                    WearProtectedScreen(
+                                        R.string.module,
+                                        showMainScreenOnNonWear = true
+                                    ) {
+                                        ModulePager(0.dp)
+                                    }
+                                }
+                                entry<Route.Settings> {
+                                    if (uiMode == UiMode.Wear) SettingPager(
+                                        navigator,
+                                        0.dp
+                                    ) else mainScreenEntry()
+                                }
                             }
                         )
                     }
@@ -209,6 +323,9 @@ class MainActivity : ComponentActivity() {
                     when (uiMode) {
                         UiMode.Material -> androidx.compose.material3.Scaffold { navDisplay() }
                         UiMode.Miuix -> Scaffold { navDisplay() }
+                        UiMode.Wear -> androidx.wear.compose.material3.AppScaffold(
+                            timeText = { TimeText() }
+                        ) { navDisplay() }
                     }
                 }
             }
@@ -244,6 +361,7 @@ fun MainScreen(
     val surfaceColor = when (uiMode) {
         UiMode.Material -> MaterialTheme.colorScheme.surface // Blur is not used in Material, this is just a placeholder
         UiMode.Miuix -> MiuixTheme.colorScheme.surface
+        UiMode.Wear -> WearMaterialTheme.colorScheme.surfaceContainer
     }
     val blurBackdrop = rememberBlurBackdrop(enableBlur)
 
@@ -322,6 +440,16 @@ fun MainScreen(
                         }
                     }
                 }
+
+                UiMode.Wear -> Row {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .consumeWindowInsets(startInsets)
+                    ) {
+                        pagerContent(navBarBottomPadding)
+                    }
+                }
             }
         } else {
             val bottomBar = @Composable {
@@ -344,11 +472,12 @@ fun MainScreen(
                 UiMode.Miuix -> Scaffold(bottomBar = bottomBar) { innerPadding ->
                     pagerContent(innerPadding.calculateBottomPadding())
                 }
+
+                UiMode.Wear -> pagerContent(0.dp)
             }
         }
     }
 }
-
 
 @Composable
 private fun MainScreenBackHandler(
@@ -432,6 +561,7 @@ private fun ZipFileIntentHandler(
 @Composable
 private fun ShortcutIntentHandler(
     intentState: MutableStateFlow<Int>,
+    canUseKernelFeatures: Boolean,
 ) {
     val activity = LocalActivity.current ?: return
     val context = LocalContext.current
@@ -443,6 +573,11 @@ private fun ShortcutIntentHandler(
 
         when (type) {
             "module_action" -> {
+                if (!canUseKernelFeatures) {
+                    intent.removeExtra("shortcut_type")
+                    intent.removeExtra("module_id")
+                    return@LaunchedEffect
+                }
                 val moduleId = intent.getStringExtra("module_id") ?: return@LaunchedEffect
                 navigator.push(Route.ExecuteModuleAction(moduleId, fromShortcut = true))
                 intent.removeExtra("shortcut_type")
@@ -450,6 +585,11 @@ private fun ShortcutIntentHandler(
             }
 
             "module_webui" -> {
+                if (!canUseKernelFeatures) {
+                    intent.removeExtra("shortcut_type")
+                    intent.removeExtra("module_id")
+                    return@LaunchedEffect
+                }
                 val moduleId = intent.getStringExtra("module_id") ?: return@LaunchedEffect
                 val webIntent = Intent(context, WebUIActivity::class.java)
                     .setData("kernelsu://webui/$moduleId".toUri())

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/UiMode.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/UiMode.kt
@@ -1,19 +1,33 @@
 package me.weishu.kernelsu.ui
 
+import android.content.pm.PackageManager
 import androidx.compose.runtime.staticCompositionLocalOf
+import me.weishu.kernelsu.ksuApp
 
 enum class UiMode(val value: String) {
     Miuix("miuix"),
-    Material("material");
+    Material("material"),
+    Wear("wear");
 
     companion object {
         fun fromValue(value: String): UiMode = when (value) {
             Material.value -> Material
+            Wear.value -> Wear
             else -> Miuix
         }
 
-        val DEFAULT_VALUE = Miuix.value
+        val isWatchDevice: Boolean by lazy {
+            ksuApp.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)
+        }
+
+        val DEFAULT_VALUE: String
+            get() = if (isWatchDevice) Wear.value else Miuix.value
+
+        val defaultUiMode: UiMode
+            get() = if (isWatchDevice) Wear else Miuix
     }
 }
 
-val LocalUiMode = staticCompositionLocalOf { UiMode.Miuix }
+val LocalUiMode = staticCompositionLocalOf { UiMode.defaultUiMode }
+
+val LocalScreenShape = staticCompositionLocalOf { "round" }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/UiMode.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/UiMode.kt
@@ -17,7 +17,9 @@ enum class UiMode(val value: String) {
         }
 
         val isWatchDevice: Boolean by lazy {
-            ksuApp.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)
+            runCatching {
+                ksuApp.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)
+            }.getOrDefault(false)
         }
 
         val DEFAULT_VALUE: String
@@ -28,6 +30,16 @@ enum class UiMode(val value: String) {
     }
 }
 
-val LocalUiMode = staticCompositionLocalOf { UiMode.defaultUiMode }
+val LocalUiMode = staticCompositionLocalOf { UiMode.Miuix }
 
-val LocalScreenShape = staticCompositionLocalOf { "round" }
+enum class ScreenShape(val value: String) {
+    Round("round"),
+    Square("square");
+
+    companion object {
+        // Defaults to Round for any unrecognized value, matching the SharedPreferences default.
+        fun fromValue(value: String): ScreenShape = if (value == Square.value) Square else Round
+    }
+}
+
+val LocalScreenShape = staticCompositionLocalOf { ScreenShape.Round }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/AppIconImage.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/AppIconImage.kt
@@ -102,6 +102,7 @@ private fun PlaceHolderBox(modifier: Modifier = Modifier) {
     val containerColor = when (LocalUiMode.current) {
         UiMode.Material -> MaterialTheme.colorScheme.secondaryContainer
         UiMode.Miuix -> MiuixTheme.colorScheme.secondaryContainer
+        UiMode.Wear -> MaterialTheme.colorScheme.secondaryContainer
     }
 
     Box(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/bottombar/BottomBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/bottombar/BottomBar.kt
@@ -93,6 +93,7 @@ fun BottomBar(
     when (LocalUiMode.current) {
         UiMode.Miuix -> BottomBarMiuix(blurBackdrop, backdrop, modifier)
         UiMode.Material -> BottomBarMaterial()
+        UiMode.Wear -> BottomBarMaterial()
     }
 }
 
@@ -104,5 +105,6 @@ fun SideRail(
     when (LocalUiMode.current) {
         UiMode.Miuix -> NavigationRailMiuix(blurBackdrop, modifier)
         UiMode.Material -> NavigationRailMaterial(modifier)
+        UiMode.Wear -> NavigationRailMaterial(modifier)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/choosekmidialog/ChooseKmiDialog.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/choosekmidialog/ChooseKmiDialog.kt
@@ -13,5 +13,6 @@ fun ChooseKmiDialog(
     when (LocalUiMode.current) {
         UiMode.Miuix -> ChooseKmiDialogMiuix(show, onDismissRequest, onSelected)
         UiMode.Material -> ChooseKmiDialogMaterial(show, onDismissRequest, onSelected)
+        UiMode.Wear -> ChooseKmiDialogMaterial(show, onDismissRequest, onSelected)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/dialog/Dialog.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/dialog/Dialog.kt
@@ -303,6 +303,7 @@ fun rememberLoadingDialog(): LoadingDialogHandle {
     when (LocalUiMode.current) {
         UiMode.Miuix -> LoadingDialogMiuix(visible)
         UiMode.Material -> LoadingDialogMaterial(visible)
+        UiMode.Wear -> LoadingDialogMaterial(visible)
     }
 
     return remember {
@@ -336,6 +337,13 @@ private fun rememberConfirmDialog(visuals: ConfirmDialogVisuals, callback: Confi
         )
 
         UiMode.Material -> ConfirmDialogMaterial(
+            handle.visuals,
+            confirm = { coroutineScope.launch { resultChannel.send(ConfirmResult.Confirmed) } },
+            dismiss = { coroutineScope.launch { resultChannel.send(ConfirmResult.Canceled) } },
+            showDialog = visible
+        )
+
+        UiMode.Wear -> ConfirmDialogMaterial(
             handle.visuals,
             confirm = { coroutineScope.launch { resultChannel.send(ConfirmResult.Confirmed) } },
             dismiss = { coroutineScope.launch { resultChannel.send(ConfirmResult.Canceled) } },

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/GithubMarkdown.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/GithubMarkdown.kt
@@ -382,6 +382,20 @@ private fun getMarkdownColors(containerColor: androidx.compose.ui.graphics.Color
             )
         }
 
+        UiMode.Wear -> {
+            val bgArgb =
+                containerColor?.toArgb() ?: MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
+                    .toArgb()
+
+            MarkdownColors(
+                bgDefault = cssColorFromArgb(bgArgb),
+                bgCode = cssColorFromArgb(MaterialTheme.colorScheme.surfaceContainerHigh.toArgb()),
+                bgRowAlt = cssColorFromArgb(MaterialTheme.colorScheme.surfaceContainerLow.toArgb()),
+                fgDefault = cssColorFromArgb(MaterialTheme.colorScheme.onSurface.toArgb()),
+                fgLink = cssColorFromArgb(MaterialTheme.colorScheme.primary.toArgb())
+            )
+        }
+
         UiMode.Miuix -> {
             val bgArgb = containerColor?.toArgb() ?: MiuixTheme.colorScheme.surfaceContainer.toArgb()
             val bgLuminance = relativeLuminance(bgArgb)

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/MarkdownContent.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/MarkdownContent.kt
@@ -28,6 +28,7 @@ fun MarkdownContent(
     val containerColor = when (LocalUiMode.current) {
         UiMode.Material -> MaterialTheme.colorScheme.surfaceContainerHigh
         UiMode.Miuix -> null
+        UiMode.Wear -> MaterialTheme.colorScheme.surfaceContainerHigh
     }
     Box(Modifier.fillMaxWidth()) {
         Box(Modifier.verticalScroll(rememberScrollState())) {
@@ -48,6 +49,7 @@ fun MarkdownContent(
                 when (LocalUiMode.current) {
                     UiMode.Material -> LoadingIndicator()
                     UiMode.Miuix -> InfiniteProgressIndicator()
+                    UiMode.Wear -> LoadingIndicator()
                 }
             }
         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/profile/ProfileConfig.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/profile/ProfileConfig.kt
@@ -30,6 +30,14 @@ fun AppProfileConfig(
             profile = profile,
             onProfileChange = onProfileChange
         )
+
+        UiMode.Wear -> AppProfileConfigMaterial(
+            modifier = modifier,
+            fixedName = fixedName,
+            enabled = enabled,
+            profile = profile,
+            onProfileChange = onProfileChange
+        )
     }
 }
 
@@ -56,6 +64,13 @@ fun RootProfileConfig(
             profile = profile,
             onProfileChange = onProfileChange
         )
+
+        UiMode.Wear -> RootProfileConfigMaterial(
+            modifier = modifier,
+            enabled = enabled,
+            profile = profile,
+            onProfileChange = onProfileChange
+        )
     }
 }
 
@@ -77,6 +92,13 @@ fun TemplateConfig(
         )
 
         UiMode.Material -> TemplateConfigMaterial(
+            profile = profile,
+            onViewTemplate = onViewTemplate,
+            onManageTemplate = onManageTemplate,
+            onProfileChange = onProfileChange
+        )
+
+        UiMode.Wear -> TemplateConfigMaterial(
             profile = profile,
             onViewTemplate = onViewTemplate,
             onManageTemplate = onManageTemplate,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/rebootlistpopup/RebootListPopup.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/rebootlistpopup/RebootListPopup.kt
@@ -39,5 +39,6 @@ fun RebootListPopup() {
     when (LocalUiMode.current) {
         UiMode.Miuix -> RebootListPopupMiuix()
         UiMode.Material -> RebootListPopupMaterial()
+        UiMode.Wear -> RebootListPopupMaterial()
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/statustag/StatusTag.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/statustag/StatusTag.kt
@@ -16,5 +16,6 @@ fun StatusTag(
     when (LocalUiMode.current) {
         UiMode.Miuix -> StatusTagMiuix(label, backgroundColor, contentColor)
         UiMode.Material -> StatusTagMaterial(label, modifier, backgroundColor, contentColor)
+        UiMode.Wear -> StatusTagMaterial(label, modifier, backgroundColor, contentColor)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/uninstalldialog/UninstallDialog.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/uninstalldialog/UninstallDialog.kt
@@ -12,5 +12,6 @@ fun UninstallDialog(
     when (LocalUiMode.current) {
         UiMode.Miuix -> UninstallDialogMiuix(show, onDismissRequest)
         UiMode.Material -> UninstallDialogMaterial(show, onDismissRequest)
+        UiMode.Wear -> UninstallDialogMaterial(show, onDismissRequest)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutScreen.kt
@@ -1,7 +1,7 @@
 package me.weishu.kernelsu.ui.screen.about
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.dropUnlessResumed
 import me.weishu.kernelsu.BuildConfig
@@ -9,11 +9,12 @@ import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
+import me.weishu.kernelsu.ui.util.openExternalUrl
 
 @Composable
 fun AboutScreen() {
     val navigator = LocalNavigator.current
-    val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
     val htmlString = stringResource(
         id = R.string.about_source_code,
         "<b><a href=\"https://github.com/tiann/KernelSU\">GitHub</a></b>",
@@ -27,11 +28,12 @@ fun AboutScreen() {
     )
     val actions = AboutScreenActions(
         onBack = dropUnlessResumed { navigator.pop() },
-        onOpenLink = uriHandler::openUri,
+        onOpenLink = { openExternalUrl(context, it) },
     )
 
     when (LocalUiMode.current) {
         UiMode.Miuix -> AboutScreenMiuix(state, actions)
         UiMode.Material -> AboutScreenMaterial(state, actions)
+        UiMode.Wear -> AboutScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutWear.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
@@ -13,7 +12,7 @@ import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
-import me.weishu.kernelsu.ui.LocalScreenShape
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
 
 @Composable
 fun AboutScreenWear(
@@ -21,7 +20,7 @@ fun AboutScreenWear(
     actions: AboutScreenActions,
 ) {
     val listState = rememberTransformingLazyColumnState()
-    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+    val horizontalPadding = wearHorizontalPadding()
 
     ScreenScaffold(
         scrollState = listState,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/about/AboutWear.kt
@@ -1,0 +1,66 @@
+package me.weishu.kernelsu.ui.screen.about
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.ui.LocalScreenShape
+
+@Composable
+fun AboutScreenWear(
+    state: AboutUiState,
+    actions: AboutScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(state.title)
+                }
+            }
+            item {
+                Text(
+                    text = state.appName,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+            }
+            item {
+                Text(
+                    text = "${state.versionName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+            }
+            state.links.forEach { link ->
+                item {
+                    Button(
+                        modifier = Modifier
+                            .padding(horizontal = horizontalPadding)
+                            .fillMaxWidth(),
+                        onClick = { actions.onOpenLink(link.url) },
+                        colors = ButtonDefaults.filledTonalButtonColors(),
+                        label = { Text(link.fullText) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
@@ -142,5 +142,10 @@ fun AppProfileScreen(uid: Int) {
             state = state,
             actions = actions,
         )
+
+        UiMode.Wear -> AppProfileScreenWear(
+            state = state,
+            actions = actions,
+        )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileWear.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
@@ -16,7 +15,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.LocalScreenShape
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
 
 @Composable
 fun AppProfileScreenWear(
@@ -24,7 +23,7 @@ fun AppProfileScreenWear(
     actions: AppProfileActions,
 ) {
     val listState = rememberTransformingLazyColumnState()
-    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+    val horizontalPadding = wearHorizontalPadding()
     val profile = state.profile
 
     ScreenScaffold(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileWear.kt
@@ -1,0 +1,98 @@
+package me.weishu.kernelsu.ui.screen.appprofile
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.LocalScreenShape
+
+@Composable
+fun AppProfileScreenWear(
+    state: AppProfileUiState,
+    actions: AppProfileActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+    val profile = state.profile
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.profile))
+                }
+            }
+
+            item {
+                Card(
+                    onClick = {},
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                ) {
+                    Text(
+                        text = state.packageName,
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Text(
+                        text = "UID: ${state.uid}",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    Text(
+                        text = if (profile.allowSu) stringResource(R.string.superuser_allow) else stringResource(
+                            R.string.superuser_deny
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+
+            item {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = {
+                        actions.onProfileChange(profile.copy(allowSu = !profile.allowSu))
+                    },
+                    colors = if (profile.allowSu) ButtonDefaults.buttonColors() else ButtonDefaults.filledTonalButtonColors(),
+                    label = {
+                        Text(
+                            if (profile.allowSu) stringResource(R.string.superuser_allow)
+                            else stringResource(R.string.superuser_deny)
+                        )
+                    },
+                    secondaryLabel = { Text(stringResource(R.string.superuser_allow_root_access)) },
+                )
+            }
+
+            item {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = actions.onManageTemplate,
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                    label = { Text(stringResource(R.string.settings_profile_template)) },
+                )
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteScreen.kt
@@ -62,5 +62,6 @@ fun ColorPaletteScreen() {
     when (LocalUiMode.current) {
         UiMode.Miuix -> ColorPaletteScreenMiuix(state, actions)
         UiMode.Material -> ColorPaletteScreenMaterial(state, actions)
+        UiMode.Wear -> ColorPaletteScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteWear.kt
@@ -1,0 +1,54 @@
+package me.weishu.kernelsu.ui.screen.colorpalette
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.LocalScreenShape
+
+@Composable
+fun ColorPaletteScreenWear(
+    state: ColorPaletteUiState,
+    actions: ColorPaletteScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.settings_theme))
+                }
+            }
+            item {
+                Card(
+                    onClick = {},
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_theme_wear_note),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/colorpalette/ColorPaletteWear.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Card
@@ -14,7 +13,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.LocalScreenShape
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
 
 @Composable
 fun ColorPaletteScreenWear(
@@ -22,7 +21,7 @@ fun ColorPaletteScreenWear(
     actions: ColorPaletteScreenActions,
 ) {
     val listState = rememberTransformingLazyColumnState()
-    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+    val horizontalPadding = wearHorizontalPadding()
 
     ScreenScaffold(
         scrollState = listState,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
@@ -50,5 +50,6 @@ fun ExecuteModuleActionScreen(moduleId: String, fromShortcut: Boolean = false) {
     when (LocalUiMode.current) {
         UiMode.Miuix -> ExecuteModuleActionScreenMiuix(state, actions)
         UiMode.Material -> ExecuteModuleActionScreenMaterial(state, actions)
+        UiMode.Wear -> ExecuteModuleActionScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionWear.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
 import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
 import androidx.wear.compose.material3.Button
@@ -15,7 +14,7 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.LocalScreenShape
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
 
 @Composable
 fun ExecuteModuleActionScreenWear(
@@ -23,7 +22,7 @@ fun ExecuteModuleActionScreenWear(
     actions: ExecuteModuleActionScreenActions,
 ) {
     val listState = rememberTransformingLazyColumnState()
-    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+    val horizontalPadding = wearHorizontalPadding()
 
     ScreenScaffold(
         scrollState = listState,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionWear.kt
@@ -1,0 +1,59 @@
+package me.weishu.kernelsu.ui.screen.executemoduleaction
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.LocalScreenShape
+
+@Composable
+fun ExecuteModuleActionScreenWear(
+    state: ExecuteModuleActionUiState,
+    actions: ExecuteModuleActionScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.module_action))
+                }
+            }
+            item {
+                Text(
+                    text = state.text,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = horizontalPadding),
+                )
+            }
+            item {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = actions.onSaveLog,
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                    label = { Text(stringResource(R.string.save_log)) },
+                )
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
@@ -62,5 +62,6 @@ fun FlashScreen(flashIt: FlashIt) {
     when (LocalUiMode.current) {
         UiMode.Miuix -> FlashScreenMiuix(state, actions)
         UiMode.Material -> FlashScreenMaterial(state, actions)
+        UiMode.Wear -> FlashScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashWear.kt
@@ -1,0 +1,97 @@
+package me.weishu.kernelsu.ui.screen.flash
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun FlashScreenWear(
+    state: FlashUiState,
+    actions: FlashScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(
+                        when (state.flashingStatus) {
+                            FlashingStatus.FLASHING -> stringResource(R.string.flashing)
+                            FlashingStatus.SUCCESS -> stringResource(R.string.flash_success)
+                            FlashingStatus.FAILED -> stringResource(R.string.flash_failed)
+                        }
+                    )
+                }
+            }
+
+            if (state.showJailbreakWarning) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.jailbreak_flash_warning),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        isError = true,
+                    )
+                }
+                item {
+                    WearPrimaryButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onConfirmJailbreakWarning,
+                        label = stringResource(R.string.confirm),
+                    )
+                }
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onDismissJailbreakWarning,
+                        label = stringResource(R.string.cancel),
+                    )
+                }
+            } else {
+                item {
+                    WearMessageText(
+                        text = state.text,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+
+                if (state.flashingStatus != FlashingStatus.FLASHING) {
+                    item {
+                        WearTonalButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = actions.onSaveLog,
+                            label = stringResource(R.string.save_log),
+                        )
+                    }
+                }
+
+                if (state.showRebootAction) {
+                    item {
+                        WearPrimaryButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = actions.onReboot,
+                            label = stringResource(R.string.reboot),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -26,6 +25,7 @@ import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.navigation3.Navigator
 import me.weishu.kernelsu.ui.navigation3.Route
+import me.weishu.kernelsu.ui.util.openExternalUrl
 import me.weishu.kernelsu.ui.viewmodel.HomeViewModel
 
 @Composable
@@ -36,8 +36,8 @@ fun HomePager(
 ) {
     val viewModel = viewModel<HomeViewModel>()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val mainState = LocalMainPagerState.current
-    val uriHandler = LocalUriHandler.current
+    val uiMode = LocalUiMode.current
+    val mainState = if (uiMode != UiMode.Wear) LocalMainPagerState.current else null
     val context = LocalContext.current
     val loadingDialog = rememberLoadingDialog()
     val scope = rememberCoroutineScope()
@@ -53,9 +53,9 @@ fun HomePager(
 
     val actions = HomeActions(
         onInstallClick = { navigator.push(Route.Install) },
-        onSuperuserClick = { mainState.animateToPage(1) },
-        onModuleClick = { mainState.animateToPage(2) },
-        onOpenUrl = uriHandler::openUri,
+        onSuperuserClick = { mainState?.animateToPage(1) ?: navigator.push(Route.SuperUser) },
+        onModuleClick = { mainState?.animateToPage(2) ?: navigator.push(Route.Module) },
+        onOpenUrl = { openExternalUrl(context, it) },
         onJailbreakClick = {
             loadingDialog.showLoading()
             context.startService(Intent(context, MagicaService::class.java))
@@ -82,6 +82,11 @@ fun HomePager(
             state = uiState,
             actions = actions,
             bottomInnerPadding = bottomInnerPadding,
+        )
+
+        UiMode.Wear -> HomePagerWear(
+            state = uiState,
+            actions = actions,
         )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeWear.kt
@@ -1,0 +1,183 @@
+package me.weishu.kernelsu.ui.screen.home
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun HomePagerWear(
+    state: HomeUiState,
+    actions: HomeActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.app_name))
+                }
+            }
+
+            item {
+                WearStatusCard(
+                    state = state,
+                    onInstallClick = actions.onInstallClick,
+                )
+            }
+
+            if (state.isFullFeatured) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onSuperuserClick,
+                        label = stringResource(R.string.superuser),
+                        secondaryLabel = state.superuserCount.toString(),
+                    )
+                }
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onModuleClick,
+                        label = stringResource(R.string.module),
+                        secondaryLabel = state.moduleCount.toString(),
+                    )
+                }
+            }
+
+            if (state.showGkiWarning) {
+                item { WearWarningCard(stringResource(R.string.home_gki_warning)) }
+            }
+            if (state.showRequireKernelWarning) {
+                item {
+                    WearWarningCard(
+                        stringResource(
+                            R.string.require_kernel_version,
+                            state.ksuVersion ?: 0,
+                            me.weishu.kernelsu.Natives.MINIMAL_SUPPORTED_KERNEL
+                        )
+                    )
+                }
+            }
+            if (state.showRootWarning) {
+                item { WearWarningCard(stringResource(R.string.grant_root_failed)) }
+            }
+
+            item {
+                WearInfoCard(state.systemInfo)
+            }
+
+            if (state.ksuVersion == null && !state.isLateLoadMode) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onInstallClick,
+                        label = stringResource(R.string.home_click_to_install),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WearStatusCard(
+    state: HomeUiState,
+    onInstallClick: () -> Unit,
+) {
+    val horizontalPadding = wearHorizontalPadding()
+    val canInstall = state.ksuVersion == null && !state.isLateLoadMode
+    val (title, subtitle) = when {
+        state.ksuVersion != null -> {
+            val mode = when (state.lkmMode) {
+                true -> " (LKM)"
+                false -> " (GKI)"
+                null -> ""
+            }
+            stringResource(R.string.home_working) + mode to
+                    stringResource(R.string.home_working_version, state.ksuVersion)
+        }
+
+        state.kernelVersion.isGKI() ->
+            stringResource(R.string.home_not_installed) to stringResource(R.string.home_click_to_install)
+
+        else ->
+            stringResource(R.string.home_unsupported) to stringResource(R.string.home_unsupported_reason)
+    }
+
+    Card(
+        onClick = {
+            if (canInstall) onInstallClick()
+        },
+        modifier = Modifier
+            .padding(horizontal = horizontalPadding)
+            .fillMaxWidth(),
+    ) {
+        Text(text = title, style = MaterialTheme.typography.titleSmall)
+        Text(text = subtitle, style = MaterialTheme.typography.bodySmall)
+    }
+}
+
+@Composable
+private fun WearWarningCard(message: String) {
+    val horizontalPadding = wearHorizontalPadding()
+    Card(
+        onClick = {},
+        modifier = Modifier
+            .padding(horizontal = horizontalPadding)
+            .fillMaxWidth(),
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun WearInfoCard(systemInfo: SystemInfo) {
+    val horizontalPadding = wearHorizontalPadding()
+    Card(
+        onClick = {},
+        modifier = Modifier
+            .padding(horizontal = horizontalPadding)
+            .fillMaxWidth(),
+    ) {
+        Text(
+            text = stringResource(R.string.home_kernel),
+            style = MaterialTheme.typography.labelSmall,
+        )
+        Text(
+            text = systemInfo.kernelVersion,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = stringResource(R.string.home_manager_version),
+            style = MaterialTheme.typography.labelSmall,
+        )
+        Text(
+            text = systemInfo.managerVersion,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
@@ -188,5 +188,6 @@ fun InstallScreen() {
     when (LocalUiMode.current) {
         UiMode.Miuix -> InstallScreenMiuix(state, actions)
         UiMode.Material -> InstallScreenMaterial(state, actions)
+        UiMode.Wear -> InstallScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallWear.kt
@@ -1,0 +1,104 @@
+package me.weishu.kernelsu.ui.screen.install
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+internal fun InstallScreenWear(
+    state: InstallUiState,
+    actions: InstallScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+    val selectedFile = (state.installMethod as? InstallMethod.SelectFile)?.uri?.lastPathSegment
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.install))
+                }
+            }
+
+            state.installMethodOptions.forEach { method ->
+                item {
+                    val isSelected = method::class == state.installMethod?.let { it::class }
+                    val onClick = {
+                        when (method) {
+                            is InstallMethod.SelectFile -> actions.onSelectBootImage()
+                            else -> actions.onSelectMethod(method)
+                        }
+                    }
+                    if (isSelected) {
+                        WearPrimaryButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = onClick,
+                            label = method.label(),
+                            secondaryLabel = method.summary,
+                        )
+                    } else {
+                        WearTonalButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = onClick,
+                            label = method.label(),
+                            secondaryLabel = method.summary,
+                        )
+                    }
+                }
+            }
+
+            selectedFile?.let { fileName ->
+                item {
+                    WearMessageText(
+                        text = fileName,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+
+            if (state.currentKmi.isNotBlank()) {
+                item {
+                    WearMessageText(
+                        text = "KMI: ${state.currentKmi}",
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+
+            item {
+                WearPrimaryButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onNext,
+                    label = stringResource(R.string.install_next),
+                    enabled = state.installMethod != null,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InstallMethod.label(): String {
+    return when (this) {
+        is InstallMethod.DirectInstall -> stringResource(R.string.direct_install)
+        is InstallMethod.DirectInstallToInactiveSlot -> stringResource(R.string.install_inactive_slot)
+        is InstallMethod.SelectFile -> stringResource(R.string.select_file)
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleScreen.kt
@@ -161,5 +161,12 @@ fun ModulePager(
             actions = actions,
             bottomInnerPadding = bottomInnerPadding,
         )
+
+        UiMode.Wear -> ModulePagerWear(
+            uiState = rawUiState,
+            confirmDialogState = rawUiState.confirmDialogState,
+            effect = rawUiState.effect,
+            actions = actions,
+        )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleWear.kt
@@ -1,0 +1,311 @@
+package me.weishu.kernelsu.ui.screen.module
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.data.model.Module
+import me.weishu.kernelsu.data.model.ModuleUpdateInfo
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun ModulePagerWear(
+    uiState: ModuleUiState,
+    confirmDialogState: ModuleConfirmDialogState?,
+    effect: ModuleEffect?,
+    actions: ModuleActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val context = LocalContext.current
+    val horizontalPadding = wearHorizontalPadding()
+    var expandedModuleId by remember { mutableStateOf<String?>(null) }
+    val modules =
+        if (uiState.searchStatus.searchText.isNotEmpty()) uiState.searchResults else uiState.moduleList
+
+    LaunchedEffect(effect) {
+        when (effect) {
+            is ModuleEffect.Toast -> {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                actions.onConsumeEffect()
+            }
+
+            is ModuleEffect.SnackBar -> {
+                Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                actions.onConsumeEffect()
+            }
+
+            null -> Unit
+        }
+    }
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.module))
+                }
+            }
+
+            if (uiState.magiskInstalled) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.module_magisk_conflict),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        isError = true,
+                    )
+                }
+            } else {
+                if (uiState.installButtonVisible) {
+                    item {
+                        WearPrimaryButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = actions.onOpenRepo,
+                            label = stringResource(R.string.module_repos),
+                        )
+                    }
+                } else if (uiState.isSafeMode) {
+                    item {
+                        WearMessageText(
+                            text = stringResource(R.string.safe_mode_module_disabled),
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            isError = true,
+                        )
+                    }
+                }
+
+                if (confirmDialogState != null) {
+                    item {
+                        ModuleWearConfirmSection(
+                            confirmDialogState = confirmDialogState,
+                            horizontalPadding = horizontalPadding,
+                            onConfirm = {
+                                when (val request = confirmDialogState.request) {
+                                    is ModuleConfirmRequest.Uninstall -> actions.onUninstallModule(
+                                        request.module
+                                    )
+
+                                    is ModuleConfirmRequest.Update -> actions.onConfirmUpdate(
+                                        request
+                                    )
+                                }
+                            },
+                            onDismiss = actions.onDismissConfirmRequest,
+                        )
+                    }
+                }
+
+                if (uiState.isRefreshing || !uiState.hasLoaded) {
+                    item {
+                        WearMessageText(
+                            text = if (uiState.isRefreshing) stringResource(R.string.processing) else "",
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        )
+                    }
+                } else if (modules.isEmpty()) {
+                    item {
+                        WearMessageText(
+                            text = stringResource(R.string.module_empty),
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        )
+                    }
+                } else {
+                    items(modules, key = { it.id }) { module ->
+                        ModuleWearItem(
+                            module = module,
+                            updateInfo = uiState.updateInfo[module.id],
+                            expanded = expandedModuleId == module.id,
+                            horizontalPadding = horizontalPadding,
+                            onToggleExpand = {
+                                expandedModuleId =
+                                    if (expandedModuleId == module.id) null else module.id
+                            },
+                            actions = actions,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModuleWearConfirmSection(
+    confirmDialogState: ModuleConfirmDialogState,
+    horizontalPadding: androidx.compose.ui.unit.Dp,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = confirmDialogState.title,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(horizontal = horizontalPadding),
+        )
+        confirmDialogState.content?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(horizontal = horizontalPadding),
+            )
+        }
+        Button(
+            modifier = Modifier
+                .padding(horizontal = horizontalPadding)
+                .fillMaxWidth(),
+            onClick = onConfirm,
+            label = { Text(confirmDialogState.confirm ?: stringResource(R.string.confirm)) },
+        )
+        Button(
+            modifier = Modifier
+                .padding(horizontal = horizontalPadding)
+                .fillMaxWidth(),
+            onClick = onDismiss,
+            colors = ButtonDefaults.filledTonalButtonColors(),
+            label = { Text(confirmDialogState.dismiss ?: stringResource(R.string.undo)) },
+        )
+    }
+}
+
+@Composable
+private fun ModuleWearItem(
+    module: Module,
+    updateInfo: ModuleUpdateInfo?,
+    expanded: Boolean,
+    horizontalPadding: androidx.compose.ui.unit.Dp,
+    onToggleExpand: () -> Unit,
+    actions: ModuleActions,
+) {
+    val secondary = buildString {
+        append(module.version)
+        append(" • ")
+        append(module.author)
+        if (module.update) append(" • ${stringResource(R.string.module_update)}")
+        if (module.remove) append(" • ${stringResource(R.string.uninstall)}")
+        if (module.metamodule) append(" • Meta")
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Button(
+            modifier = Modifier
+                .padding(horizontal = horizontalPadding)
+                .fillMaxWidth(),
+            onClick = onToggleExpand,
+            label = { Text(module.name, maxLines = 1) },
+            secondaryLabel = { Text(secondary, maxLines = 2) },
+            colors = if (module.enabled) {
+                ButtonDefaults.buttonColors()
+            } else {
+                ButtonDefaults.filledTonalButtonColors()
+            },
+        )
+
+        if (expanded) {
+            if (module.update && updateInfo != null) {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = { actions.onRequestUpdateConfirmation(module, updateInfo) },
+                    label = { Text(stringResource(R.string.module_update)) },
+                )
+            }
+
+            Button(
+                modifier = Modifier
+                    .padding(horizontal = horizontalPadding)
+                    .fillMaxWidth(),
+                onClick = { actions.onToggleModule(module) },
+                colors = ButtonDefaults.filledTonalButtonColors(),
+                label = {
+                    Text(
+                        if (module.enabled) stringResource(R.string.disable) else stringResource(
+                            R.string.enable
+                        )
+                    )
+                },
+            )
+
+            if (module.hasWebUi) {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = { actions.onOpenWebUi(module) },
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                    label = { Text(stringResource(R.string.webui)) },
+                )
+            }
+
+            if (module.hasActionScript) {
+                Button(
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                    onClick = { actions.onExecuteModuleAction(module) },
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                    label = { Text(stringResource(R.string.module_action)) },
+                )
+            }
+
+            Button(
+                modifier = Modifier
+                    .padding(horizontal = horizontalPadding)
+                    .fillMaxWidth(),
+                onClick = {
+                    if (module.remove) {
+                        actions.onUndoUninstallModule(module)
+                    } else {
+                        actions.onRequestUninstallConfirmation(module)
+                    }
+                },
+                colors = ButtonDefaults.filledTonalButtonColors(),
+                label = {
+                    Text(
+                        if (module.remove) stringResource(R.string.undo) else stringResource(
+                            R.string.uninstall
+                        )
+                    )
+                },
+            )
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoScreen.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.Dispatchers
@@ -17,6 +17,7 @@ import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.screen.flash.FlashIt
 import me.weishu.kernelsu.ui.util.module.fetchModuleDetail
+import me.weishu.kernelsu.ui.util.openExternalUrl
 import me.weishu.kernelsu.ui.viewmodel.ModuleRepoViewModel
 import me.weishu.kernelsu.ui.viewmodel.ModuleViewModel
 
@@ -61,13 +62,14 @@ fun ModuleRepoScreen() {
     when (LocalUiMode.current) {
         UiMode.Miuix -> ModuleRepoScreenMiuix(uiState, actions)
         UiMode.Material -> ModuleRepoScreenMaterial(uiState, actions)
+        UiMode.Wear -> ModuleRepoScreenWear(uiState, actions)
     }
 }
 
 @Composable
 fun ModuleRepoDetailScreen(module: RepoModuleArg) {
     val navigator = LocalNavigator.current
-    val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
     var readmeHtml by remember(module.moduleId) { mutableStateOf<String?>(null) }
     var readmeLoaded by remember(module.moduleId) { mutableStateOf(false) }
     var detailReleases by remember(module.moduleId) { mutableStateOf<List<ReleaseArg>>(emptyList()) }
@@ -116,13 +118,14 @@ fun ModuleRepoDetailScreen(module: RepoModuleArg) {
     )
     val actions = ModuleRepoDetailActions(
         onBack = { navigator.pop() },
-        onOpenWebUrl = { if (webUrl.isNotEmpty()) uriHandler.openUri(webUrl) },
-        onOpenUrl = uriHandler::openUri,
+        onOpenWebUrl = { if (webUrl.isNotEmpty()) openExternalUrl(context, webUrl) },
+        onOpenUrl = { openExternalUrl(context, it) },
         onInstallModule = { uri -> navigator.push(Route.Flash(FlashIt.FlashModules(listOf(uri)))) },
     )
 
     when (LocalUiMode.current) {
         UiMode.Miuix -> ModuleRepoDetailScreenMiuix(state, actions)
         UiMode.Material -> ModuleRepoDetailScreenMaterial(state, actions)
+        UiMode.Wear -> ModuleRepoDetailScreenWear(state, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoWear.kt
@@ -201,6 +201,9 @@ fun ModuleRepoDetailScreenWear(
                                             onDownloading = {
                                                 isDownloading = true
                                             },
+                                            onFailed = {
+                                                isDownloading = false
+                                            },
                                             onProgress = { p ->
                                                 progress = p
                                             },

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoWear.kt
@@ -1,0 +1,227 @@
+package me.weishu.kernelsu.ui.screen.modulerepo
+
+import android.net.Uri
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.util.download
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearSearchField
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+import java.io.File
+
+@Composable
+fun ModuleRepoScreenWear(
+    uiState: ModuleRepoUiState,
+    actions: ModuleRepoActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+    val modules =
+        if (uiState.searchStatus.searchText.isNotEmpty()) uiState.searchResults else uiState.modules
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.module_repos))
+                }
+            }
+
+            item {
+                WearSearchField(
+                    value = uiState.searchStatus.searchText,
+                    placeholder = stringResource(R.string.wear_search_modules),
+                    onValueChange = actions.onSearchTextChange,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            if (uiState.searchStatus.searchText.isNotEmpty()) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onClearSearch,
+                        label = stringResource(R.string.delete),
+                    )
+                }
+            }
+
+            item {
+                WearTonalButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onRefresh,
+                    label = stringResource(R.string.pull_down_refresh),
+                )
+            }
+
+            if (uiState.isRefreshing) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.processing),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else if (modules.isEmpty()) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.module_empty),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else {
+                items(modules, key = { it.moduleId }) { module ->
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onOpenRepoDetail(module) },
+                        label = module.moduleName,
+                        secondaryLabel = module.authors,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ModuleRepoDetailScreenWear(
+    state: ModuleRepoDetailUiState,
+    actions: ModuleRepoDetailActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(state.module.moduleName)
+                }
+            }
+
+            item {
+                Card(
+                    onClick = {},
+                    modifier = Modifier
+                        .padding(horizontal = horizontalPadding)
+                        .fillMaxWidth(),
+                ) {
+                    Text(
+                        text = state.module.authors,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    state.module.latestRelease.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+            }
+
+            item {
+                WearTonalButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onOpenWebUrl,
+                    label = stringResource(R.string.module_repo_open_web),
+                )
+            }
+
+            state.detailReleases.forEach { release ->
+                item {
+                    Card(
+                        onClick = {},
+                        modifier = Modifier
+                            .padding(horizontal = horizontalPadding)
+                            .fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = release.name.ifEmpty { release.tagName },
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        release.assets.forEach { asset ->
+                            var isDownloading by remember(
+                                asset.name,
+                                asset.downloadUrl
+                            ) { mutableStateOf(false) }
+                            var progress by remember(
+                                asset.name,
+                                asset.downloadUrl
+                            ) { mutableIntStateOf(0) }
+                            var downloadedUri by remember(
+                                asset.name,
+                                asset.downloadUrl
+                            ) { mutableStateOf<Uri?>(null) }
+                            WearTonalButton(
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = {
+                                    val readyUri = downloadedUri
+                                    if (readyUri != null) {
+                                        actions.onInstallModule(readyUri)
+                                    } else if (!isDownloading) {
+                                        download(
+                                            url = asset.downloadUrl,
+                                            fileName = asset.name,
+                                            onDownloaded = { uri ->
+                                                isDownloading = false
+                                                downloadedUri = uri
+                                                val file = uri.path?.let(::File)
+                                                if (file == null || file.exists()) {
+                                                    actions.onInstallModule(uri)
+                                                }
+                                            },
+                                            onDownloading = {
+                                                isDownloading = true
+                                            },
+                                            onProgress = { p ->
+                                                progress = p
+                                            },
+                                        )
+                                    }
+                                },
+                                label = when {
+                                    downloadedUri != null -> stringResource(R.string.install)
+                                    isDownloading -> stringResource(R.string.download)
+                                    else -> asset.name
+                                },
+                                secondaryLabel = when {
+                                    downloadedUri != null -> asset.name
+                                    isDownloading -> "${progress}%"
+                                    else -> null
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsScreen.kt
@@ -30,7 +30,7 @@ fun SettingPager(
         onSetCheckModuleUpdate = viewModel::setCheckModuleUpdate,
         onOpenTheme = { navigator.push(Route.ColorPalette) },
         onSetUiModeIndex = { index ->
-            viewModel.setUiMode(if (index == 0) UiMode.Miuix.value else UiMode.Material.value)
+            viewModel.setUiMode(UiMode.entries.getOrElse(index) { UiMode.Miuix }.value)
         },
         onOpenProfileTemplate = { navigator.push(Route.AppProfileTemplate) },
         onSetSuCompatMode = viewModel::setSuCompatMode,
@@ -40,11 +40,13 @@ fun SettingPager(
         onSetDefaultUmountModules = viewModel::setDefaultUmountModules,
         onSetEnableWebDebugging = viewModel::setEnableWebDebugging,
         onSetAutoJailbreak = viewModel::setAutoJailbreak,
+        onSetScreenShape = viewModel::setScreenShape,
         onOpenAbout = { navigator.push(Route.About) },
     )
 
     when (LocalUiMode.current) {
         UiMode.Miuix -> SettingPagerMiuix(uiState, actions, bottomInnerPadding)
         UiMode.Material -> SettingPagerMaterial(uiState, actions, bottomInnerPadding)
+        UiMode.Wear -> SettingPagerWear(uiState, actions)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
@@ -3,6 +3,7 @@ package me.weishu.kernelsu.ui.screen.settings
 import androidx.compose.runtime.Immutable
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamiccolor.ColorSpec
+import me.weishu.kernelsu.ui.ScreenShape
 import me.weishu.kernelsu.ui.UiMode
 
 @Immutable
@@ -51,7 +52,7 @@ data class SettingsUiState(
     // Auto Jailbreak
     val autoJailbreak: Boolean = false,
 
-    val screenShape: String = "round"
+    val screenShape: ScreenShape = ScreenShape.Round
 )
 
 @Immutable
@@ -68,6 +69,6 @@ data class SettingsScreenActions(
     val onSetDefaultUmountModules: (Boolean) -> Unit,
     val onSetEnableWebDebugging: (Boolean) -> Unit,
     val onSetAutoJailbreak: (Boolean) -> Unit,
-    val onSetScreenShape: (String) -> Unit,
+    val onSetScreenShape: (ScreenShape) -> Unit,
     val onOpenAbout: () -> Unit,
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
@@ -10,6 +10,8 @@ data class SettingsUiState(
     val uiMode: String = UiMode.DEFAULT_VALUE,
     val checkUpdate: Boolean = true,
     val checkModuleUpdate: Boolean = true,
+    val hasKsu: Boolean = false,
+    val canUseKernelFeatures: Boolean = false,
     val themeMode: Int = 0,
     val miuixMonet: Boolean = false,
     val keyColor: Int = 0,
@@ -47,7 +49,9 @@ data class SettingsUiState(
     val isLateLoadMode: Boolean = false,
 
     // Auto Jailbreak
-    val autoJailbreak: Boolean = false
+    val autoJailbreak: Boolean = false,
+
+    val screenShape: String = "round"
 )
 
 @Immutable
@@ -64,5 +68,6 @@ data class SettingsScreenActions(
     val onSetDefaultUmountModules: (Boolean) -> Unit,
     val onSetEnableWebDebugging: (Boolean) -> Unit,
     val onSetAutoJailbreak: (Boolean) -> Unit,
+    val onSetScreenShape: (String) -> Unit,
     val onOpenAbout: () -> Unit,
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsWear.kt
@@ -9,6 +9,7 @@ import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.ScreenShape
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.wear.WearTonalButton
 import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
@@ -71,7 +72,7 @@ fun SettingPagerWear(
                 }
             }
             item {
-                val shapeLabel = if (uiState.screenShape == "round")
+                val shapeLabel = if (uiState.screenShape == ScreenShape.Round)
                     stringResource(R.string.settings_screen_shape_round)
                 else
                     stringResource(R.string.settings_screen_shape_square)
@@ -80,7 +81,7 @@ fun SettingPagerWear(
                     secondaryLabel = shapeLabel,
                     modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
                     onClick = {
-                        val next = if (uiState.screenShape == "round") "square" else "round"
+                        val next = if (uiState.screenShape == ScreenShape.Round) ScreenShape.Square else ScreenShape.Round
                         actions.onSetScreenShape(next)
                     }
                 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsWear.kt
@@ -1,0 +1,121 @@
+package me.weishu.kernelsu.ui.screen.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun SettingPagerWear(
+    uiState: SettingsUiState,
+    actions: SettingsScreenActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val isWatch = UiMode.isWatchDevice
+    val horizontalPadding = wearHorizontalPadding()
+    val enabledText =
+        stringResource(if (uiState.checkUpdate) R.string.wear_state_on else R.string.wear_state_off)
+    val moduleEnabledText =
+        stringResource(if (uiState.checkModuleUpdate) R.string.wear_state_on else R.string.wear_state_off)
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.settings))
+                }
+            }
+            if (!isWatch) {
+                item {
+                    val currentUiMode = UiMode.fromValue(uiState.uiMode)
+                    val currentUiModeIndex = UiMode.entries.indexOf(currentUiMode).coerceAtLeast(0)
+                    val nextUiModeIndex = (currentUiModeIndex + 1) % UiMode.entries.size
+                    WearSettingsButton(
+                        label = stringResource(R.string.settings_ui_mode),
+                        secondaryLabel = currentUiMode.name,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onSetUiModeIndex(nextUiModeIndex) }
+                    )
+                }
+            }
+            item {
+                WearSettingsButton(
+                    label = stringResource(R.string.settings_check_update),
+                    secondaryLabel = enabledText,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = { actions.onSetCheckUpdate(!uiState.checkUpdate) }
+                )
+            }
+            if (uiState.canUseKernelFeatures) {
+                item {
+                    WearSettingsButton(
+                        label = stringResource(R.string.settings_module_check_update),
+                        secondaryLabel = moduleEnabledText,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onSetCheckModuleUpdate(!uiState.checkModuleUpdate) }
+                    )
+                }
+            }
+            item {
+                val shapeLabel = if (uiState.screenShape == "round")
+                    stringResource(R.string.settings_screen_shape_round)
+                else
+                    stringResource(R.string.settings_screen_shape_square)
+                WearSettingsButton(
+                    label = stringResource(R.string.settings_screen_shape),
+                    secondaryLabel = shapeLabel,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = {
+                        val next = if (uiState.screenShape == "round") "square" else "round"
+                        actions.onSetScreenShape(next)
+                    }
+                )
+            }
+            if (uiState.canUseKernelFeatures) {
+                item {
+                    WearSettingsButton(
+                        label = stringResource(R.string.settings_profile_template),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onOpenProfileTemplate
+                    )
+                }
+            }
+            item {
+                WearSettingsButton(
+                    label = stringResource(R.string.about),
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onOpenAbout
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WearSettingsButton(
+    label: String,
+    secondaryLabel: String? = null,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    WearTonalButton(
+        label = label,
+        secondaryLabel = secondaryLabel,
+        onClick = onClick,
+        modifier = modifier,
+    )
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogScreen.kt
@@ -59,6 +59,7 @@ fun SulogScreen() {
     when (uiMode) {
         UiMode.Material -> SulogScreenMaterial(state, actions)
         UiMode.Miuix -> SulogScreenMiuix(state, actions)
+        UiMode.Wear -> SulogScreenWear(state, actions)
     }
 }
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogWear.kt
@@ -1,0 +1,165 @@
+package me.weishu.kernelsu.ui.screen.sulog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.itemsIndexed
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.util.SulogEventFilter
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearSearchField
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun SulogScreenWear(
+    state: SulogScreenState,
+    actions: SulogActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+    val fileSelector = buildSulogFileSelector(state.files, state.selectedFilePath)
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.settings_sulog))
+                }
+            }
+
+            item {
+                WearTonalButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onRefresh,
+                    label = stringResource(R.string.pull_down_refresh),
+                )
+            }
+
+            item {
+                WearSearchField(
+                    value = state.searchText,
+                    placeholder = stringResource(R.string.wear_search_logs),
+                    onValueChange = actions.onSearchTextChange,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            if (state.searchText.isNotEmpty()) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onSearchTextChange("") },
+                        label = stringResource(R.string.delete),
+                    )
+                }
+            }
+
+            if (fileSelector.items.size > 1 && fileSelector.selectedIndex >= 0) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = {
+                            val nextIndex =
+                                (fileSelector.selectedIndex + 1) % fileSelector.items.size
+                            state.files.getOrNull(nextIndex)?.path?.let(actions.onSelectFile)
+                        },
+                        label = stringResource(R.string.sulog_log_files),
+                        secondaryLabel = fileSelector.items[fileSelector.selectedIndex],
+                    )
+                }
+            }
+
+            SulogEventFilter.entries.forEach { filter ->
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onToggleFilter(filter) },
+                        label = sulogFilterLabel(filter),
+                        secondaryLabel = if (filter in state.selectedFilters) stringResource(R.string.wear_state_on) else stringResource(
+                            R.string.wear_state_off
+                        ),
+                    )
+                }
+            }
+
+            if (!state.isSulogEnabled) {
+                item {
+                    WearPrimaryButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onEnableSulog,
+                        label = stringResource(R.string.sulog_enable),
+                    )
+                }
+            }
+
+            if (state.sulogStatus.isNotEmpty()) {
+                item {
+                    WearMessageText(
+                        text = state.sulogStatus,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+
+            if (state.isLoading || state.isRefreshing) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.processing),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else if (state.visibleEntries.isEmpty()) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.sulog_empty),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else {
+                itemsIndexed(state.visibleEntries, key = { index, entry -> "$index-${entry.key}" }) { _, entry ->
+                    val title = sulogEntryTitle(entry)
+                    val desc = sulogEntryDescription(entry)
+                    Card(
+                        onClick = {},
+                        modifier = Modifier
+                            .padding(horizontal = horizontalPadding)
+                            .fillMaxWidth(),
+                    ) {
+                        Text(text = title, style = MaterialTheme.typography.titleSmall)
+                        if (desc != null) {
+                            Text(
+                                text = desc,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 2,
+                            )
+                        }
+                        val status = sulogEntryStatus(entry)
+                        if (status != null) {
+                            Text(
+                                text = status,
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserScreen.kt
@@ -72,5 +72,10 @@ fun SuperUserPager(
             actions = actions,
             bottomInnerPadding = bottomInnerPadding,
         )
+
+        UiMode.Wear -> SuperUserPagerWear(
+            uiState = uiState,
+            actions = actions,
+        )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserWear.kt
@@ -1,0 +1,162 @@
+package me.weishu.kernelsu.ui.screen.superuser
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearSearchField
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun SuperUserPagerWear(
+    uiState: SuperUserUiState,
+    actions: SuperUserActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+    var expandedUid by remember { mutableStateOf<Int?>(null) }
+    val apps =
+        if (uiState.searchStatus.searchText.isNotEmpty()) uiState.searchResults else uiState.groupedApps
+    val stateOn = stringResource(R.string.wear_state_on)
+    val stateOff = stringResource(R.string.wear_state_off)
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.superuser))
+                }
+            }
+
+            item {
+                WearPrimaryButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onOpenSulog,
+                    label = stringResource(R.string.settings_sulog),
+                )
+            }
+
+            item {
+                WearSearchField(
+                    value = uiState.searchStatus.searchText,
+                    placeholder = stringResource(R.string.wear_search_apps),
+                    onValueChange = actions.onSearchTextChange,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            if (uiState.searchStatus.searchText.isNotEmpty()) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onClearSearch,
+                        label = stringResource(R.string.delete),
+                    )
+                }
+            }
+
+            item {
+                WearTonalButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onToggleShowSystemApps,
+                    label = stringResource(R.string.show_system_apps),
+                    secondaryLabel = if (uiState.showSystemApps) stateOn else stateOff,
+                )
+            }
+
+            if (uiState.userIds.size > 1) {
+                item {
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onToggleShowOnlyPrimaryUserApps,
+                        label = stringResource(R.string.show_only_primary_user_apps),
+                        secondaryLabel = if (uiState.showOnlyPrimaryUserApps) stateOn else stateOff,
+                    )
+                }
+            }
+
+            if (uiState.isRefreshing || !uiState.hasLoaded) {
+                item {
+                    WearMessageText(
+                        text = if (uiState.isRefreshing) stringResource(R.string.processing) else "",
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else if (apps.isEmpty()) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.wear_no_apps),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else {
+                items(apps, key = { it.uid }) { group ->
+                    val label = group.primary.label
+                    val statusText = when {
+                        group.anyAllowSu -> stringResource(R.string.superuser_allow)
+                        group.anyCustom -> stringResource(R.string.profile_custom)
+                        else -> stringResource(R.string.profile_default)
+                    }
+                    Column(
+                        modifier = Modifier
+                            .wearPaddedFullWidth(horizontalPadding)
+                            .padding(vertical = 4.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        WearTonalButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = {
+                                expandedUid = if (expandedUid == group.uid) null else group.uid
+                            },
+                            label = label,
+                            secondaryLabel = statusText,
+                        )
+
+                        if (expandedUid == group.uid) {
+                            WearPrimaryButton(
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = { actions.onOpenProfile(group) },
+                                label = stringResource(R.string.profile),
+                            )
+
+                            if (group.apps.size > 1) {
+                                group.apps.forEach { app ->
+                                    WearTonalButton(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        onClick = { actions.onOpenProfile(group) },
+                                        label = app.label,
+                                        secondaryLabel = app.packageName,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
@@ -111,6 +111,10 @@ fun AppProfileTemplateScreen() {
                 UiMode.Material -> navigator.push(
                     Route.TemplateEditor(TemplateViewModel.TemplateInfo(), false)
                 )
+
+                UiMode.Wear -> navigator.push(
+                    Route.TemplateEditor(TemplateViewModel.TemplateInfo(), false)
+                )
             }
         },
         onOpenTemplate = { template ->
@@ -121,6 +125,10 @@ fun AppProfileTemplateScreen() {
                 )
 
                 UiMode.Material -> navigator.push(
+                    Route.TemplateEditor(template, !template.local)
+                )
+
+                UiMode.Wear -> navigator.push(
                     Route.TemplateEditor(template, !template.local)
                 )
             }
@@ -134,6 +142,11 @@ fun AppProfileTemplateScreen() {
         )
 
         UiMode.Material -> AppProfileTemplateScreenMaterial(
+            state = uiState,
+            actions = actions,
+        )
+
+        UiMode.Wear -> AppProfileTemplateScreenWear(
             state = uiState,
             actions = actions,
         )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateWear.kt
@@ -1,0 +1,82 @@
+package me.weishu.kernelsu.ui.screen.template
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun AppProfileTemplateScreenWear(
+    state: TemplateUiState,
+    actions: TemplateActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.settings_profile_template))
+                }
+            }
+
+            item {
+                WearPrimaryButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = actions.onCreateTemplate,
+                    label = stringResource(R.string.app_profile_template_create),
+                )
+            }
+
+            item {
+                WearTonalButton(
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    onClick = { actions.onRefresh(true) },
+                    label = stringResource(R.string.pull_down_refresh),
+                )
+            }
+
+            if (state.isRefreshing) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.processing),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else if (state.templateList.isEmpty()) {
+                item {
+                    WearMessageText(
+                        text = stringResource(R.string.app_profile_template_empty),
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            } else {
+                items(state.templateList, key = { it.id }) { template ->
+                    WearTonalButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = { actions.onOpenTemplate(template) },
+                        label = template.name,
+                        secondaryLabel = template.author,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/templateeditor/TemplateEditorScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/templateeditor/TemplateEditorScreen.kt
@@ -135,5 +135,10 @@ fun TemplateEditorScreen(template: TemplateViewModel.TemplateInfo, readOnly: Boo
             state = uiState,
             actions = actions,
         )
+
+        UiMode.Wear -> TemplateEditorScreenWear(
+            state = uiState,
+            actions = actions,
+        )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/templateeditor/TemplateEditorWear.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/templateeditor/TemplateEditorWear.kt
@@ -1,0 +1,120 @@
+package me.weishu.kernelsu.ui.screen.templateeditor
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.wear.WearMessageText
+import me.weishu.kernelsu.ui.wear.WearPrimaryButton
+import me.weishu.kernelsu.ui.wear.WearTextField
+import me.weishu.kernelsu.ui.wear.WearTonalButton
+import me.weishu.kernelsu.ui.wear.wearHorizontalPadding
+import me.weishu.kernelsu.ui.wear.wearPaddedFullWidth
+
+@Composable
+fun TemplateEditorScreenWear(
+    state: TemplateEditorUiState,
+    actions: TemplateEditorActions,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+    val template = state.template
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(
+                        if (state.isCreation) stringResource(R.string.app_profile_template_create)
+                        else state.titleSummary
+                    )
+                }
+            }
+
+            item {
+                WearTextField(
+                    label = stringResource(R.string.app_profile_template_name),
+                    value = template.name,
+                    onValueChange = actions.onNameChange,
+                    readOnly = state.readOnly,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            if (state.isCreation) {
+                item {
+                    WearTextField(
+                        label = stringResource(R.string.app_profile_template_id),
+                        value = template.id,
+                        onValueChange = actions.onIdChange,
+                        readOnly = state.readOnly,
+                        isError = state.idErrorHint.isNotEmpty(),
+                        supportingText = state.idErrorHint.takeIf { it.isNotEmpty() },
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+
+            item {
+                WearTextField(
+                    label = stringResource(R.string.module_author),
+                    value = template.author,
+                    onValueChange = actions.onAuthorChange,
+                    readOnly = state.readOnly,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            item {
+                WearTextField(
+                    label = stringResource(R.string.app_profile_template_description),
+                    value = template.description,
+                    onValueChange = actions.onDescriptionChange,
+                    readOnly = state.readOnly,
+                    singleLine = false,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+
+            if (state.idErrorHint.isNotEmpty()) {
+                item {
+                    WearMessageText(
+                        text = state.idErrorHint,
+                        isError = true,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+
+            if (!state.readOnly) {
+                item {
+                    WearPrimaryButton(
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                        onClick = actions.onSave,
+                        label = stringResource(R.string.save),
+                    )
+                }
+
+                if (!state.isCreation) {
+                    item {
+                        WearTonalButton(
+                            modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                            onClick = actions.onDelete,
+                            label = stringResource(R.string.delete),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
@@ -110,6 +110,11 @@ fun KernelSUTheme(
             appSettings = currentAppSettings,
             content = content
         )
+
+        UiMode.Wear -> WearKernelSUTheme(
+            appSettings = currentAppSettings,
+            content = content
+        )
     }
 }
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/WearTheme.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/WearTheme.kt
@@ -3,7 +3,6 @@ package me.weishu.kernelsu.ui.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.platform.LocalContext
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.MaterialTheme
 import com.materialkolor.rememberDynamicColorScheme
@@ -45,7 +44,6 @@ fun WearKernelSUTheme(
     appSettings: AppSettings,
     content: @Composable () -> Unit
 ) {
-    val context = LocalContext.current
     val hasCustomColor = appSettings.keyColor != 0
 
     val wearColorScheme = if (hasCustomColor) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/WearTheme.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/WearTheme.kt
@@ -1,0 +1,103 @@
+package me.weishu.kernelsu.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalContext
+import androidx.wear.compose.material3.ColorScheme
+import androidx.wear.compose.material3.MaterialTheme
+import com.materialkolor.rememberDynamicColorScheme
+import me.weishu.kernelsu.ui.webui.MonetColorsProvider
+
+private val defaultWearColorScheme: ColorScheme = ColorScheme(
+    primary = Color(0xFFD8BAFA),
+    onPrimary = Color(0xFF3C245A),
+    primaryContainer = Color(0xFF543B72),
+    onPrimaryContainer = Color(0xFFEEDBFF),
+    secondary = Color(0xFFCFC1DA),
+    onSecondary = Color(0xFF362D40),
+    secondaryContainer = Color(0xFF4D4357),
+    onSecondaryContainer = Color(0xFFECDDF7),
+    tertiary = Color(0xFFF2B7C0),
+    onTertiary = Color(0xFF4B252C),
+    tertiaryContainer = Color(0xFF653B42),
+    onTertiaryContainer = Color(0xFFFFD9DE),
+    error = Color(0xFFFFB4AB),
+    onError = Color(0xFF690005),
+    errorContainer = Color(0xFF93000A),
+    onErrorContainer = Color(0xFFFFDAD6),
+    background = Color(0xFF151218),
+    onBackground = Color(0xFFE8E0E8),
+    onSurface = Color(0xFFE8E0E8),
+    onSurfaceVariant = Color(0xFFCCC4CF),
+    outline = Color(0xFF958E98),
+    outlineVariant = Color(0xFF4A454E),
+    surfaceContainerLow = Color(0xFF1D1A20),
+    surfaceContainer = Color(0xFF221E24),
+    surfaceContainerHigh = Color(0xFF2C292F),
+    primaryDim = Color(0xFF543B72),
+    secondaryDim = Color(0xFF4D4357),
+    tertiaryDim = Color(0xFF653B42),
+)
+
+@Composable
+fun WearKernelSUTheme(
+    appSettings: AppSettings,
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val hasCustomColor = appSettings.keyColor != 0
+
+    val wearColorScheme = if (hasCustomColor) {
+        // Generate a dark MD3 scheme from the custom seed and map it to Wear tokens.
+        val md3 = rememberDynamicColorScheme(
+            seedColor = Color(appSettings.keyColor),
+            isDark = true,
+            isAmoled = true,
+            style = appSettings.paletteStyle,
+            specVersion = appSettings.colorSpec,
+        )
+        // Wear button defaults use the *Dim tokens, so darken the accent colors here.
+        ColorScheme(
+            primary = md3.primary,
+            onPrimary = md3.onPrimary,
+            primaryContainer = md3.primaryContainer,
+            onPrimaryContainer = md3.onPrimaryContainer,
+            secondary = md3.secondary,
+            onSecondary = md3.onSecondary,
+            secondaryContainer = md3.secondaryContainer,
+            onSecondaryContainer = md3.onSecondaryContainer,
+            tertiary = md3.tertiary,
+            onTertiary = md3.onTertiary,
+            tertiaryContainer = md3.tertiaryContainer,
+            onTertiaryContainer = md3.onTertiaryContainer,
+            error = md3.error,
+            onError = md3.onError,
+            errorContainer = md3.errorContainer,
+            onErrorContainer = md3.onErrorContainer,
+            background = md3.background,
+            onBackground = md3.onBackground,
+            onSurface = md3.onSurface,
+            onSurfaceVariant = md3.onSurfaceVariant,
+            outline = md3.outline,
+            outlineVariant = md3.outlineVariant,
+            surfaceContainerLow = md3.surfaceContainerLow,
+            surfaceContainer = md3.surfaceContainer,
+            surfaceContainerHigh = md3.surfaceContainerHigh,
+            primaryDim = lerp(md3.primary, Color.Black, 0.6f),
+            secondaryDim = lerp(md3.secondary, Color.Black, 0.6f),
+            tertiaryDim = lerp(md3.tertiary, Color.Black, 0.6f),
+        )
+    } else {
+        // Keep a stable dark Wear palette; emulator dynamic colors are often too bright.
+        defaultWearColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = wearColorScheme,
+        content = {
+            MonetColorsProvider.UpdateCss()
+            content()
+        }
+    )
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/Downloader.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/Downloader.kt
@@ -18,6 +18,7 @@ fun download(
     fileName: String,
     onDownloaded: (Uri) -> Unit = {},
     onDownloading: () -> Unit = {},
+    onFailed: () -> Unit = {},
     onProgress: (Int) -> Unit = {}
 ) {
     onDownloading()
@@ -36,6 +37,9 @@ fun download(
             if (state.status == DownloadManager.Status.COMPLETED ||
                 state.status == DownloadManager.Status.FAILED
             ) {
+                if (state.status == DownloadManager.Status.FAILED) {
+                    onFailed()
+                }
                 cancel()
             }
         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ExternalUrl.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ExternalUrl.kt
@@ -1,5 +1,6 @@
 package me.weishu.kernelsu.ui.util
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
@@ -10,17 +11,17 @@ import me.weishu.kernelsu.R
 fun openExternalUrl(context: Context, url: String) {
     if (url.isBlank()) return
     runCatching {
-        context.startActivity(
-            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-        )
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        if (context !is Activity) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
     }.onFailure {
         val messageRes = when (it) {
             is SecurityException,
-            is ActivityNotFoundException -> R.string.wear_open_link_unavailable
+            is ActivityNotFoundException -> R.string.open_link_unavailable
 
-            else -> R.string.wear_open_link_failed
+            else -> R.string.open_link_failed
         }
         Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ExternalUrl.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/ExternalUrl.kt
@@ -1,0 +1,27 @@
+package me.weishu.kernelsu.ui.util
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import me.weishu.kernelsu.R
+
+fun openExternalUrl(context: Context, url: String) {
+    if (url.isBlank()) return
+    runCatching {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
+    }.onFailure {
+        val messageRes = when (it) {
+            is SecurityException,
+            is ActivityNotFoundException -> R.string.wear_open_link_unavailable
+
+            else -> R.string.wear_open_link_failed
+        }
+        Toast.makeText(context, messageRes, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityUiState.kt
@@ -1,6 +1,7 @@
 package me.weishu.kernelsu.ui.viewmodel
 
 import androidx.compose.runtime.Immutable
+import me.weishu.kernelsu.ui.ScreenShape
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.theme.AppSettings
 
@@ -13,5 +14,5 @@ data class MainActivityUiState(
     val enableFloatingBottomBarBlur: Boolean,
     val enableSmoothCorner: Boolean,
     val uiMode: UiMode,
-    val screenShape: String = if (UiMode.isWatchDevice) "round" else "square",
+    val screenShape: ScreenShape = if (UiMode.isWatchDevice) ScreenShape.Round else ScreenShape.Square,
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityUiState.kt
@@ -13,4 +13,5 @@ data class MainActivityUiState(
     val enableFloatingBottomBarBlur: Boolean,
     val enableSmoothCorner: Boolean,
     val uiMode: UiMode,
+    val screenShape: String = if (UiMode.isWatchDevice) "round" else "square",
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import me.weishu.kernelsu.data.repository.SettingsRepository
 import me.weishu.kernelsu.data.repository.SettingsRepositoryImpl
 import me.weishu.kernelsu.ksuApp
+import me.weishu.kernelsu.ui.ScreenShape
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.theme.ThemeController
 
@@ -52,7 +53,7 @@ class MainActivityViewModel(
             enableFloatingBottomBarBlur = settingRepo.enableFloatingBottomBarBlur,
             enableSmoothCorner = settingRepo.enableSmoothCorner,
             uiMode = UiMode.fromValue(settingRepo.uiMode),
-            screenShape = settingRepo.screenShape,
+            screenShape = ScreenShape.fromValue(settingRepo.screenShape),
         )
     }
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
@@ -52,6 +52,7 @@ class MainActivityViewModel(
             enableFloatingBottomBarBlur = settingRepo.enableFloatingBottomBarBlur,
             enableSmoothCorner = settingRepo.enableSmoothCorner,
             uiMode = UiMode.fromValue(settingRepo.uiMode),
+            screenShape = settingRepo.screenShape,
         )
     }
 
@@ -67,6 +68,7 @@ class MainActivityViewModel(
             "enable_floating_bottom_bar_blur",
             "enable_smooth_corner",
             "ui_mode",
+            "screen_shape",
         )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import me.weishu.kernelsu.data.repository.SettingsRepository
 import me.weishu.kernelsu.data.repository.SettingsRepositoryImpl
 import me.weishu.kernelsu.ui.screen.settings.SettingsUiState
 import me.weishu.kernelsu.ui.theme.ColorMode
+import me.weishu.kernelsu.ui.util.rootAvailable
 
 class SettingsViewModel(
     private val repo: SettingsRepository = SettingsRepositoryImpl()
@@ -29,6 +30,8 @@ class SettingsViewModel(
         viewModelScope.launch {
             val checkUpdate = repo.checkUpdate
             val checkModuleUpdate = repo.checkModuleUpdate
+            val hasKsu = Natives.isManager && Natives.version != -1
+            val canUseKernelFeatures = hasKsu && !Natives.requireNewKernel() && rootAvailable()
             val themeMode = repo.themeMode
             val miuixMonet = repo.miuixMonet
             val keyColor = repo.keyColor
@@ -41,9 +44,6 @@ class SettingsViewModel(
             val enableSmoothCorner = repo.enableSmoothCorner
             val colorStyle = repo.colorStyle
             val colorSpec = repo.colorSpec
-            val isLkmMode = repo.isLkmMode()
-
-            // Async loading for natives/features
             val suCompatStatus = repo.getSuCompatStatus()
             val suCompatPersistValue = repo.getSuCompatPersistValue()
             val isSuEnabled = repo.isSuEnabled()
@@ -59,13 +59,17 @@ class SettingsViewModel(
             val isDefaultUmountModules = repo.isDefaultUmountModules()
             val uiMode = repo.uiMode
             val autoJailbreak = repo.autoJailbreak
+            val screenShape = repo.screenShape
             val isLateLoadMode = Natives.isLateLoadMode
+            val isLkmMode = repo.isLkmMode()
 
             _uiState.update {
                 it.copy(
                     uiMode = uiMode,
                     checkUpdate = checkUpdate,
                     checkModuleUpdate = checkModuleUpdate,
+                    hasKsu = hasKsu,
+                    canUseKernelFeatures = canUseKernelFeatures,
                     themeMode = themeMode,
                     miuixMonet = miuixMonet,
                     keyColor = keyColor,
@@ -90,6 +94,7 @@ class SettingsViewModel(
                     isDefaultUmountModules = isDefaultUmountModules,
                     isLkmMode = isLkmMode,
                     autoJailbreak = autoJailbreak,
+                    screenShape = screenShape,
                     isLateLoadMode = isLateLoadMode,
                 )
             }
@@ -281,5 +286,10 @@ class SettingsViewModel(
                 _uiState.update { it.copy(isDefaultUmountModules = enabled) }
             }
         }
+    }
+
+    fun setScreenShape(shape: String) {
+        repo.screenShape = shape
+        _uiState.update { it.copy(screenShape = shape) }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.data.repository.SettingsRepository
 import me.weishu.kernelsu.data.repository.SettingsRepositoryImpl
+import me.weishu.kernelsu.ui.ScreenShape
 import me.weishu.kernelsu.ui.screen.settings.SettingsUiState
 import me.weishu.kernelsu.ui.theme.ColorMode
 import me.weishu.kernelsu.ui.util.rootAvailable
@@ -59,7 +60,7 @@ class SettingsViewModel(
             val isDefaultUmountModules = repo.isDefaultUmountModules()
             val uiMode = repo.uiMode
             val autoJailbreak = repo.autoJailbreak
-            val screenShape = repo.screenShape
+            val screenShape = ScreenShape.fromValue(repo.screenShape)
             val isLateLoadMode = Natives.isLateLoadMode
             val isLkmMode = repo.isLkmMode()
 
@@ -288,8 +289,8 @@ class SettingsViewModel(
         }
     }
 
-    fun setScreenShape(shape: String) {
-        repo.screenShape = shape
+    fun setScreenShape(shape: ScreenShape) {
+        repo.screenShape = shape.value
         _uiState.update { it.copy(screenShape = shape) }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearComponents.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearComponents.kt
@@ -1,0 +1,217 @@
+package me.weishu.kernelsu.ui.wear
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.Card
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.ui.LocalScreenShape
+
+@Composable
+fun wearHorizontalPadding(): Dp = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+
+fun Modifier.wearPaddedFullWidth(horizontalPadding: Dp): Modifier =
+    padding(horizontal = horizontalPadding).fillMaxWidth()
+
+@Composable
+fun WearPrimaryButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    secondaryLabel: String? = null,
+    enabled: Boolean = true,
+) {
+    val colors = ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primaryDim,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        secondaryContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        iconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+    if (secondaryLabel == null) {
+        Button(
+            modifier = modifier,
+            enabled = enabled,
+            onClick = onClick,
+            label = { Text(label, maxLines = 1) },
+            colors = colors,
+        )
+    } else {
+        Button(
+            modifier = modifier,
+            enabled = enabled,
+            onClick = onClick,
+            label = { Text(label, maxLines = 1) },
+            secondaryLabel = { Text(secondaryLabel, maxLines = 1) },
+            colors = colors,
+        )
+    }
+}
+
+@Composable
+fun WearTonalButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    secondaryLabel: String? = null,
+    enabled: Boolean = true,
+) {
+    val colors = ButtonDefaults.filledTonalButtonColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        secondaryContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        iconColor = MaterialTheme.colorScheme.onSurface,
+    )
+    if (secondaryLabel == null) {
+        Button(
+            modifier = modifier,
+            enabled = enabled,
+            onClick = onClick,
+            label = { Text(label, maxLines = 1) },
+            colors = colors,
+        )
+    } else {
+        Button(
+            modifier = modifier,
+            enabled = enabled,
+            onClick = onClick,
+            label = { Text(label, maxLines = 1) },
+            secondaryLabel = { Text(secondaryLabel, maxLines = 1) },
+            colors = colors,
+        )
+    }
+}
+
+@Composable
+fun WearInfoCard(
+    title: String,
+    body: String? = null,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        onClick = {},
+        modifier = modifier,
+    ) {
+        Text(text = title, style = MaterialTheme.typography.titleSmall)
+        if (!body.isNullOrEmpty()) {
+            Text(text = body, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun WearMessageText(
+    text: String,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun WearSearchField(
+    value: String,
+    placeholder: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.onSurface,
+        ),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                shape = RoundedCornerShape(22.dp),
+            )
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        decorationBox = { innerTextField ->
+            if (value.isEmpty()) {
+                Text(
+                    text = placeholder,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            innerTextField()
+        },
+    )
+}
+
+@Composable
+fun WearTextField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
+    isError: Boolean = false,
+    supportingText: String? = null,
+    singleLine: Boolean = true,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+        )
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            readOnly = readOnly,
+            singleLine = singleLine,
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onSurface,
+            ),
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    shape = RoundedCornerShape(22.dp),
+                )
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            decorationBox = { innerTextField ->
+                if (value.isEmpty()) {
+                    Text(
+                        text = label,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                innerTextField()
+            },
+        )
+        if (!supportingText.isNullOrEmpty()) {
+            Text(
+                text = supportingText,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+            )
+        }
+    }
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearComponents.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearComponents.kt
@@ -19,9 +19,10 @@ import androidx.wear.compose.material3.Card
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import me.weishu.kernelsu.ui.LocalScreenShape
+import me.weishu.kernelsu.ui.ScreenShape
 
 @Composable
-fun wearHorizontalPadding(): Dp = if (LocalScreenShape.current == "round") 10.dp else 0.dp
+fun wearHorizontalPadding(): Dp = if (LocalScreenShape.current == ScreenShape.Round) 10.dp else 0.dp
 
 fun Modifier.wearPaddedFullWidth(horizontalPadding: Dp): Modifier =
     padding(horizontal = horizontalPadding).fillMaxWidth()

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearMainScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/wear/WearMainScreen.kt
@@ -1,0 +1,142 @@
+package me.weishu.kernelsu.ui.wear
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.foundation.lazy.TransformingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberTransformingLazyColumnState
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.Text
+import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.navigation3.Navigator
+import me.weishu.kernelsu.ui.navigation3.Route
+
+@Composable
+fun WearMainScreen(
+    navigator: Navigator,
+    canUseKernelFeatures: Boolean,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(R.string.app_name))
+                }
+            }
+            item {
+                WearMenuButton(
+                    label = R.string.home,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                ) {
+                    navigator.push(Route.Home)
+                }
+            }
+            if (canUseKernelFeatures) {
+                item {
+                    WearMenuButton(
+                        label = R.string.superuser,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    ) {
+                        navigator.push(Route.SuperUser)
+                    }
+                }
+                item {
+                    WearMenuButton(
+                        label = R.string.module,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    ) {
+                        navigator.push(Route.Module)
+                    }
+                }
+            }
+            item {
+                WearMenuButton(
+                    label = R.string.settings,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                ) {
+                    navigator.push(Route.Settings)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun WearPlaceholderScreen(
+    @StringRes title: Int,
+    message: String,
+    actionLabel: String? = null,
+    onAction: (() -> Unit)? = null,
+) {
+    val listState = rememberTransformingLazyColumnState()
+    val horizontalPadding = wearHorizontalPadding()
+
+    ScreenScaffold(
+        scrollState = listState,
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+        ) {
+            item {
+                ListHeader {
+                    Text(stringResource(title))
+                }
+            }
+            item {
+                WearMessageText(
+                    text = message,
+                    modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                )
+            }
+            if (actionLabel != null && onAction != null) {
+                item {
+                    WearPrimaryButton(
+                        label = actionLabel,
+                        onClick = onAction,
+                        modifier = Modifier.wearPaddedFullWidth(horizontalPadding),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun WearInstallRequiredScreen(
+    @StringRes title: Int,
+    canInstall: Boolean,
+    onInstallClick: () -> Unit,
+) {
+    WearPlaceholderScreen(
+        title = title,
+        message = stringResource(
+            if (canInstall) R.string.wear_install_required else R.string.wear_feature_unavailable
+        ),
+        actionLabel = if (canInstall) stringResource(R.string.home_click_to_install) else null,
+        onAction = if (canInstall) onInstallClick else null,
+    )
+}
+
+@Composable
+private fun WearMenuButton(
+    @StringRes label: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    WearTonalButton(
+        label = stringResource(label),
+        onClick = onClick,
+        modifier = modifier,
+    )
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/MonetColorsProvider.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/MonetColorsProvider.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme as WearMaterialTheme
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
 import top.yukonga.miuix.kmp.theme.MiuixTheme
@@ -28,6 +29,7 @@ object MonetColorsProvider {
         when (LocalUiMode.current) {
             UiMode.Miuix -> UpdateCssMiuix()
             UiMode.Material -> UpdateCssMaterial()
+            UiMode.Wear -> UpdateCssWear()
         }
     }
 
@@ -139,6 +141,63 @@ object MonetColorsProvider {
                 "filledCardContainerColor" to colorScheme.primaryContainer.toCssValue(),
                 "filledCardDisabledContentColor" to colorScheme.onSurfaceVariant.toCssValue(),
                 "filledCardDisabledContainerColor" to colorScheme.surfaceVariant.toCssValue()
+            )
+
+            colorsCss.set(monetColors.toCssVars())
+        }
+    }
+
+    @Composable
+    private fun UpdateCssWear() {
+        val colorScheme = WearMaterialTheme.colorScheme
+
+        LaunchedEffect(colorScheme) {
+            val monetColors = mapOf(
+                "primary" to colorScheme.primary.toCssValue(),
+                "onPrimary" to colorScheme.onPrimary.toCssValue(),
+                "primaryContainer" to colorScheme.primaryContainer.toCssValue(),
+                "onPrimaryContainer" to colorScheme.onPrimaryContainer.toCssValue(),
+                "inversePrimary" to colorScheme.primaryContainer.toCssValue(),
+                "secondary" to colorScheme.secondary.toCssValue(),
+                "onSecondary" to colorScheme.onSecondary.toCssValue(),
+                "secondaryContainer" to colorScheme.secondaryContainer.toCssValue(),
+                "onSecondaryContainer" to colorScheme.onSecondaryContainer.toCssValue(),
+                "tertiary" to colorScheme.tertiary.toCssValue(),
+                "onTertiary" to colorScheme.onTertiary.toCssValue(),
+                "tertiaryContainer" to colorScheme.tertiaryContainer.toCssValue(),
+                "onTertiaryContainer" to colorScheme.onTertiaryContainer.toCssValue(),
+                "background" to colorScheme.background.toCssValue(),
+                "onBackground" to colorScheme.onBackground.toCssValue(),
+                "surface" to colorScheme.background.toCssValue(),
+                "tonalSurface" to colorScheme.surfaceContainer.toCssValue(),
+                "onSurface" to colorScheme.onSurface.toCssValue(),
+                "surfaceVariant" to colorScheme.surfaceContainerHigh.toCssValue(),
+                "onSurfaceVariant" to colorScheme.onSurfaceVariant.toCssValue(),
+                "surfaceTint" to colorScheme.primary.toCssValue(),
+                "inverseSurface" to colorScheme.primary.toCssValue(),
+                "inverseOnSurface" to colorScheme.onPrimary.toCssValue(),
+                "error" to colorScheme.error.toCssValue(),
+                "onError" to colorScheme.onError.toCssValue(),
+                "errorContainer" to colorScheme.errorContainer.toCssValue(),
+                "onErrorContainer" to colorScheme.onErrorContainer.toCssValue(),
+                "outline" to colorScheme.outline.toCssValue(),
+                "outlineVariant" to colorScheme.outlineVariant.toCssValue(),
+                "scrim" to Color.Black.toCssValue(),
+                "surfaceBright" to colorScheme.surfaceContainerHigh.toCssValue(),
+                "surfaceDim" to colorScheme.surfaceContainerLow.toCssValue(),
+                "surfaceContainer" to colorScheme.surfaceContainer.toCssValue(),
+                "surfaceContainerHigh" to colorScheme.surfaceContainerHigh.toCssValue(),
+                "surfaceContainerHighest" to colorScheme.surfaceContainerHigh.toCssValue(),
+                "surfaceContainerLow" to colorScheme.surfaceContainerLow.toCssValue(),
+                "surfaceContainerLowest" to colorScheme.surfaceContainerLow.toCssValue(),
+                "filledTonalButtonContentColor" to colorScheme.onPrimaryContainer.toCssValue(),
+                "filledTonalButtonContainerColor" to colorScheme.secondaryContainer.toCssValue(),
+                "filledTonalButtonDisabledContentColor" to colorScheme.onSurfaceVariant.toCssValue(),
+                "filledTonalButtonDisabledContainerColor" to colorScheme.surfaceContainerHigh.toCssValue(),
+                "filledCardContentColor" to colorScheme.onPrimaryContainer.toCssValue(),
+                "filledCardContainerColor" to colorScheme.primaryContainer.toCssValue(),
+                "filledCardDisabledContentColor" to colorScheme.onSurfaceVariant.toCssValue(),
+                "filledCardDisabledContainerColor" to colorScheme.surfaceContainerHigh.toCssValue(),
             )
 
             colorsCss.set(monetColors.toCssVars())

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
@@ -138,5 +138,16 @@ private fun LoadingContent() {
                 androidx.compose.material3.LoadingIndicator()
             }
         }
+
+        UiMode.Wear -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.material3.LoadingIndicator()
+            }
+        }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIActivity.kt
@@ -31,6 +31,7 @@ import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.theme.KernelSUTheme
 import me.weishu.kernelsu.ui.theme.ThemeController
 import top.yukonga.miuix.kmp.basic.InfiniteProgressIndicator
+import androidx.wear.compose.material3.MaterialTheme as WearMaterialTheme
 
 @SuppressLint("SetJavaScriptEnabled")
 class WebUIActivity : ComponentActivity() {
@@ -143,10 +144,10 @@ private fun LoadingContent() {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background),
+                    .background(WearMaterialTheme.colorScheme.background),
                 contentAlignment = Alignment.Center
             ) {
-                androidx.compose.material3.LoadingIndicator()
+                androidx.wear.compose.material3.CircularProgressIndicator()
             }
         }
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/webui/WebUIScreen.kt
@@ -127,6 +127,7 @@ fun WebUIScreen(webUIState: WebUIState) {
     when (LocalUiMode.current) {
         UiMode.Miuix -> HandleWebUIEventMiuix(webUIState, fileLauncher)
         UiMode.Material -> HandleWebUIEventMaterial(webUIState, fileLauncher)
+        UiMode.Wear -> HandleWebUIEventMaterial(webUIState, fileLauncher)
     }
 
     HandleWebViewLifecycle(webUIState)

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -125,6 +125,9 @@
     <string name="home_pr_kernel_warning">当前内核包含 PR 签名支持，这不是一个生产内核！</string>
     <string name="action">执行</string>
     <string name="open">打开</string>
+    <string name="webui" translatable="false">WebUI</string>
+    <string name="enable">启用</string>
+    <string name="disable">禁用</string>
     <string name="enable_web_debugging">WebView 调试</string>
     <string name="enable_web_debugging_summary">可用于调试 WebUI，请仅在需要时启用</string>
     <string name="direct_install">直接安装（推荐）</string>
@@ -180,6 +183,9 @@
     <string name="settings_key_color_default">默认</string>
     <string name="settings_ui_mode">界面风格</string>
     <string name="settings_ui_mode_summary">选择应用的界面风格</string>
+    <string name="settings_screen_shape">屏幕形状</string>
+    <string name="settings_screen_shape_round">圆形</string>
+    <string name="settings_screen_shape_square">方形</string>
     <string name="settings_page_scale">界面缩放</string>
     <string name="settings_page_scale_summary">调整全局显示比例</string>
     <string name="settings_color_spec">色彩标准</string>
@@ -249,4 +255,14 @@
     <string name="download_cancel">取消</string>
     <string name="download_install">安装</string>
     <string name="settings_adb_root_summary">以 root 权限运行 adbd 守护进程</string>
+    <string name="wear_state_on">开</string>
+    <string name="wear_state_off">关</string>
+    <string name="wear_no_apps">没有应用</string>
+    <string name="wear_open_link_unavailable">手表上没有可打开此链接的应用</string>
+    <string name="wear_open_link_failed">打开链接失败</string>
+    <string name="wear_search_modules">搜索模块</string>
+    <string name="wear_search_apps">搜索应用</string>
+    <string name="wear_search_logs">搜索日志</string>
+    <string name="wear_install_required">请先安装 KernelSU 再使用此功能</string>
+    <string name="wear_feature_unavailable">此设备当前无法使用此功能</string>
 </resources>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -258,11 +258,24 @@
     <string name="wear_state_on">开</string>
     <string name="wear_state_off">关</string>
     <string name="wear_no_apps">没有应用</string>
-    <string name="wear_open_link_unavailable">手表上没有可打开此链接的应用</string>
-    <string name="wear_open_link_failed">打开链接失败</string>
+    <string name="open_link_unavailable">没有可打开此链接的应用</string>
+    <string name="open_link_failed">打开链接失败</string>
     <string name="wear_search_modules">搜索模块</string>
     <string name="wear_search_apps">搜索应用</string>
     <string name="wear_search_logs">搜索日志</string>
     <string name="wear_install_required">请先安装 KernelSU 再使用此功能</string>
     <string name="wear_feature_unavailable">此设备当前无法使用此功能</string>
+    <string name="superuser_allow">允许</string>
+    <string name="superuser_deny">拒绝</string>
+    <string name="superuser_allow_root_access">Root 访问</string>
+    <string name="cancel">取消</string>
+    <string name="save">保存</string>
+    <string name="delete">删除</string>
+    <string name="pull_down_refresh">刷新</string>
+    <string name="sulog_enable">启用 SU 日志</string>
+    <string name="sulog_empty">暂无日志</string>
+    <string name="module_action">模块操作</string>
+    <string name="settings_theme_wear_note">Wear OS 上不支持主题设置。</string>
+    <string name="module_repo_open_web">在浏览器中打开</string>
+    <string name="app_profile_template_empty">暂无模版</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -147,6 +147,7 @@
     <string name="home_pr_kernel_warning">The kernel was built with PR signature support. This is not a production kernel!</string>
     <string name="action">Action</string>
     <string name="open">Open</string>
+    <string name="webui" translatable="false">WebUI</string>
     <string name="enable_web_debugging">WebView debugging</string>
     <string name="enable_web_debugging_summary">Can be used to debug WebUI. Please enable only when needed.</string>
     <string name="direct_install">Direct install (Recommended)</string>
@@ -204,6 +205,9 @@
     <string name="settings_key_color_default">Default</string>
     <string name="settings_ui_mode">UI Style</string>
     <string name="settings_ui_mode_summary">Choose the interface style.</string>
+    <string name="settings_screen_shape">Screen Shape</string>
+    <string name="settings_screen_shape_round">Round</string>
+    <string name="settings_screen_shape_square">Square</string>
     <string name="settings_page_scale">Page Scale</string>
     <string name="settings_page_scale_summary">Adjust the global display scale.</string>
     <string name="settings_color_spec">Color Spec</string>
@@ -271,4 +275,29 @@
     <string name="download_install">Install</string>
     <string name="settings_adb_root" translatable="false">ADB Root</string>
     <string name="settings_adb_root_summary">Run adbd daemon with root privileges</string>
+    <string name="superuser_allow">Allow</string>
+    <string name="superuser_deny">Deny</string>
+    <string name="superuser_allow_root_access">Root access</string>
+    <string name="enable">Enable</string>
+    <string name="disable">Disable</string>
+    <string name="cancel">Cancel</string>
+    <string name="save">Save</string>
+    <string name="delete">Delete</string>
+    <string name="pull_down_refresh">Refresh</string>
+    <string name="wear_state_on">On</string>
+    <string name="wear_state_off">Off</string>
+    <string name="wear_no_apps">No apps</string>
+    <string name="wear_open_link_unavailable">No available app to open this link on Wear</string>
+    <string name="wear_open_link_failed">Failed to open link</string>
+    <string name="wear_search_modules">Search modules</string>
+    <string name="wear_search_apps">Search apps</string>
+    <string name="wear_search_logs">Search logs</string>
+    <string name="wear_install_required">Install KernelSU first to use this feature</string>
+    <string name="wear_feature_unavailable">This feature is currently unavailable on this device</string>
+    <string name="sulog_enable">Enable SU log</string>
+    <string name="sulog_empty">No log entries</string>
+    <string name="module_action">Module action</string>
+    <string name="settings_theme_wear_note">Theme settings are not available on Wear OS.</string>
+    <string name="module_repo_open_web">Open in browser</string>
+    <string name="app_profile_template_empty">No templates</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -287,8 +287,8 @@
     <string name="wear_state_on">On</string>
     <string name="wear_state_off">Off</string>
     <string name="wear_no_apps">No apps</string>
-    <string name="wear_open_link_unavailable">No available app to open this link on Wear</string>
-    <string name="wear_open_link_failed">Failed to open link</string>
+    <string name="open_link_unavailable">No available app to open this link</string>
+    <string name="open_link_failed">Failed to open link</string>
     <string name="wear_search_modules">Search modules</string>
     <string name="wear_search_apps">Search apps</string>
     <string name="wear_search_logs">Search logs</string>

--- a/manager/gradle/libs.versions.toml
+++ b/manager/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ commonmark = "0.28.0"
 webkit = "1.15.0"
 parcelablelist = "2.0.1"
 material3 = "1.5.0-alpha18"
+wear-compose = "1.6.1"
 materialKolor = "4.1.1"
 ndk = "29.0.14206865"
 libsu = "6.0.0"
@@ -40,6 +41,10 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
+androidx-wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
+androidx-wear-compose-navigation3 = { module = "androidx.wear.compose:compose-navigation3", version.ref = "wear-compose" }
+androidx-wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "wear-compose" }
 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
This pull request introduces comprehensive support for Wear OS devices, including UI adaptations, navigation, and feature gating based on device capabilities. The changes ensure the app can run on both standard Android and Wear OS devices, providing tailored experiences and restricting unsupported features on Wear OS as needed.

**Wear OS support and UI adaptation:**
- Added Wear OS Compose libraries and updated the manifest to declare Wear features and permissions, allowing the app to run on watches and utilize Wear-specific UI components. [[1]](diffhunk://#diff-ba39b8b55c8bf73a5936139c8ca62fb05baf3255af53290629a8081f6e1fba63R170-R175) [[2]](diffhunk://#diff-d4cb309a1213382fd4fd361e3254579e2e7dca6f0559ec308bea5c9047317c92R11-R18) [[3]](diffhunk://#diff-d4cb309a1213382fd4fd361e3254579e2e7dca6f0559ec308bea5c9047317c92R32-R35)

**UI and navigation enhancements for Wear OS:**
- Introduced a new `UiMode.Wear` and logic to detect watch devices, defaulting to Wear UI mode on such devices. Provided Wear-specific navigation scaffolding, screens, and protected routes to handle feature availability and display appropriate messages or screens (e.g., install required, safe mode warnings). [[1]](diffhunk://#diff-8380393d07d0705a2cbd2ca82d27d751352b1905364fc859d06138be0e4a52cdR3-R33) [[2]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R166-R226) [[3]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276L191-R328)
- Updated `MainScreen`, bottom bar, and color schemes to support Wear UI, ensuring consistent visual integration. [[1]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R364) [[2]](diffhunk://#diff-3d13774cff9308d6f0a081aae4ec682fe08c4f3b56951d3b1ae51e71915b1a71R96) [[3]](diffhunk://#diff-9fb39d13ad8a1d6627048f4786a0875da38b696ca6b569b900b5f45dd9b9139dR105)

**Feature gating and shortcut handling:**
- Added checks to prevent access to kernel-dependent features and shortcuts on Wear OS when not supported, improving stability and user experience. [[1]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R564) [[2]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R576-R592)

**Settings and configuration:**
- Added a `screenShape` property to `SettingsRepository` to distinguish between round and square screens, enabling further UI customization for different Wear devices. [[1]](diffhunk://#diff-b07c945350eefab9fc0fb7ee5d384d63d2db6c0119327f5ed1d2a3872e147bb9R20) [[2]](diffhunk://#diff-bf1682491adeba2dd3ed6d3f93d873cb75ab0559d8fc4a102ed64afec4291534R102-R106)

**Codebase improvements and refactoring:**
- Refactored imports and composition locals to support Wear-specific theming and resource usage, and to cleanly separate logic for different UI modes. [[1]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R14) [[2]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R46-R49) [[3]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R60) [[4]](diffhunk://#diff-7154eee2760a97c41821ee2b6e0f8b57d0f51dfa81492cf61075c78a66488276R105-R111)

These changes collectively allow the app to provide a robust and user-friendly experience on both phones and Wear OS devices, with clear separation and protection of features based on device capabilities.