### PR TITLE
kernel: prune redundant avtab nodes after deny rules

### DIFF
--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -20,7 +20,7 @@
 //////////////////////////////////////////////////////
 
 static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *key,
-                                          struct avtab_extended_perms *xperms);
+                                         struct avtab_extended_perms *xperms);
 
 static bool is_redundant_avtab_node(struct avtab_node *node);
 
@@ -83,7 +83,7 @@ static bool add_typeattribute(struct policydb *db, const char *type, const char 
 #define avtab_for_each(avtab, cur) ksu_hash_for_each(avtab.htable, avtab.nslot, cur);
 
 static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *key,
-                                          struct avtab_extended_perms *xperms)
+                                         struct avtab_extended_perms *xperms)
 {
     struct avtab_node *node;
 
@@ -188,7 +188,7 @@ static void remove_avtab_node(struct policydb *db, struct avtab_node *node)
 }
 
 static bool add_rule(struct policydb *db, const char *s, const char *t, const char *c, const char *p, int effect,
-                      bool invert)
+                     bool invert)
 {
     struct type_datum *src = NULL, *tgt = NULL;
     struct class_datum *cls = NULL;

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -24,12 +24,12 @@ static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *
 
 static bool is_redundant_avtab_node(struct avtab_node *node);
 
-static void remove_avtab_node(struct policydb *db, struct avtab_node *node);
+static bool remove_avtab_node(struct policydb *db, struct avtab_node *node);
 
 static bool add_rule(struct policydb *db, const char *s, const char *t, const char *c, const char *p, int effect,
                      bool invert);
 
-static void add_rule_raw(struct policydb *db, struct type_datum *src, struct type_datum *tgt, struct class_datum *cls,
+static bool add_rule_raw(struct policydb *db, struct type_datum *src, struct type_datum *tgt, struct class_datum *cls,
                          struct perm_datum *perm, int effect, bool invert);
 
 static void add_xperm_rule_raw(struct policydb *db, struct type_datum *src, struct type_datum *tgt,
@@ -145,46 +145,48 @@ static bool is_redundant_avtab_node(struct avtab_node *node)
     return node->datum.u.data == 0U;
 }
 
-static void remove_avtab_node(struct policydb *db, struct avtab_node *node)
+static bool remove_avtab_node(struct policydb *db, struct avtab_node *node)
 {
     int i;
     int ret;
-    bool found = false;
     int shrink_size = sizeof(struct avtab_key) + sizeof(struct avtab_datum);
-    struct avtab new_avtab;
+    struct avtab removed = {};
     struct avtab_node *n;
+    struct avtab_node *prev;
 
-    ret = avtab_alloc_dup(&new_avtab, &db->te_avtab);
+    ret = avtab_alloc(&removed, 1);
     if (ret < 0)
-        return;
-    new_avtab.nel = 0;
+        return false;
 
     for (i = 0; i < db->te_avtab.nslot; i++) {
-        for (n = db->te_avtab.htable[i]; n; n = n->next) {
-            if (n == node) {
-                found = true;
+        prev = NULL;
+        for (n = db->te_avtab.htable[i]; n; prev = n, n = n->next) {
+            if (n != node)
                 continue;
-            }
 
-            if (!avtab_insert_nonunique(&new_avtab, &n->key, &n->datum)) {
-                avtab_destroy(&new_avtab);
-                return;
+            if (prev)
+                prev->next = n->next;
+            else
+                db->te_avtab.htable[i] = n->next;
+
+            if (db->te_avtab.nel > 0)
+                db->te_avtab.nel--;
+
+            if ((n->key.specified & AVTAB_XPERMS) && n->datum.u.xperms) {
+                shrink_size += sizeof(u8) + sizeof(u8) + sizeof(u32) * ARRAY_SIZE(n->datum.u.xperms->perms.p);
             }
+            n->next = NULL;
+            removed.htable[0] = n;
+            removed.nel = 1;
+            avtab_destroy(&removed);
+            if (db->len >= shrink_size)
+                db->len -= shrink_size;
+            return true;
         }
     }
 
-    if (!found) {
-        avtab_destroy(&new_avtab);
-        return;
-    }
-
-    if ((node->key.specified & AVTAB_XPERMS) && node->datum.u.xperms)
-        shrink_size += sizeof(u8) + sizeof(u8) + sizeof(u32) * ARRAY_SIZE(node->datum.u.xperms->perms.p);
-
-    avtab_destroy(&db->te_avtab);
-    db->te_avtab = new_avtab;
-    if (db->len >= shrink_size)
-        db->len -= shrink_size;
+    avtab_destroy(&removed);
+    return false;
 }
 
 static bool add_rule(struct policydb *db, const char *s, const char *t, const char *c, const char *p, int effect,
@@ -233,26 +235,27 @@ static bool add_rule(struct policydb *db, const char *s, const char *t, const ch
             return false;
         }
     }
-    add_rule_raw(db, src, tgt, cls, perm, effect, invert);
-    return true;
+    return add_rule_raw(db, src, tgt, cls, perm, effect, invert);
 }
 
-static void add_rule_raw(struct policydb *db, struct type_datum *src, struct type_datum *tgt, struct class_datum *cls,
+static bool add_rule_raw(struct policydb *db, struct type_datum *src, struct type_datum *tgt, struct class_datum *cls,
                          struct perm_datum *perm, int effect, bool invert)
 {
+    bool success = true;
+
     if (src == NULL) {
         struct hashtab_node *node;
         if (strip_av(effect, invert)) {
             ksu_hashtab_for_each(db->p_types.table, node)
             {
-                add_rule_raw(db, (struct type_datum *)node->datum, tgt, cls, perm, effect, invert);
+                success &= add_rule_raw(db, (struct type_datum *)node->datum, tgt, cls, perm, effect, invert);
             };
         } else {
             ksu_hashtab_for_each(db->p_types.table, node)
             {
                 struct type_datum *type = (struct type_datum *)(node->datum);
                 if (type->attribute) {
-                    add_rule_raw(db, type, tgt, cls, perm, effect, invert);
+                    success &= add_rule_raw(db, type, tgt, cls, perm, effect, invert);
                 }
             };
         }
@@ -261,14 +264,14 @@ static void add_rule_raw(struct policydb *db, struct type_datum *src, struct typ
         if (strip_av(effect, invert)) {
             ksu_hashtab_for_each(db->p_types.table, node)
             {
-                add_rule_raw(db, src, (struct type_datum *)node->datum, cls, perm, effect, invert);
+                success &= add_rule_raw(db, src, (struct type_datum *)node->datum, cls, perm, effect, invert);
             };
         } else {
             ksu_hashtab_for_each(db->p_types.table, node)
             {
                 struct type_datum *type = (struct type_datum *)(node->datum);
                 if (type->attribute) {
-                    add_rule_raw(db, src, type, cls, perm, effect, invert);
+                    success &= add_rule_raw(db, src, type, cls, perm, effect, invert);
                 }
             };
         }
@@ -276,36 +279,43 @@ static void add_rule_raw(struct policydb *db, struct type_datum *src, struct typ
         struct hashtab_node *node;
         ksu_hashtab_for_each(db->p_classes.table, node)
         {
-            add_rule_raw(db, src, tgt, (struct class_datum *)node->datum, perm, effect, invert);
+            success &= add_rule_raw(db, src, tgt, (struct class_datum *)node->datum, perm, effect, invert);
         }
     } else {
         struct avtab_key key;
+        struct avtab_node *node;
+
         key.source_type = src->value;
         key.target_type = tgt->value;
         key.target_class = cls->value;
         key.specified = effect;
 
-        struct avtab_node *node;
-        if (invert) {
+        if (invert && effect != AVTAB_AUDITDENY) {
             node = avtab_search_node(&db->te_avtab, &key);
             if (!node)
-                return;
+                return true;
+        } else {
+            node = get_avtab_node(db, &key, NULL);
+            if (!node)
+                return false;
+        }
+
+        if (invert) {
             if (perm)
                 node->datum.u.data &= ~(1U << (perm->value - 1));
             else
                 node->datum.u.data = 0U;
         } else {
-            node = get_avtab_node(db, &key, NULL);
-            if (!node)
-                return;
             if (perm)
                 node->datum.u.data |= 1U << (perm->value - 1);
             else
                 node->datum.u.data = ~0U;
         }
         if (is_redundant_avtab_node(node))
-            remove_avtab_node(db, node);
+            return remove_avtab_node(db, node);
     }
+
+    return success;
 }
 
 #define ioctl_driver(x) (x >> 8 & 0xFF)

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -20,7 +20,11 @@
 //////////////////////////////////////////////////////
 
 static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *key,
-                                         struct avtab_extended_perms *xperms);
+                                          struct avtab_extended_perms *xperms);
+
+static bool is_redundant_avtab_node(struct avtab_node *node);
+
+static void remove_avtab_node(struct policydb *db, struct avtab_node *node);
 
 static bool add_rule(struct policydb *db, const char *s, const char *t, const char *c, const char *p, int effect,
                      bool invert);
@@ -79,7 +83,7 @@ static bool add_typeattribute(struct policydb *db, const char *type, const char 
 #define avtab_for_each(avtab, cur) ksu_hash_for_each(avtab.htable, avtab.nslot, cur);
 
 static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *key,
-                                         struct avtab_extended_perms *xperms)
+                                          struct avtab_extended_perms *xperms)
 {
     struct avtab_node *node;
 
@@ -114,6 +118,8 @@ static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *
         }
         /* this is used to get the node - insertion is actually unique */
         node = avtab_insert_nonunique(&db->te_avtab, key, &avdatum);
+        if (!node)
+            return NULL;
 
         int grow_size = sizeof(struct avtab_key);
         grow_size += sizeof(struct avtab_datum);
@@ -128,8 +134,61 @@ static struct avtab_node *get_avtab_node(struct policydb *db, struct avtab_key *
     return node;
 }
 
+static bool is_redundant_avtab_node(struct avtab_node *node)
+{
+    if (node->key.specified & AVTAB_XPERMS)
+        return node->datum.u.xperms == NULL;
+    if (!(node->key.specified & AVTAB_AV))
+        return false;
+    if (node->key.specified & AVTAB_AUDITDENY)
+        return node->datum.u.data == ~0U;
+    return node->datum.u.data == 0U;
+}
+
+static void remove_avtab_node(struct policydb *db, struct avtab_node *node)
+{
+    int i;
+    int ret;
+    bool found = false;
+    int shrink_size = sizeof(struct avtab_key) + sizeof(struct avtab_datum);
+    struct avtab new_avtab;
+    struct avtab_node *n;
+
+    ret = avtab_alloc_dup(&new_avtab, &db->te_avtab);
+    if (ret < 0)
+        return;
+    new_avtab.nel = 0;
+
+    for (i = 0; i < db->te_avtab.nslot; i++) {
+        for (n = db->te_avtab.htable[i]; n; n = n->next) {
+            if (n == node) {
+                found = true;
+                continue;
+            }
+
+            if (!avtab_insert_nonunique(&new_avtab, &n->key, &n->datum)) {
+                avtab_destroy(&new_avtab);
+                return;
+            }
+        }
+    }
+
+    if (!found) {
+        avtab_destroy(&new_avtab);
+        return;
+    }
+
+    if ((node->key.specified & AVTAB_XPERMS) && node->datum.u.xperms)
+        shrink_size += sizeof(u8) + sizeof(u8) + sizeof(u32) * ARRAY_SIZE(node->datum.u.xperms->perms.p);
+
+    avtab_destroy(&db->te_avtab);
+    db->te_avtab = new_avtab;
+    if (db->len >= shrink_size)
+        db->len -= shrink_size;
+}
+
 static bool add_rule(struct policydb *db, const char *s, const char *t, const char *c, const char *p, int effect,
-                     bool invert)
+                      bool invert)
 {
     struct type_datum *src = NULL, *tgt = NULL;
     struct class_datum *cls = NULL;
@@ -226,18 +285,26 @@ static void add_rule_raw(struct policydb *db, struct type_datum *src, struct typ
         key.target_class = cls->value;
         key.specified = effect;
 
-        struct avtab_node *node = get_avtab_node(db, &key, NULL);
+        struct avtab_node *node;
         if (invert) {
+            node = avtab_search_node(&db->te_avtab, &key);
+            if (!node)
+                return;
             if (perm)
                 node->datum.u.data &= ~(1U << (perm->value - 1));
             else
                 node->datum.u.data = 0U;
         } else {
+            node = get_avtab_node(db, &key, NULL);
+            if (!node)
+                return;
             if (perm)
                 node->datum.u.data |= 1U << (perm->value - 1);
             else
                 node->datum.u.data = ~0U;
         }
+        if (is_redundant_avtab_node(node))
+            remove_avtab_node(db, node);
     }
 }
 
@@ -410,6 +477,8 @@ static bool add_type_rule(struct policydb *db, const char *s, const char *t, con
     key.specified = effect;
 
     struct avtab_node *node = get_avtab_node(db, &key, NULL);
+    if (!node)
+        return false;
     node->datum.u.data = def->value;
 
     return true;


### PR DESCRIPTION
Runtime deny rules clear permission bits from AVTAB_ALLOWED entries. When all permissions are removed from an existing entry, the update can leave an AVTAB_ALLOWED node with data == 0.

Such zero-permission avtab nodes are redundant and can make external policy parsers, such as sepatch, reject /sys/fs/selinux/policy with errors like:

  Invalid access vector
  Invalid avtab
  Invalid policydb
  policy image is invalid

This was observed when applying:

  deny appdomain cgroup_v2 dir search

The rule itself is valid, but the runtime patch left a redundant avtab entry behind.

Avoid creating new entries for deny updates when the target entry does not exist, and prune redundant nodes after access-vector rule updates by rebuilding the avtab and destroying the old table through avtab_destroy().

This preserves deny semantics while keeping the live policy parseable by policydb-based tools.

Thanks to @Xieansecn for discovering this issue (chenxiaolong/MSD#90).