### PR TITLE
kernel, ksud, manager: implement uapi version check

### DIFF
--- a/kernel/build-all.sh
+++ b/kernel/build-all.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
-cd "$(dirname "$(readlink -f "$0")")"
-
 set -e
 
 mkdir -p output
 
 KMIS="android12-5.10 android13-5.10 android13-5.15 android14-5.15 android14-6.1 android15-6.6 android16-6.12"
 
-cd ..
+mv .ddk-version .ddk-version.bak || true
 
 for kmi in $KMIS; do
     echo "========== Building $kmi =========="
     export DDK_TARGET=$kmi
-    if ddk build \
-        -e CONFIG_KSU=m \
-        -- -C kernel; then
-        cd kernel/
+    if ddk build -e CONFIG_KSU=m; then
         if [ -f kernelsu.ko ]; then
             cp kernelsu.ko "kernelsu-${kmi}.ko"
-            llvm-objcopy --strip-unneeded "kernelsu-${kmi}.ko"
+            llvm-objcopy --strip-unneeded --discard-locals "kernelsu-${kmi}.ko"
             echo "✓ Built kernelsu-${kmi}.ko"
         fi
-        cd ..
     else
         echo "✗ Build failed for $kmi"
     fi
@@ -29,7 +23,7 @@ for kmi in $KMIS; do
     unset DDK_TARGET
 done
 
-cd kernel
+mv .ddk-version.bak .ddk-version || true
 
 echo "========== Final output =========="
 ls -la

--- a/kernel/build-all.sh
+++ b/kernel/build-all.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
+cd "$(dirname "$(readlink -f "$0")")"
+
 set -e
 
 mkdir -p output
 
 KMIS="android12-5.10 android13-5.10 android13-5.15 android14-5.15 android14-6.1 android15-6.6 android16-6.12"
 
-mv .ddk-version .ddk-version.bak || true
+cd ..
 
 for kmi in $KMIS; do
     echo "========== Building $kmi =========="
     export DDK_TARGET=$kmi
-    if ddk build -e CONFIG_KSU=m; then
+    if ddk build \
+        -e CONFIG_KSU=m \
+        -- -C kernel; then
+        cd kernel/
         if [ -f kernelsu.ko ]; then
             cp kernelsu.ko "kernelsu-${kmi}.ko"
-            llvm-objcopy --strip-unneeded --discard-locals "kernelsu-${kmi}.ko"
+            llvm-objcopy --strip-unneeded "kernelsu-${kmi}.ko"
             echo "✓ Built kernelsu-${kmi}.ko"
         fi
+        cd ..
     else
         echo "✗ Build failed for $kmi"
     fi
@@ -23,7 +29,7 @@ for kmi in $KMIS; do
     unset DDK_TARGET
 done
 
-mv .ddk-version.bak .ddk-version || true
+cd kernel
 
 echo "========== Final output =========="
 ls -la

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -65,6 +65,33 @@ static int do_get_info(void __user *arg)
     return 0;
 }
 
+static int do_get_info_legacy(void __user *arg)
+{
+    struct ksu_get_info_legacy_cmd cmd = { .version = KERNEL_SU_VERSION, .flags = 0 };
+
+#ifdef MODULE
+    cmd.flags |= KSU_GET_INFO_FLAG_LKM;
+#endif
+
+    if (is_manager()) {
+        cmd.flags |= KSU_GET_INFO_FLAG_MANAGER;
+    }
+    if (ksu_late_loaded) {
+        cmd.flags |= KSU_GET_INFO_FLAG_LATE_LOAD;
+    }
+#ifdef EXPECTED_SIZE2
+    cmd.flags |= KSU_GET_INFO_FLAG_PR_BUILD;
+#endif
+    cmd.features = KSU_FEATURE_MAX;
+
+    if (copy_to_user(arg, &cmd, sizeof(cmd))) {
+        pr_err("get_version: copy_to_user failed\n");
+        return -EFAULT;
+    }
+
+    return 0;
+}
+
 static int do_report_event(void __user *arg)
 {
     struct ksu_report_event_cmd cmd;
@@ -668,6 +695,12 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
         .cmd = KSU_IOCTL_GET_INFO,
         .name = "GET_INFO",
         .handler = do_get_info,
+        .perm_check = always_allow
+    },
+    {
+        .cmd = KSU_IOCTL_GET_INFO_LEGACY,
+        .name = "GET_INFO_LEGACY",
+        .handler = do_get_info_legacy,
         .perm_check = always_allow
     },
     {

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -55,6 +55,7 @@ static int do_get_info(void __user *arg)
     cmd.flags |= KSU_GET_INFO_FLAG_PR_BUILD;
 #endif
     cmd.features = KSU_FEATURE_MAX;
+    cmd.uapi_version = KERNEL_SU_UAPI_VERSION;
 
     if (copy_to_user(arg, &cmd, sizeof(cmd))) {
         pr_err("get_version: copy_to_user failed\n");

--- a/manager/app/src/main/cpp/jni.cc
+++ b/manager/app/src/main/cpp/jni.cc
@@ -25,6 +25,18 @@ Java_me_weishu_kernelsu_Natives_getVersion(JNIEnv *env, jobject) {
 
 extern "C"
 JNIEXPORT jint JNICALL
+Java_me_weishu_kernelsu_Natives_getKernelUAPIVersion(JNIEnv *env, jobject) {
+    return get_kernel_uapi_version();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_me_weishu_kernelsu_Natives_getManagerUAPIVersion(JNIEnv *env, jobject) {
+    return get_manager_uapi_version();
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
 Java_me_weishu_kernelsu_Natives_getSuperuserCount(JNIEnv *env, jobject) {
     struct ksu_new_get_allow_list_cmd cmd = {
         .count = 0

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -79,7 +79,10 @@ static struct ksu_get_info_cmd g_version {};
 
 struct ksu_get_info_cmd get_info() {
     if (!g_version.version) {
-        ksuctl(KSU_IOCTL_GET_INFO, &g_version);
+        if (ksuctl(KSU_IOCTL_GET_INFO, &g_version) < 0) {
+            ksuctl(KSU_IOCTL_GET_INFO_LEGACY, &g_version);
+            g_version.uapi_version = 0;
+        }
     }
     return g_version;
 }

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -84,12 +84,12 @@ struct ksu_get_info_cmd get_info() {
     return g_version;
 }
 
-uint16_t get_kernel_uapi_version() {
+uint32_t get_kernel_uapi_version() {
     auto info = get_info();
     return info.uapi_version;
 }
 
-uint16_t get_manager_uapi_version() {
+uint32_t get_manager_uapi_version() {
     return KERNEL_SU_UAPI_VERSION;
 }
 

--- a/manager/app/src/main/cpp/ksu.cc
+++ b/manager/app/src/main/cpp/ksu.cc
@@ -84,6 +84,15 @@ struct ksu_get_info_cmd get_info() {
     return g_version;
 }
 
+uint16_t get_kernel_uapi_version() {
+    auto info = get_info();
+    return info.uapi_version;
+}
+
+uint16_t get_manager_uapi_version() {
+    return KERNEL_SU_UAPI_VERSION;
+}
+
 uint32_t get_version() {
     auto info = get_info();
     return info.version;

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -12,9 +12,9 @@
 
 #include "uapi/ksu.h"
 
-uint16_t get_kernel_uapi_version();
+uint32_t get_kernel_uapi_version();
 
-uint16_t get_manager_uapi_version();
+uint32_t get_manager_uapi_version();
 
 uint32_t get_version();
 

--- a/manager/app/src/main/cpp/ksu.h
+++ b/manager/app/src/main/cpp/ksu.h
@@ -12,6 +12,10 @@
 
 #include "uapi/ksu.h"
 
+uint16_t get_kernel_uapi_version();
+
+uint16_t get_manager_uapi_version();
+
 uint32_t get_version();
 
 bool uid_should_umount(int uid);

--- a/manager/app/src/main/java/me/weishu/kernelsu/Natives.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/Natives.kt
@@ -21,8 +21,8 @@ object Natives {
     // 32310: new get_allow_list ioctl
     // 32336: new set_sepolicy ioctl
     // 32377: add set_init_pgrp ioctl
-    // 32483: add uapi version
-    const val MINIMAL_SUPPORTED_KERNEL = 32483
+    // 32513: add uapi version
+    const val MINIMAL_SUPPORTED_KERNEL = 32513
 
     const val KERNEL_SU_DOMAIN = "u:r:ksu:s0"
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/Natives.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/Natives.kt
@@ -21,7 +21,8 @@ object Natives {
     // 32310: new get_allow_list ioctl
     // 32336: new set_sepolicy ioctl
     // 32377: add set_init_pgrp ioctl
-    const val MINIMAL_SUPPORTED_KERNEL = 32377
+    // 32483: add uapi version
+    const val MINIMAL_SUPPORTED_KERNEL = 32483
 
     const val KERNEL_SU_DOMAIN = "u:r:ksu:s0"
 
@@ -114,8 +115,18 @@ object Natives {
         }
     }
 
+    val kernelUAPIVersion: Int
+        external get
+
+    val managerUAPIVersion: Int
+        external get
+
+    fun checkUAPIMismatch(): Boolean {
+        return kernelUAPIVersion != managerUAPIVersion
+    }
+
     fun requireNewKernel(): Boolean {
-        return version != -1 && version < MINIMAL_SUPPORTED_KERNEL
+        return (version != -1 && version < MINIMAL_SUPPORTED_KERNEL) || checkUAPIMismatch()
     }
 
     @Keep

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -252,7 +252,7 @@ private fun StatusCard(
                             }
                             Spacer(Modifier.height(4.dp))
                             Text(
-                                text = stringResource(R.string.home_working_version, state.ksuVersion),
+                                text = stringResource(R.string.home_working_version, "${state.ksuVersion}/${state.kernelUAPIVersion}"),
                                 style = MaterialTheme.typography.bodyMedium
                             )
                         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.KernelVersion
+import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.material.TonalCard
@@ -94,14 +95,33 @@ fun HomePagerMaterial(
             if (state.showGkiWarning) {
                 WarningCard(stringResource(id = R.string.home_gki_warning))
             }
-            if (state.showRequireKernelWarning) {
+            if (state.showUAPIMisMatchWarning) {
                 WarningCard(
                     stringResource(
-                        id = R.string.require_kernel_version,
-                        state.ksuVersion ?: 0,
-                        me.weishu.kernelsu.Natives.MINIMAL_SUPPORTED_KERNEL
+                        id = R.string.uapi_mismatch,
+                        state.managerUAPIVersion,
+                        state.kernelUAPIVersion ?: 0,
                     )
                 )
+            }
+            if (state.showRequireKernelWarning) {
+                if (state.currentManagerVersionCode < (state.ksuVersion ?: 0)) {
+                    WarningCard(
+                        stringResource(
+                            id = R.string.require_manager_version,
+                            state.currentManagerVersionCode,
+                            state.ksuVersion ?: 0,
+                        )
+                    )
+                } else {
+                    WarningCard(
+                        stringResource(
+                            id = R.string.require_kernel_version,
+                            state.ksuVersion ?: 0,
+                            Natives.MINIMAL_SUPPORTED_KERNEL
+                        )
+                    )
+                }
             }
             if (state.showRootWarning) {
                 WarningCard(stringResource(id = R.string.grant_root_failed))
@@ -584,4 +604,7 @@ private fun previewHomeScreenState(
     superuserCount = superuserCount,
     moduleCount = moduleCount,
     systemInfo = previewSystemInfo.copy(selinuxStatus = selinuxStatus),
+    kernelUAPIVersion = 1,
+    managerUAPIVersion = 1,
+    uapiMismatch = false
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
@@ -131,13 +131,33 @@ fun HomePagerMiuix(
                         if (state.showGkiWarning) {
                             WarningCard(stringResource(id = R.string.home_gki_warning))
                         }
-                        if (state.showRequireKernelWarning) {
+                        if (state.showUAPIMisMatchWarning) {
                             WarningCard(
                                 stringResource(
-                                    id = R.string.require_kernel_version,
-                                    state.ksuVersion ?: 0, me.weishu.kernelsu.Natives.MINIMAL_SUPPORTED_KERNEL
-                                ),
+                                    id = R.string.uapi_mismatch,
+                                    state.managerUAPIVersion,
+                                    state.kernelUAPIVersion ?: 0,
+                                )
                             )
+                        }
+                        if (state.showRequireKernelWarning) {
+                            if (state.currentManagerVersionCode < (state.ksuVersion ?: 0)) {
+                                WarningCard(
+                                    stringResource(
+                                        id = R.string.require_manager_version,
+                                        state.currentManagerVersionCode,
+                                        state.ksuVersion ?: 0,
+                                    )
+                                )
+                            } else {
+                                WarningCard(
+                                    stringResource(
+                                        id = R.string.require_kernel_version,
+                                        state.ksuVersion ?: 0,
+                                        me.weishu.kernelsu.Natives.MINIMAL_SUPPORTED_KERNEL
+                                    )
+                                )
+                            }
                         }
                         if (state.showRootWarning) {
                             WarningCard(stringResource(id = R.string.grant_root_failed))
@@ -656,4 +676,7 @@ private fun previewHomeScreenState(
     superuserCount = superuserCount,
     moduleCount = moduleCount,
     systemInfo = previewSystemInfo.copy(selinuxStatus = selinuxStatus),
+    kernelUAPIVersion = 1,
+    managerUAPIVersion = 1,
+    uapiMismatch = false,
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
@@ -313,7 +313,7 @@ private fun StatusCard(
                                 Spacer(Modifier.height(2.dp))
                                 Text(
                                     modifier = Modifier.fillMaxWidth(),
-                                    text = stringResource(R.string.home_working_version, state.ksuVersion),
+                                    text = stringResource(R.string.home_working_version, "${state.ksuVersion}/${state.kernelUAPIVersion}"),
                                     fontSize = 14.sp,
                                     fontWeight = FontWeight.Medium,
                                 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeUiState.kt
@@ -8,11 +8,14 @@ import me.weishu.kernelsu.ui.util.module.LatestVersionInfo
 data class HomeUiState(
     val kernelVersion: KernelVersion,
     val ksuVersion: Int?,
+    val managerUAPIVersion: Int,
+    val kernelUAPIVersion: Int?,
     val lkmMode: Boolean?,
     val isManager: Boolean,
     val isManagerPrBuild: Boolean,
     val isKernelPrBuild: Boolean,
     val requiresNewKernel: Boolean,
+    val uapiMismatch: Boolean,
     val isRootAvailable: Boolean,
     val isSafeMode: Boolean,
     val isLateLoadMode: Boolean,
@@ -34,6 +37,9 @@ data class HomeUiState(
 
     val showRequireKernelWarning: Boolean
         get() = isManager && requiresNewKernel
+
+    val showUAPIMisMatchWarning: Boolean
+        get() = isManager && showRequireKernelWarning && uapiMismatch
 
     val showRootWarning: Boolean
         get() = ksuVersion != null && !isRootAvailable

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
@@ -48,6 +48,7 @@ class HomeViewModel : ViewModel() {
         val isManager = Natives.isManager
         val ksuVersion = if (isManager) Natives.version else null
         val kernelUAPIVersion = if (isManager) Natives.kernelUAPIVersion else null
+        val managerUAPIVersion = Natives.managerUAPIVersion
         val lkmMode = ksuVersion?.let { if (kernelVersion.isGKI()) Natives.isLkmMode else null }
         val isRootAvailable = rootAvailable()
         val managerVersion = getManagerVersion(ksuApp)
@@ -62,7 +63,7 @@ class HomeViewModel : ViewModel() {
             requiresNewKernel = isManager && Natives.requireNewKernel(),
             uapiMismatch = isManager && Natives.checkUAPIMismatch(),
             kernelUAPIVersion = kernelUAPIVersion,
-            managerUAPIVersion = Natives.managerUAPIVersion,
+            managerUAPIVersion = managerUAPIVersion,
             isRootAvailable = isRootAvailable,
             isSafeMode = Natives.isSafeMode,
             isLateLoadMode = Natives.isLateLoadMode,
@@ -74,7 +75,7 @@ class HomeViewModel : ViewModel() {
             moduleCount = getModuleCount(),
             systemInfo = SystemInfo(
                 kernelVersion = Os.uname().release,
-                managerVersion = "${managerVersion.versionName} (${managerVersion.versionCode})",
+                managerVersion = "${managerVersion.versionName} (${managerVersion.versionCode}/${managerUAPIVersion})",
                 deviceModel = resolveDeviceName(),
                 fingerprint = Build.FINGERPRINT,
                 selinuxStatus = getSELinuxStatusRaw(),

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
@@ -47,6 +47,7 @@ class HomeViewModel : ViewModel() {
         val kernelVersion = getKernelVersion()
         val isManager = Natives.isManager
         val ksuVersion = if (isManager) Natives.version else null
+        val kernelUAPIVersion = if (isManager) Natives.kernelUAPIVersion else null
         val lkmMode = ksuVersion?.let { if (kernelVersion.isGKI()) Natives.isLkmMode else null }
         val isRootAvailable = rootAvailable()
         val managerVersion = getManagerVersion(ksuApp)
@@ -59,6 +60,9 @@ class HomeViewModel : ViewModel() {
             isManagerPrBuild = BuildConfig.IS_PR_BUILD,
             isKernelPrBuild = Natives.isPrBuild,
             requiresNewKernel = isManager && Natives.requireNewKernel(),
+            uapiMismatch = isManager && Natives.checkUAPIMismatch(),
+            kernelUAPIVersion = kernelUAPIVersion,
+            managerUAPIVersion = Natives.managerUAPIVersion,
             isRootAvailable = isRootAvailable,
             isSafeMode = Natives.isSafeMode,
             isLateLoadMode = Natives.isLateLoadMode,

--- a/manager/app/src/main/res/values-ar/strings.xml
+++ b/manager/app/src/main/res/values-ar/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">غير مثبت</string>
     <string name="home_click_to_install">إضغط للتثبيت</string>
     <string name="home_working">يعمل</string>
-    <string name="home_working_version">الإصدار: %d</string>
+    <string name="home_working_version">الإصدار: %s</string>
     <string name="home_unsupported">غير مدعوم</string>
     <string name="home_unsupported_reason">KernelSU يدعم GKI kernels فقط</string>
     <string name="home_kernel">إصدار النواة</string>

--- a/manager/app/src/main/res/values-az/strings.xml
+++ b/manager/app/src/main/res/values-az/strings.xml
@@ -5,7 +5,7 @@
     <string name="home_not_installed">Yüklənmədi</string>
     <string name="home_click_to_install">Yükləmək üçün toxunun</string>
     <string name="home_working">İşləyir</string>
-    <string name="home_working_version">Versiya: %d</string>
+    <string name="home_working_version">Versiya: %s</string>
     <string name="home_unsupported_reason">Hal-hazırda KernelSU yalnız GKI nüvələrini dəstəkləyir</string>
     <string name="home_unsupported">Dəstəklənmir</string>
     <string name="module_install">Yüklə</string>

--- a/manager/app/src/main/res/values-bg/strings.xml
+++ b/manager/app/src/main/res/values-bg/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Не е инсталирано</string>
     <string name="home_click_to_install">Натиснете да инсталирате</string>
     <string name="home_working">Работи</string>
-    <string name="home_working_version">Версия: %d</string>
+    <string name="home_working_version">Версия: %s</string>
     <string name="home_unsupported">Неподдържано</string>
     <string name="home_unsupported_reason">KernelSU само поддържа GKI кернели за сега.</string>
     <string name="home_kernel">Версия на кернела</string>

--- a/manager/app/src/main/res/values-bn-rBD/strings.xml
+++ b/manager/app/src/main/res/values-bn-rBD/strings.xml
@@ -30,7 +30,7 @@
     <string name="selinux_status_permissive">পারমিসিভ</string>
     <string name="module_failed_to_disable">মোডিউল ডিসেবল করা যায়নি: %s</string>
     <string name="module_empty">কোনো মোডিউল ইন্সটল করা নেই</string>
-    <string name="home_working_version">সংস্করণ: %d</string>
+    <string name="home_working_version">সংস্করণ: %s</string>
     <string name="profile_namespace">নেইম স্পেস মাউন্ট</string>
     <string name="profile_namespace_inherited">ইনহেরিটেড</string>
     <string name="profile_namespace_individual">ইন্ডিভিজুয়াল</string>

--- a/manager/app/src/main/res/values-bn/strings.xml
+++ b/manager/app/src/main/res/values-bn/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">ইনস্টল করা হয়নি</string>
     <string name="home_click_to_install">ইনস্টল করার জন্য ক্লিক করুন</string>
     <string name="home_working"> ওয়ার্কিং</string>
-    <string name="home_working_version">ওয়ার্কিং সংস্করণ: %d</string>
+    <string name="home_working_version">ওয়ার্কিং সংস্করণ: %s</string>
     <string name="home_unsupported">অসমর্থিত</string>
     <string name="home_unsupported_reason">KernelSU শুধুমাত্র GKI কার্নেল সমর্থন করে</string>
     <string name="home_kernel">কার্নেল সংস্করণ</string>

--- a/manager/app/src/main/res/values-bs/strings.xml
+++ b/manager/app/src/main/res/values-bs/strings.xml
@@ -49,7 +49,7 @@
     <string name="profile_selinux_rules">Pravila</string>
     <string name="failed_to_update_sepolicy">Neuspješno ažuriranje SELinux pravila za: %s</string>
     <string name="home_working">Radi</string>
-    <string name="home_working_version">Verzija: %d</string>
+    <string name="home_working_version">Verzija: %s</string>
     <string name="home_kernel">Kernel verzija</string>
     <string name="selinux_status_permissive">Permisivno</string>
     <string name="uninstall">Deinstalirajte</string>

--- a/manager/app/src/main/res/values-da/strings.xml
+++ b/manager/app/src/main/res/values-da/strings.xml
@@ -50,7 +50,7 @@
     <string name="failed_to_update_sepolicy">Opdatering af SELinux-regler mislykkedes for %s</string>
     <string name="module_start_downloading">Start download: %s</string>
     <string name="home_click_to_install">Klik for at installere</string>
-    <string name="home_working_version">Version: %d</string>
+    <string name="home_working_version">Version: %s</string>
     <string name="home">Hjem</string>
     <string name="home_not_installed">Ikke installeret</string>
     <string name="home_fingerprint">Fingeraftryk</string>

--- a/manager/app/src/main/res/values-de/strings.xml
+++ b/manager/app/src/main/res/values-de/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Nicht installiert</string>
     <string name="selinux_status_permissive">Permissiv</string>
     <string name="home_working">Funktioniert</string>
-    <string name="home_working_version">Version: %d</string>
+    <string name="home_working_version">Version: %s</string>
     <string name="superuser">Superuser</string>
     <string name="home_click_to_install">Tippe zum Installieren</string>
     <string name="selinux_status_unknown">Unbekannt</string>

--- a/manager/app/src/main/res/values-es/strings.xml
+++ b/manager/app/src/main/res/values-es/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">No instalado</string>
     <string name="home_click_to_install">Haz clic para instalar</string>
     <string name="home_working">Funcionando</string>
-    <string name="home_working_version">Versión: %d</string>
+    <string name="home_working_version">Versión: %s</string>
     <string name="home_unsupported">Sin soporte</string>
     <string name="home_unsupported_reason">KernelSU solo admite kernels GKI por ahora</string>
     <string name="home_kernel">Versión del kernel</string>

--- a/manager/app/src/main/res/values-et/strings.xml
+++ b/manager/app/src/main/res/values-et/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="home_working">Töötamine</string>
-    <string name="home_working_version">Versioon: %d</string>
+    <string name="home_working_version">Versioon: %s</string>
     <string name="home_kernel">Tuum</string>
     <string name="home_manager_version">Manageri versioon</string>
     <string name="home_fingerprint">Sõrmejälg</string>

--- a/manager/app/src/main/res/values-fa/strings.xml
+++ b/manager/app/src/main/res/values-fa/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">نصب نشده است</string>
     <string name="home_click_to_install">برای نصب ضربه بزنید</string>
     <string name="home_working">به درستی کار می‌کند</string>
-    <string name="home_working_version">نسخه: %d</string>
+    <string name="home_working_version">نسخه: %s</string>
     <string name="home_unsupported">پشتیبانی نشده</string>
     <string name="home_unsupported_reason">کرنل اس یو فقط هسته های gki را پشتیبانی میکند</string>
     <string name="home_kernel">هسته</string>

--- a/manager/app/src/main/res/values-fil/strings.xml
+++ b/manager/app/src/main/res/values-fil/strings.xml
@@ -8,7 +8,7 @@
     <string name="home">Panimula</string>
     <string name="home_click_to_install">I-click para i-install</string>
     <string name="home_working">Gumagana</string>
-    <string name="home_working_version">Bersyon: %d</string>
+    <string name="home_working_version">Bersyon: %s</string>
     <string name="selinux_status_unknown">Hindi matukoy</string>
     <string name="home_unsupported">Hindi Suportado</string>
     <string name="home_unsupported_reason">Sinusuportahan lamang ng KernelSU ang mga GKI na kernel.</string>

--- a/manager/app/src/main/res/values-fr/strings.xml
+++ b/manager/app/src/main/res/values-fr/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_not_installed">Non installé</string>
     <string name="home_working">Fonctionnel</string>
-    <string name="home_working_version">Version : %d</string>
+    <string name="home_working_version">Version : %s</string>
     <string name="home_unsupported_reason">KernelSU prend désormais en charge seulement les noyaux GKI, mais vous pouvez patcher l\'image pour les appareils GKI.</string>
     <string name="home_kernel">Version du noyau</string>
     <string name="home_fingerprint">Empreinte</string>

--- a/manager/app/src/main/res/values-hi/strings.xml
+++ b/manager/app/src/main/res/values-hi/strings.xml
@@ -45,7 +45,7 @@
     <string name="module">मॉड्यूल</string>
     <string name="module_author">निर्माता</string>
     <string name="about">हमारे बारे में</string>
-    <string name="home_working_version">वर्जन: %d</string>
+    <string name="home_working_version">वर्जन: %s</string>
     <string name="reboot">रीबूट करें</string>
     <string name="home_unsupported_reason">KernelSU अभी केवल GKI कर्नल्स को सपोर्ट करता है</string>
     <string name="home_selinux_status">SELinux स्थिति</string>

--- a/manager/app/src/main/res/values-hr/strings.xml
+++ b/manager/app/src/main/res/values-hr/strings.xml
@@ -7,7 +7,7 @@
     <string name="failed_to_update_sepolicy">Nije uspjelo ažuriranje SELinux pravila za %s</string>
     <string name="home">Početna</string>
     <string name="home_not_installed">Nije instalirano</string>
-    <string name="home_working_version">Verzija: %d</string>
+    <string name="home_working_version">Verzija: %s</string>
     <string name="home_click_to_install">Kliknite da instalirate</string>
     <string name="home_working">Radi</string>
     <string name="home_unsupported">Nepodržano</string>

--- a/manager/app/src/main/res/values-hu/strings.xml
+++ b/manager/app/src/main/res/values-hu/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="home_working">Működik</string>
-    <string name="home_working_version">Verzió: %d</string>
+    <string name="home_working_version">Verzió: %s</string>
     <string name="home_unsupported_reason">A KernelSU jelenleg csak GKI kerneleket támogat</string>
     <string name="home_kernel">Kernel</string>
     <string name="home_manager_version">Alkalmazás verziója</string>

--- a/manager/app/src/main/res/values-in/strings.xml
+++ b/manager/app/src/main/res/values-in/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Tidak terpasang</string>
     <string name="home_click_to_install">Ketuk untuk memasang</string>
     <string name="home_working">Berfungsi</string>
-    <string name="home_working_version">Versi: %d</string>
+    <string name="home_working_version">Versi: %s</string>
     <string name="home_unsupported">Tidak didukung</string>
     <string name="home_unsupported_reason">KernelSU sekarang hanya mendukung kernel GKI, tetapi Anda dapat menambal image untuk perangkat GKI.</string>
     <string name="home_kernel">Versi kernel</string>

--- a/manager/app/src/main/res/values-it/strings.xml
+++ b/manager/app/src/main/res/values-it/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Non installato</string>
     <string name="home_click_to_install">Clicca per installare</string>
     <string name="home_working">In esecuzione</string>
-    <string name="home_working_version">Versione: %d</string>
+    <string name="home_working_version">Versione: %s</string>
     <string name="home_unsupported">Non supportato</string>
     <string name="home_unsupported_reason">KernelSU ora supporta solo i kernel GKI</string>
     <string name="home_kernel">Kernel</string>

--- a/manager/app/src/main/res/values-iw/strings.xml
+++ b/manager/app/src/main/res/values-iw/strings.xml
@@ -45,7 +45,7 @@
     <string name="module">מודולים</string>
     <string name="module_author">יוצר</string>
     <string name="about">אודות</string>
-    <string name="home_working_version">גרסה: %d</string>
+    <string name="home_working_version">גרסה: %s</string>
     <string name="reboot">הפעלה מחדש</string>
     <string name="home_unsupported_reason">KernelSU תומך רק בליבת GKI כעת</string>
     <string name="home_selinux_status">סטטוס SELinux</string>

--- a/manager/app/src/main/res/values-ja/strings.xml
+++ b/manager/app/src/main/res/values-ja/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">未インストール</string>
     <string name="home_click_to_install">タップしてインストール</string>
     <string name="home_working">動作中</string>
-    <string name="home_working_version">バージョン: %d</string>
+    <string name="home_working_version">バージョン: %s</string>
     <string name="home_unsupported">非対応</string>
     <string name="home_unsupported_reason">KernelSU は現在 GKI カーネルのみをサポートしています。ただし、GKI デバイス向けにイメージにパッチを適用することは可能です。</string>
     <string name="home_kernel">カーネル</string>

--- a/manager/app/src/main/res/values-kn/strings.xml
+++ b/manager/app/src/main/res/values-kn/strings.xml
@@ -37,7 +37,7 @@
     <string name="module">ಮಾಡ್ಯೂಲ್</string>
     <string name="module_author">ಲೇಖಕ</string>
     <string name="about">ಬಗ್ಗೆ</string>
-    <string name="home_working_version">ವರ್ಷನ್: %d</string>
+    <string name="home_working_version">ವರ್ಷನ್: %s</string>
     <string name="reboot">ರೀಬೂಟ್</string>
     <string name="home_unsupported_reason">KernelSU ಈಗ GKI ಕರ್ನಲ್‌ಗಳನ್ನು ಮಾತ್ರ ಬೆಂಬಲಿಸುತ್ತದೆ</string>
     <string name="home_selinux_status">SELinux ಸ್ಥಿತಿ</string>

--- a/manager/app/src/main/res/values-ko/strings.xml
+++ b/manager/app/src/main/res/values-ko/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">설치되지 않음</string>
     <string name="home_click_to_install">이 곳을 눌러 설치하기</string>
     <string name="home_working">작동 중</string>
-    <string name="home_working_version">버전: %d</string>
+    <string name="home_working_version">버전: %s</string>
     <string name="home_unsupported">지원되지 않음</string>
     <string name="home_unsupported_reason">KernelSU는 현재 GKI 커널만 지원합니다.</string>
     <string name="home_kernel">커널 버전</string>

--- a/manager/app/src/main/res/values-lt/strings.xml
+++ b/manager/app/src/main/res/values-lt/strings.xml
@@ -58,7 +58,7 @@
     <string name="home_unsupported_reason">KernelSU dabar palaiko tik GKI branduolius</string>
     <string name="home_click_to_install">Spustelėkite norėdami įdiegti</string>
     <string name="home_working">Veikia</string>
-    <string name="home_working_version">Versija: %d</string>
+    <string name="home_working_version">Versija: %s</string>
     <string name="home_unsupported">Nepalaikoma</string>
     <string name="home_manager_version">Tvarkyklės versija</string>
     <string name="home_kernel">Branduolys</string>

--- a/manager/app/src/main/res/values-lv/strings.xml
+++ b/manager/app/src/main/res/values-lv/strings.xml
@@ -12,7 +12,7 @@
     <string name="home_not_installed">Nav uzstādīts</string>
     <string name="home_click_to_install">Noklikšķiniet, lai uzstādītu</string>
     <string name="home_working">Darbojas</string>
-    <string name="home_working_version">Versija: %d</string>
+    <string name="home_working_version">Versija: %s</string>
     <string name="home_unsupported">Neatbalstīts</string>
     <string name="home_unsupported_reason">KernelSU pagaidām atbalsta tikai GKI kodolus</string>
     <string name="home_kernel">Kodols</string>

--- a/manager/app/src/main/res/values-mr/strings.xml
+++ b/manager/app/src/main/res/values-mr/strings.xml
@@ -4,7 +4,7 @@
     <string name="home">होम</string>
     <string name="home_click_to_install">इंस्टॉल साठी क्लिक करा</string>
     <string name="home_working">कार्यरत</string>
-    <string name="home_working_version">आवृत्ती: %d</string>
+    <string name="home_working_version">आवृत्ती: %s</string>
     <string name="home_unsupported">असमर्थित</string>
     <string name="home_unsupported_reason">KernelSU आता फक्त GKI कर्नलचे समर्थन करते</string>
     <string name="home_kernel">कर्नल</string>

--- a/manager/app/src/main/res/values-ms/strings.xml
+++ b/manager/app/src/main/res/values-ms/strings.xml
@@ -15,7 +15,7 @@
     <string name="home_click_to_install">Tekan untuk memasang</string>
     <string name="module">Modul</string>
     <string name="about">Tentang</string>
-    <string name="home_working_version">Versi: %d</string>
+    <string name="home_working_version">Versi: %s</string>
     <string name="reboot">Reboot</string>
     <string name="home_unsupported_reason">KernelSU ketika ini hanya menyokong kernel GKI</string>
     <string name="home_selinux_status">Status SELinux</string>

--- a/manager/app/src/main/res/values-nl/strings.xml
+++ b/manager/app/src/main/res/values-nl/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Niet geïnstalleerd</string>
     <string name="home_click_to_install">Tik om te installeren</string>
     <string name="home_working">Werkend</string>
-    <string name="home_working_version">Versie: %d</string>
+    <string name="home_working_version">Versie: %s</string>
     <string name="home_unsupported">Niet ondersteund</string>
     <string name="home_unsupported_reason">KernelSU ondersteunt momenteel alleen GKI-kernels, maar je kunt de image patchen voor GKI-apparaten.</string>
     <string name="home_kernel">Kernel version</string>

--- a/manager/app/src/main/res/values-pl/strings.xml
+++ b/manager/app/src/main/res/values-pl/strings.xml
@@ -5,7 +5,7 @@
     <string name="home_not_installed">Nie zainstalowano</string>
     <string name="home_click_to_install">Kliknij, aby zainstalować</string>
     <string name="home_working">Działa</string>
-    <string name="home_working_version">Wersja: %d</string>
+    <string name="home_working_version">Wersja: %s</string>
     <string name="home_unsupported">Nieobsługiwany</string>
     <string name="home_unsupported_reason">KernelSU obsługuje obecnie tylko jądra GKI.</string>
     <string name="home_kernel">Wersja jądra</string>

--- a/manager/app/src/main/res/values-pt-rBR/strings.xml
+++ b/manager/app/src/main/res/values-pt-rBR/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Não instalado</string>
     <string name="home_click_to_install">Clique para instalar</string>
     <string name="home_working">Em execução</string>
-    <string name="home_working_version">Versão: %d</string>
+    <string name="home_working_version">Versão: %s</string>
     <string name="home_unsupported">Sem suporte</string>
     <string name="home_unsupported_reason">KernelSU suporta apenas kernels GKI agora</string>
     <string name="home_kernel">Versão do kernel</string>

--- a/manager/app/src/main/res/values-pt/strings.xml
+++ b/manager/app/src/main/res/values-pt/strings.xml
@@ -4,7 +4,7 @@
     <string name="home">Início</string>
     <string name="home_click_to_install">Clique para instalar</string>
     <string name="home_working">Funcionando</string>
-    <string name="home_working_version">Versão: %d</string>
+    <string name="home_working_version">Versão: %s</string>
     <string name="home_kernel">Kernel</string>
     <string name="install">Instalar</string>
     <string name="home_unsupported">Sem suporte</string>

--- a/manager/app/src/main/res/values-ro/strings.xml
+++ b/manager/app/src/main/res/values-ro/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Nu este instalat</string>
     <string name="home_click_to_install">Click pentru a instala</string>
     <string name="home_working">Funcționează</string>
-    <string name="home_working_version">Versiune: %d</string>
+    <string name="home_working_version">Versiune: %s</string>
     <string name="home_unsupported">Necompatibil</string>
     <string name="home_unsupported_reason">KernelSU suportă doar nuclee GKI acum</string>
     <string name="home_kernel">Nucleu</string>

--- a/manager/app/src/main/res/values-ru/strings.xml
+++ b/manager/app/src/main/res/values-ru/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Не установлен</string>
     <string name="home_click_to_install">Нажмите, чтобы установить</string>
     <string name="home_working">Работает</string>
-    <string name="home_working_version">Версия: %d</string>
+    <string name="home_working_version">Версия: %s</string>
     <!--Don't translate this string!-->
     <string name="home_unsupported">Не поддерживается</string>
     <string name="home_unsupported_reason">Теперь KernelSU поддерживает только ядра GKI, однако вы всё ещё можете пропатчить образ для GKI-устройств.</string>

--- a/manager/app/src/main/res/values-sl/strings.xml
+++ b/manager/app/src/main/res/values-sl/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="home_click_to_install">Klikni za namestitev</string>
     <string name="home_working">V obdelavi</string>
-    <string name="home_working_version">Verzija: %d</string>
+    <string name="home_working_version">Verzija: %s</string>
     <string name="home_unsupported_reason">KernelSU podpira samo GKI kernele</string>
     <string name="home_kernel">Kernel</string>
     <string name="home_manager_version">Verzija upravitelja</string>

--- a/manager/app/src/main/res/values-sr/strings.xml
+++ b/manager/app/src/main/res/values-sr/strings.xml
@@ -3,7 +3,7 @@
     <string name="home_click_to_install">Додирните да бисте инсталирали</string>
     <string name="home">Почетна</string>
     <string name="home_not_installed">Није инсталирано</string>
-    <string name="home_working_version">Верзија: %d</string>
+    <string name="home_working_version">Верзија: %s</string>
     <string name="home_working">Ради</string>
     <string name="save_log">Сачувај Дневнике</string>
     <string name="settings_sucompat">Preusmeri su binarni fajl</string>

--- a/manager/app/src/main/res/values-te/strings.xml
+++ b/manager/app/src/main/res/values-te/strings.xml
@@ -14,7 +14,7 @@
     <string name="home_not_installed">ఇన్‌స్టాల్ చేయలేదు</string>
     <string name="home_click_to_install">ఇన్‌స్టాల్ చేయడానికి క్లిక్ చేయండి</string>
     <string name="home_working">పని చేస్తోంది</string>
-    <string name="home_working_version">వెర్షన్: %d</string>
+    <string name="home_working_version">వెర్షన్: %s</string>
     <string name="save_log">లాగ్‌లు సేవ్ చేయండి</string>
     <string name="settings_sucompat">su బైనరీని మళ్ళించండి</string>
     <string name="settings_sucompat_summary">యాప్ ప్రొఫైల్‌లో సూపర్‌యూజర్ అనుమతి ఉన్న యాప్‌ల కోసం /system/bin/su ని ksud కి మళ్ళించండి; కొత్త ప్రాసెస్‌లకు మాత్రమే పని చేస్తుంది.</string>

--- a/manager/app/src/main/res/values-th/strings.xml
+++ b/manager/app/src/main/res/values-th/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">ยังไม่ได้ติดตั้ง</string>
     <string name="home_click_to_install">กดเพื่อติดตั้ง</string>
     <string name="home_working">กำลังทำงาน</string>
-    <string name="home_working_version">เวอร์ชัน: %d</string>
+    <string name="home_working_version">เวอร์ชัน: %s</string>
     <string name="home_manager_version">เวอร์ชันตัวจัดการ</string>
     <string name="home_unsupported">ไม่รองรับ</string>
     <string name="selinux_status_enforcing">Enforcing</string>

--- a/manager/app/src/main/res/values-tr/strings.xml
+++ b/manager/app/src/main/res/values-tr/strings.xml
@@ -5,7 +5,7 @@
     <string name="home_not_installed">Kurulmadı</string>
     <string name="home_click_to_install">Yüklemek için dokunun</string>
     <string name="home_working">Çalışıyor</string>
-    <string name="home_working_version">Sürüm: %d</string>
+    <string name="home_working_version">Sürüm: %s</string>
     <string name="home_unsupported">Desteklenmiyor</string>
     <string name="home_unsupported_reason">KernelSU şimdilik sadece GKI çekirdeklerini destekliyor</string>
     <string name="home_kernel">Çekirdek Versiyonu</string>

--- a/manager/app/src/main/res/values-uk/strings.xml
+++ b/manager/app/src/main/res/values-uk/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">Не встановлено</string>
     <string name="home_click_to_install">Натисніть щоб встановити</string>
     <string name="home_working">Працює</string>
-    <string name="home_working_version">Версія: %d</string>
+    <string name="home_working_version">Версія: %s</string>
     <string name="home_unsupported">Не підтримується</string>
     <string name="home_unsupported_reason">KernelSU зараз підтримує лише ядра GKI.</string>
     <string name="home_kernel">Версія ядра</string>

--- a/manager/app/src/main/res/values-vi/strings.xml
+++ b/manager/app/src/main/res/values-vi/strings.xml
@@ -26,7 +26,7 @@
     <string name="home_not_installed">Chưa cài đặt</string>
     <string name="home_click_to_install">Nhấn để cài đặt</string>
     <string name="home_working">Đang hoạt động</string>
-    <string name="home_working_version">Phiên bản: %d</string>
+    <string name="home_working_version">Phiên bản: %s</string>
     <string name="home_unsupported">Không được hỗ trợ</string>
     <string name="home_unsupported_reason">KernelSU hiện tại chỉ hỗ trợ Kernel GKI, nhưng bạn có thể patch file .img của thiết bị GKI mà bạn cần.</string>
     <string name="home_kernel">Phiên bản Kernel</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,6 +83,8 @@
     <string name="profile_selinux_context">SELinux</string>
     <string name="profile_umount_modules">卸载模块</string>
     <string name="failed_to_update_app_profile">为 %s 更新 App Profile 失败</string>
+    <string name="uapi_mismatch">管理器 uapi 版本 (%1$d) 与 KernelSU 驱动 uapi 版本 (%2$d) 不匹配。</string>
+    <string name="require_manager_version">当前 KernelSU 管理器版本 %1$d 过低，KernelSU 无法正常工作. 请将 KernelSU 管理器版本升级至 %2$d 或以上!</string>
     <string name="require_kernel_version">当前 KernelSU 版本 %1$d 过低，管理器无法正常工作，请将内核 KernelSU 版本升级至 %2$d 或以上！</string>
     <string name="settings_umount_modules_default">默认卸载模块</string>
     <string name="settings_umount_modules_default_summary">App Profile 中「卸载模块」的全局默认值，如果启用，会将未自定义 Profile 的应用移除所有模块针对系统的修改</string>

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">未安装</string>
     <string name="home_click_to_install">点击安装</string>
     <string name="home_working">工作中</string>
-    <string name="home_working_version">版本：%d</string>
+    <string name="home_working_version">版本：%s</string>
     <string name="home_unsupported">不支持</string>
     <string name="home_unsupported_reason">KernelSU 现在只支持 GKI 内核，但是你可以为 GKI 设备补丁镜像。</string>
     <string name="home_version_mismatch">管理器版本 (%1$d) 与 KernelSU 驱动版本 (%2$d) 不匹配。</string>

--- a/manager/app/src/main/res/values-zh-rHK/strings.xml
+++ b/manager/app/src/main/res/values-zh-rHK/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">未安裝</string>
     <string name="home_click_to_install">按一下開始安裝</string>
     <string name="home_working">運作中</string>
-    <string name="home_working_version">KernelSU 版本：%d</string>
+    <string name="home_working_version">KernelSU 版本：%s</string>
     <string name="home_unsupported">不支援</string>
     <string name="home_unsupported_reason">KernelSU 現僅支援 GKI 核心，但仍可修補 GKI 裝置映像。</string>
     <string name="home_device_model">裝置型號</string>

--- a/manager/app/src/main/res/values-zh-rTW/strings.xml
+++ b/manager/app/src/main/res/values-zh-rTW/strings.xml
@@ -4,7 +4,7 @@
     <string name="home_not_installed">尚未安裝</string>
     <string name="home_click_to_install">點選開始安裝</string>
     <string name="home_working">已開始運作</string>
-    <string name="home_working_version">版本：%d</string>
+    <string name="home_working_version">版本：%s</string>
     <string name="home_unsupported">未受支援</string>
     <string name="home_unsupported_reason">KernelSU 目前僅支援 GKI 核心</string>
     <string name="home_device_model">裝置型號</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="home_not_installed">Not installed</string>
     <string name="home_click_to_install">Tap to install</string>
     <string name="home_working">Working</string>
-    <string name="home_working_version">Version: %d</string>
+    <string name="home_working_version">Version: %s</string>
     <string name="home_unsupported">Unsupported</string>
     <string name="home_unsupported_reason">KernelSU only supports GKI kernels now, but you can patch the image for GKI devices.</string>
     <string name="home_version_mismatch">Manager version (%1$d) and KernelSU driver version (%2$d) mismatch.</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="profile_selinux_context">SELinux context</string>
     <string name="profile_umount_modules">Umount modules</string>
     <string name="failed_to_update_app_profile">Failed to update App Profile for %s</string>
+    <string name="uapi_mismatch">Manager uapi version (%1$d) and KernelSU driver uapi version (%2$d) mismatch.</string>
+    <string name="require_manager_version">The current KernelSU manager version %1$d is too low for KernelSU to work properly. Please upgrade manager to version %2$d or higher!</string>
     <string name="require_kernel_version">The current KernelSU version %1$d is too low for the manager to work properly. Please upgrade to version %2$d or higher!</string>
     <string name="settings_umount_modules_default">Umount modules by default</string>
     <string name="settings_umount_modules_default_summary">The global default value for \"Umount modules\" in App Profile. If enabled, it will remove all module modifications to the system for apps that don\'t have a profile set.</string>

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -6,6 +6,10 @@
 
 #include "uapi/app_profile.h"
 
+// use __u16 to avoid we maybe have version more than 255
+// yep, it's possible it will never be exceeded, just to prevent the possibility
+static const __u16 KERNEL_SU_UAPI_VERSION = 1;
+
 /* Magic numbers for reboot hook to install fd */
 static const __u32 KSU_INSTALL_MAGIC1 = 0xDEADBEEF;
 static const __u32 KSU_INSTALL_MAGIC2 = 0xCAFEBABE;
@@ -18,14 +22,15 @@ static const __u32 EVENT_POST_FS_DATA = 1;
 static const __u32 EVENT_BOOT_COMPLETED = 2;
 static const __u32 EVENT_MODULE_MOUNTED = 3;
 
-static const __u32 KSU_GET_INFO_FLAG_LKM = (1U << 0);
-static const __u32 KSU_GET_INFO_FLAG_MANAGER = (1U << 1);
-static const __u32 KSU_GET_INFO_FLAG_LATE_LOAD = (1U << 2);
-static const __u32 KSU_GET_INFO_FLAG_PR_BUILD = (1U << 3);
+static const __u16 KSU_GET_INFO_FLAG_LKM = (1U << 0);
+static const __u16 KSU_GET_INFO_FLAG_MANAGER = (1U << 1);
+static const __u16 KSU_GET_INFO_FLAG_LATE_LOAD = (1U << 2);
+static const __u16 KSU_GET_INFO_FLAG_PR_BUILD = (1U << 3);
 
 struct ksu_get_info_cmd {
     __u32 version; /* Output: KERNEL_SU_VERSION */
-    __u32 flags; /* Output: KSU_GET_INFO_FLAG_* bits */
+    __u16 flags; /* Output: KSU_GET_INFO_FLAG_* bits */
+    __u16 uapi_version; /* Output: KERNEL_SU_UAPI_VERSION */
     __u32 features; /* Output: max feature ID supported */
 };
 

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -6,8 +6,6 @@
 
 #include "uapi/app_profile.h"
 
-// use __u16 to avoid we maybe have version more than 255
-// yep, it's possible it will never be exceeded, just to prevent the possibility
 static const __u32 KERNEL_SU_UAPI_VERSION = 1;
 
 /* Magic numbers for reboot hook to install fd */

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -8,7 +8,7 @@
 
 // use __u16 to avoid we maybe have version more than 255
 // yep, it's possible it will never be exceeded, just to prevent the possibility
-static const __u16 KERNEL_SU_UAPI_VERSION = 1;
+static const __u32 KERNEL_SU_UAPI_VERSION = 1;
 
 /* Magic numbers for reboot hook to install fd */
 static const __u32 KSU_INSTALL_MAGIC1 = 0xDEADBEEF;
@@ -22,15 +22,21 @@ static const __u32 EVENT_POST_FS_DATA = 1;
 static const __u32 EVENT_BOOT_COMPLETED = 2;
 static const __u32 EVENT_MODULE_MOUNTED = 3;
 
-static const __u16 KSU_GET_INFO_FLAG_LKM = (1U << 0);
-static const __u16 KSU_GET_INFO_FLAG_MANAGER = (1U << 1);
-static const __u16 KSU_GET_INFO_FLAG_LATE_LOAD = (1U << 2);
-static const __u16 KSU_GET_INFO_FLAG_PR_BUILD = (1U << 3);
+static const __u32 KSU_GET_INFO_FLAG_LKM = (1U << 0);
+static const __u32 KSU_GET_INFO_FLAG_MANAGER = (1U << 1);
+static const __u32 KSU_GET_INFO_FLAG_LATE_LOAD = (1U << 2);
+static const __u32 KSU_GET_INFO_FLAG_PR_BUILD = (1U << 3);
 
 struct ksu_get_info_cmd {
     __u32 version; /* Output: KERNEL_SU_VERSION */
-    __u16 flags; /* Output: KSU_GET_INFO_FLAG_* bits */
-    __u16 uapi_version; /* Output: KERNEL_SU_UAPI_VERSION */
+    __u32 flags; /* Output: KSU_GET_INFO_FLAG_* bits */
+    __u32 features; /* Output: max feature ID supported */
+    __u32 uapi_version; /* Output: KERNEL_SU_UAPI_VERSION */
+};
+
+struct ksu_get_info_legacy_cmd {
+    __u32 version; /* Output: KERNEL_SU_VERSION */
+    __u32 flags; /* Output: KSU_GET_INFO_FLAG_* bits */
     __u32 features; /* Output: max feature ID supported */
 };
 
@@ -145,7 +151,9 @@ static const __u8 KSU_UMOUNT_DEL = 2; /* delete entry, strcmp */
 
 /* IOCTL command definitions */
 static const __u32 KSU_IOCTL_GRANT_ROOT = _IOC(_IOC_NONE, 'K', 1, 0);
-static const __u32 KSU_IOCTL_GET_INFO = _IOC(_IOC_READ, 'K', 2, 0);
+static const __u32 KSU_IOCTL_GET_INFO = _IOR('K', 2, struct ksu_get_info_cmd);
+/* deprecated */
+static const __u32 KSU_IOCTL_GET_INFO_LEGACY = _IOC(_IOC_READ, 'K', 2, 0);
 static const __u32 KSU_IOCTL_REPORT_EVENT = _IOC(_IOC_WRITE, 'K', 3, 0);
 static const __u32 KSU_IOCTL_SET_SEPOLICY = _IOC(_IOC_READ | _IOC_WRITE, 'K', 4, 0);
 static const __u32 KSU_IOCTL_CHECK_SAFEMODE = _IOC(_IOC_READ, 'K', 5, 0);

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -8,7 +8,8 @@ use log::{LevelFilter, error, info};
 use crate::boot_patch::{BootPatchArgs, BootRestoreArgs};
 use crate::module::regenerate_preinit_rc;
 use crate::{
-    apk_sign, assets, debug, defs, init_event, ksu_uapi, ksucalls, module, module_config, sulog, utils
+    apk_sign, assets, debug, defs, init_event, ksu_uapi, ksucalls, module, module_config, sulog,
+    utils,
 };
 
 /// KernelSU userspace cli

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -8,7 +8,7 @@ use log::{LevelFilter, error, info};
 use crate::boot_patch::{BootPatchArgs, BootRestoreArgs};
 use crate::module::regenerate_preinit_rc;
 use crate::{
-    apk_sign, assets, debug, defs, init_event, ksucalls, module, module_config, sulog, utils,
+    apk_sign, assets, debug, defs, init_event, ksu_uapi, ksucalls, module, module_config, sulog, utils
 };
 
 /// KernelSU userspace cli
@@ -214,6 +214,9 @@ enum Debug {
 
     /// Launch sulogd daemon manually
     Sulogd,
+
+    /// Get kernel info
+    Info,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -700,6 +703,26 @@ pub fn run() -> Result<()> {
                 MarkCommand::Refresh => debug::mark_refresh(),
             },
             Debug::Sulogd => sulog::ensure_sulogd_running(),
+            Debug::Info => {
+                let info = ksucalls::get_info();
+                println!("version: {}", info.version);
+                println!("flags: 0x{:x}", info.flags);
+                println!("uapi_version: {}", info.uapi_version);
+                println!("features: 0x{:x}", info.features);
+                println!(
+                    "lkm: {}",
+                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_LKM) != 0
+                );
+                println!(
+                    "late_load: {}",
+                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_LATE_LOAD) != 0
+                );
+                println!(
+                    "pr_build: {}",
+                    (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_PR_BUILD) != 0
+                );
+                Ok(())
+            }
         },
 
         Commands::BootPatch(boot_patch) => crate::boot_patch::patch(boot_patch),

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use libc::_exit;
-use log::{info, warn};
+use log::{error, info, warn};
 use prop_rs_android::resetprop::ResetProp;
 use prop_rs_android::sys_prop;
 use rustix::process::chdir;
@@ -14,6 +14,11 @@ use std::path::Path;
 use std::process::Command;
 
 pub fn on_post_data_fs() -> Result<()> {
+    if ksucalls::is_uapi_version_mismatch() {
+        error!("Kernel and userspace uapi version mismatch! skip on_post_fs_data");
+        return Ok(());
+    }
+
     ksucalls::report_post_fs_data();
 
     utils::umask(0);
@@ -151,11 +156,21 @@ pub fn run_stage(stage: &str, block: bool) {
 }
 
 pub fn on_services() {
+    if ksucalls::is_uapi_version_mismatch() {
+        error!("Kernel and userspace uapi version mismatch! skip on_services");
+        return;
+    }
+
     info!("on_services triggered!");
     run_stage("service", false);
 }
 
 pub fn on_boot_completed() {
+    if ksucalls::is_uapi_version_mismatch() {
+        error!("Kernel and userspace uapi version mismatch! skip on_boot_completed");
+        return;
+    }
+
     ksucalls::report_boot_complete();
     info!("on_boot_completed triggered!");
 
@@ -230,6 +245,12 @@ fn catch_bootlog(logname: &str, command: &[&str]) -> Result<()> {
 }
 
 pub fn soft_reboot() -> Result<()> {
+    // check it avoid user click "soft_reboot" in manager when version mismatch
+    if ksucalls::is_uapi_version_mismatch() {
+        error!("Kernel and userspace uapi version mismatch! skip soft_reboot");
+        return Ok(());
+    }
+
     utils::daemonize_with(true, || -> Result<()> {
         switch_mnt_ns(1)?;
         chdir("/")?;

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -62,7 +62,7 @@ fn ksuctl<T>(request: u32, arg: *mut T) -> std::io::Result<i32> {
 }
 
 // API implementations
-fn get_info() -> ksu_uapi::ksu_get_info_cmd {
+pub fn get_info() -> ksu_uapi::ksu_get_info_cmd {
     *INFO_CACHE.get_or_init(|| {
         let mut cmd = ksu_uapi::ksu_get_info_cmd {
             version: 0,
@@ -70,7 +70,9 @@ fn get_info() -> ksu_uapi::ksu_get_info_cmd {
             features: 0,
             uapi_version: 0,
         };
-        let _ = ksuctl(ksu_uapi::KSU_IOCTL_GET_INFO, &raw mut cmd);
+        if ksuctl(ksu_uapi::KSU_IOCTL_GET_INFO, &raw mut cmd).is_err() {
+            let _ = ksuctl(ksu_uapi::KSU_IOCTL_GET_INFO_LEGACY, &raw mut cmd);
+        }
         cmd
     })
 }

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -68,6 +68,7 @@ fn get_info() -> ksu_uapi::ksu_get_info_cmd {
             version: 0,
             flags: 0,
             features: 0,
+            uapi_version: 0,
         };
         let _ = ksuctl(ksu_uapi::KSU_IOCTL_GET_INFO, &raw mut cmd);
         cmd
@@ -80,6 +81,10 @@ pub fn get_version() -> i32 {
 
 pub fn is_late_load() -> bool {
     get_info().flags & ksu_uapi::KSU_GET_INFO_FLAG_LATE_LOAD != 0
+}
+
+pub fn is_uapi_version_mismatch() -> bool {
+    get_info().uapi_version != ksu_uapi::KERNEL_SU_UAPI_VERSION
 }
 
 pub fn grant_root() -> std::io::Result<()> {

--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -158,6 +158,7 @@ fn has_kernelsu_v2() -> bool {
         version: u32,
         flags: u32,
         features: u32,
+        uapi_version: u32,
     }
 
     // Try new method: get driver fd using reboot syscall with magic numbers

--- a/userspace/ksuinit/src/lib.rs
+++ b/userspace/ksuinit/src/lib.rs
@@ -150,7 +150,8 @@ fn has_kernelsu_v2() -> bool {
     use syscalls::{Sysno, syscall};
     const KSU_INSTALL_MAGIC1: u32 = 0xDEADBEEF;
     const KSU_INSTALL_MAGIC2: u32 = 0xCAFEBABE;
-    const KSU_IOCTL_GET_INFO: u32 = 0x80004b02; // _IOC(_IOC_READ, 'K', 2, 0)
+    const KSU_IOCTL_GET_INFO: u32 = 0x80104b02; // _IOR('K', 2, struct ksu_get_info_cmd)
+    const KSU_IOCTL_GET_INFO_LEGACY: u32 = 0x80004b02; // _IOC(_IOC_READ, 'K', 2, 0)
 
     #[repr(C)]
     #[derive(Default)]
@@ -159,6 +160,14 @@ fn has_kernelsu_v2() -> bool {
         flags: u32,
         features: u32,
         uapi_version: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct GetInfoLegacyCmd {
+        version: u32,
+        flags: u32,
+        features: u32,
     }
 
     // Try new method: get driver fd using reboot syscall with magic numbers
@@ -181,7 +190,18 @@ fn has_kernelsu_v2() -> bool {
 
             match ret {
                 Ok(_) => cmd.version,
-                Err(_) => 0,
+                Err(_) => {
+                    let mut cmd = GetInfoLegacyCmd::default();
+                    match syscall!(
+                        Sysno::ioctl,
+                        fd,
+                        KSU_IOCTL_GET_INFO_LEGACY,
+                        &mut cmd as *mut _
+                    ) {
+                        Ok(_) => cmd.version,
+                        Err(_) => 0,
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
We always have an problem:
We should keep forward compatibility in uapi, or users may face problem

e.g:
new sepolicy api (https://github.com/tiann/KernelSU/commit/b98c05eb129ec923dafef2c219b5a38c0f0ecb20)
new allowlist api (https://github.com/tiann/KernelSU/commit/9f68f239f62c242964311aeec3080ced9cda4d29)

They all resulted in varying degrees of functional impairment and severely impacted the user experience.

For example
new sepolicy api cause some modules looks "working", but actually not, them sepolicy.rule haven't be loaded.
new allowlist api cause manager show "0 SuperUsers"

That's cause by userspace version mismatch with kernel version

This pull request implement an uapi check, when userspace see uapi version mismatch with kernel's uapi version
ksud will stop handle post_fs_data, services, boot_completed and more
manager will show "incompatible kernel" warning card

This gives users a clear indication: they messed up,
either using an older version of the manager with the new kernel
or trying to make the new manager work with an older kernel.

To prevent users from sending invalid bug reports to the module developer/us due to their own issues.