### PR TITLE
ksud: fix some module scripts won't add KSU_MODULE environment var

### DIFF
--- a/userspace/ksud/src/metamodule.rs
+++ b/userspace/ksud/src/metamodule.rs
@@ -66,6 +66,15 @@ pub fn get_metamodule_path() -> Option<PathBuf> {
     result
 }
 
+/// Get Metamodule Id
+pub fn get_metamodule_id() -> Option<String> {
+    get_metamodule_path().and_then(|path| {
+        path.file_name()
+            .and_then(|os_str| os_str.to_str())
+            .map(ToString::to_string)
+    })
+}
+
 /// Check if metamodule exists
 pub fn has_metamodule() -> bool {
     get_metamodule_path().is_some()
@@ -227,7 +236,9 @@ pub fn exec_metauninstall_script(module_id: &str) -> Result<()> {
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", metauninstall_path.to_str().unwrap()])
         .current_dir(metauninstall_path.parent().unwrap())
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_ID", module_id)
         .status()?;
 
@@ -250,7 +261,9 @@ pub fn exec_mount_script(module_dir: &str) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", mount_script.to_str().unwrap()])
-        .envs(crate::module::get_common_script_envs())
+        .envs(crate::module::get_common_script_envs(
+            get_metamodule_id().as_deref(),
+        ))
         .env("MODULE_DIR", module_dir)
         .status()?;
 

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use const_format::concatcp;
 use is_executable::is_executable;
 use java_properties::PropertiesIter;
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use regex_lite::Regex;
 
 use std::fs::{copy, rename};
@@ -57,7 +57,7 @@ pub fn validate_module_id(module_id: &str) -> Result<()> {
 }
 
 /// Get common environment variables for script execution
-pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
+pub fn get_common_script_envs(module_id: Option<&str>) -> Vec<(&'static str, String)> {
     let mut envs = vec![
         ("ASH_STANDALONE", "1".to_string()),
         ("KSU", "true".to_string()),
@@ -74,6 +74,14 @@ pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
         ),
     ];
 
+    if let Some(id) = module_id {
+        if validate_module_id(id).is_ok() {
+            envs.push(("KSU_MODULE", id.to_string()));
+        } else {
+            error!("Invalid module_id provided: {id}");
+        }
+    }
+
     if ksucalls::is_late_load() {
         envs.push(("KSU_LATE_LOAD", "1".to_string()));
     }
@@ -81,7 +89,7 @@ pub fn get_common_script_envs() -> Vec<(&'static str, String)> {
     envs
 }
 
-fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
+fn exec_install_script(module_file: &str, is_metamodule: bool, module_id: &str) -> Result<()> {
     let realpath = std::fs::canonicalize(module_file)
         .with_context(|| format!("realpath: {module_file} failed"))?;
 
@@ -91,7 +99,7 @@ fn exec_install_script(module_file: &str, is_metamodule: bool) -> Result<()> {
 
     let result = Command::new(assets::BUSYBOX_PATH)
         .args(["sh", "-c", &install_script])
-        .envs(get_common_script_envs())
+        .envs(get_common_script_envs(Some(module_id)))
         .env("OUTFD", "1")
         .env("ZIPFILE", realpath)
         .status()?;
@@ -224,12 +232,7 @@ pub fn exec_script<T: AsRef<Path>>(path: T, wait: bool) -> Result<()> {
         .current_dir(path.as_ref().parent().unwrap())
         .arg("sh")
         .arg(path.as_ref())
-        .envs(get_common_script_envs());
-
-    // Set KSU_MODULE environment variable if module_id was validated successfully
-    if let Some(id) = validated_module_id {
-        command = command.env("KSU_MODULE", id);
-    }
+        .envs(get_common_script_envs(validated_module_id));
 
     let result = if wait {
         command.status().map(|_| ())
@@ -515,7 +518,7 @@ fn install_module_to_system(zip: &str) -> Result<()> {
 
     // Execute install script
     println!("- Running module installer");
-    exec_install_script(zip, is_metamodule)?;
+    exec_install_script(zip, is_metamodule, module_id)?;
 
     let module_dir = Path::new(MODULE_DIR).join(module_id);
     ensure_dir_exists(&module_dir)?;


### PR DESCRIPTION
KSU_MODULE environment var will only pass in exec_script, that's cause only stage-scripts, action.sh and uninstall scripts have this environment var

So, it cause customize.sh, and meta*.sh won't have this envionment var 
And module developers will see them can't use ksud module config set command, 
because ksud throw 
`This command must be run in the context of a module or passed --internal <name>`

Taking the magic_mount_rs module as an example:
before:
```
KSU='true'
KSU_KERNEL_VER_CODE='32481'
KSU_VER='3.2.4-24-gcc83433b'
KSU_VER_CODE='32481'
```
after:
```
KSU='true'
KSU_KERNEL_VER_CODE='32481'
KSU_MODULE='magic_mount_rs'
KSU_VER='3.2.4-24-gcc83433b'
KSU_VER_CODE='32481'
```