### PR TITLE
ci: disable cache-bin in ksud-extra to fix macOS build

### DIFF
--- a/.github/workflows/ksud-extra.yml
+++ b/.github/workflows/ksud-extra.yml
@@ -48,6 +48,7 @@ jobs:
       with:
         workspaces: userspace/ksud
         cache-targets: false
+        cache-bin: false
 
     - name: Install cross
       run: |


### PR DESCRIPTION
On macOS runners, rust-cache restores ~/.cargo/bin which overwrites rustup's cargo proxy shim with a cached rustup-init binary, causing "unexpected argument 'install' found" when running cargo install.

Setting cache-bin: false prevents rust-cache from saving/restoring ~/.cargo/bin. This is the documented workaround from rust-cache: https://github.com/Swatinem/rust-cache#known-issues