### PR TITLE
kernel,ksud: support module-provided init.rc injection

### DIFF
--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -80,6 +80,9 @@ bool allow_shell = false;
 #endif
 module_param(allow_shell, bool, 0);
 
+bool ksu_no_custom_rc = false;
+module_param_named(norc, ksu_no_custom_rc, bool, 0);
+
 int __init kernelsu_init(void)
 {
 #if defined(__x86_64__)

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -11,6 +11,7 @@ extern struct cred *ksu_cred;
 extern bool ksu_late_loaded;
 extern bool allow_shell;
 extern struct selinux_policy *backup_sepolicy;
+extern bool ksu_no_custom_rc;
 
 static inline int startswith(char *s, char *prefix)
 {

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -1,6 +1,7 @@
 #include "feature/selinux_hide.h"
 #include <linux/rcupdate.h>
 #include <linux/slab.h>
+#include <linux/mm.h>
 #include <asm/current.h>
 #include <linux/compat.h>
 #include <linux/cred.h>
@@ -17,6 +18,7 @@
 #include <linux/namei.h>
 #include <linux/workqueue.h>
 #include <linux/uio.h>
+#include <linux/stat.h>
 
 #include "arch.h"
 #include "klog.h" // IWYU pragma: keep
@@ -183,6 +185,69 @@ static struct file_operations fops_proxy;
 static ssize_t ksu_rc_pos = 0;
 const size_t ksu_rc_len = sizeof(KERNEL_SU_RC) - 1;
 
+// Dynamic rc content from /metadata/watchdog/ksu/modules.rc, populated lazily at
+// the first read/fstat of /system/etc/init/hw/init.rc.
+#define MODULE_RC_PATH "/metadata/watchdog/ksu/modules.rc"
+#define MODULE_RC_MAX (1u << 20) /* 1 MiB safety cap */
+static char *module_rc_buf;
+static size_t module_rc_len;
+static ssize_t module_rc_pos;
+
+static void load_module_rc_once(void)
+{
+    static bool loaded = false;
+    struct file *f;
+    loff_t pos = 0;
+    ssize_t r;
+    size_t fsize;
+
+    if (loaded)
+        return;
+    loaded = true;
+
+    f = filp_open(MODULE_RC_PATH, O_RDONLY, 0);
+    if (IS_ERR(f)) {
+        pr_info("module rc: open %s failed: %ld\n", MODULE_RC_PATH, PTR_ERR(f));
+        return;
+    }
+
+    if (!S_ISREG(file_inode(f)->i_mode)) {
+        pr_warn("module rc: %s is not a regular file\n", MODULE_RC_PATH);
+        filp_close(f, NULL);
+        return;
+    }
+
+    fsize = i_size_read(file_inode(f));
+    if (fsize == 0) {
+        filp_close(f, NULL);
+        return;
+    }
+    if (fsize > MODULE_RC_MAX) {
+        pr_warn("module rc: %s too large (%zu), truncating to %u\n", MODULE_RC_PATH, fsize, MODULE_RC_MAX);
+        fsize = MODULE_RC_MAX;
+    }
+
+    module_rc_buf = kvmalloc(fsize, GFP_KERNEL);
+    if (!module_rc_buf) {
+        pr_err("module rc: alloc %zu failed\n", fsize);
+        filp_close(f, NULL);
+        return;
+    }
+
+    r = kernel_read(f, module_rc_buf, fsize, &pos);
+    filp_close(f, NULL);
+
+    if (r <= 0) {
+        pr_err("module rc: read failed: %zd\n", r);
+        kvfree(module_rc_buf);
+        module_rc_buf = NULL;
+        return;
+    }
+
+    module_rc_len = r;
+    pr_info("module rc: loaded %zu bytes from %s\n", module_rc_len, MODULE_RC_PATH);
+}
+
 // https://cs.android.com/android/platform/superproject/main/+/main:system/core/init/parser.cpp;l=144;drc=61197364367c9e404c7da6900658f1b16c42d0da
 // https://cs.android.com/android/platform/superproject/main/+/main:system/libbase/file.cpp;l=241-243;drc=61197364367c9e404c7da6900658f1b16c42d0da
 // The system will read init.rc file until EOF, whenever read() returns 0,
@@ -194,28 +259,49 @@ static ssize_t read_proxy(struct file *file, char __user *buf, size_t count, lof
     size_t append_count;
     if (ksu_rc_pos && ksu_rc_pos < ksu_rc_len)
         goto append_ksu_rc;
+    if (ksu_rc_pos >= ksu_rc_len && module_rc_pos < module_rc_len)
+        goto append_module_rc;
 
     ret = orig_read(file, buf, count, pos);
-    if (ret != 0 || ksu_rc_pos >= ksu_rc_len) {
+    if (ret != 0) {
         return ret;
-    } else {
-        pr_info("read_proxy: orig read finished, start append rc\n");
     }
-append_ksu_rc:
-    append_count = ksu_rc_len - ksu_rc_pos;
-    if (append_count > count - ret)
-        append_count = count - ret;
-    // copy_to_user returns the number of not copied
-    if (copy_to_user(buf + ret, KERNEL_SU_RC + ksu_rc_pos, append_count)) {
-        pr_info("read_proxy: append error, totally appended %ld\n", ksu_rc_pos);
-    } else {
-        pr_info("read_proxy: append %ld\n", append_count);
+    if (ksu_rc_pos >= ksu_rc_len && module_rc_pos >= module_rc_len) {
+        return ret;
+    }
+    pr_info("read_proxy: orig read finished, start append rc\n");
 
-        ksu_rc_pos += append_count;
-        if (ksu_rc_pos == ksu_rc_len) {
-            pr_info("read_proxy: append done\n");
+append_ksu_rc:
+    if (ksu_rc_pos < ksu_rc_len) {
+        append_count = ksu_rc_len - ksu_rc_pos;
+        if (append_count > count - ret)
+            append_count = count - ret;
+        // copy_to_user returns the number of bytes that could not be copied
+        if (copy_to_user(buf + ret, KERNEL_SU_RC + ksu_rc_pos, append_count)) {
+            pr_info("read_proxy: append error, totally appended %ld\n", ksu_rc_pos);
+            return ret;
         }
+        pr_info("read_proxy: append static %zu\n", append_count);
+        ksu_rc_pos += append_count;
         ret += append_count;
+        if (ksu_rc_pos == ksu_rc_len)
+            pr_info("read_proxy: static append done\n");
+    }
+
+append_module_rc:
+    if (module_rc_pos < module_rc_len && (size_t)ret < count) {
+        append_count = module_rc_len - module_rc_pos;
+        if (append_count > count - ret)
+            append_count = count - ret;
+        if (copy_to_user(buf + ret, module_rc_buf + module_rc_pos, append_count)) {
+            pr_info("read_proxy: module append error, totally appended %zd\n", module_rc_pos);
+            return ret;
+        }
+        pr_info("read_proxy: append module %zu\n", append_count);
+        module_rc_pos += append_count;
+        ret += append_count;
+        if (module_rc_pos == (ssize_t)module_rc_len)
+            pr_info("read_proxy: module append done\n");
     }
 
     return ret;
@@ -227,26 +313,45 @@ static ssize_t read_iter_proxy(struct kiocb *iocb, struct iov_iter *to)
     size_t append_count;
     if (ksu_rc_pos && ksu_rc_pos < ksu_rc_len)
         goto append_ksu_rc;
+    if (ksu_rc_pos >= ksu_rc_len && module_rc_pos < module_rc_len)
+        goto append_module_rc;
 
     ret = orig_read_iter(iocb, to);
-    if (ret != 0 || ksu_rc_pos >= ksu_rc_len) {
+    if (ret != 0) {
         return ret;
-    } else {
-        pr_info("read_iter_proxy: orig read finished, start append rc\n");
     }
-append_ksu_rc:
-    // copy_to_iter returns the number of copied bytes
-    append_count = copy_to_iter(KERNEL_SU_RC + ksu_rc_pos, ksu_rc_len - ksu_rc_pos, to);
-    if (!append_count) {
-        pr_info("read_iter_proxy: append error, totally appended %ld\n", ksu_rc_pos);
-    } else {
-        pr_info("read_iter_proxy: append %ld\n", append_count);
+    if (ksu_rc_pos >= ksu_rc_len && module_rc_pos >= module_rc_len) {
+        return ret;
+    }
+    pr_info("read_iter_proxy: orig read finished, start append rc\n");
 
-        ksu_rc_pos += append_count;
-        if (ksu_rc_pos == ksu_rc_len) {
-            pr_info("read_iter_proxy: append done\n");
+append_ksu_rc:
+    if (ksu_rc_pos < ksu_rc_len) {
+        // copy_to_iter returns the number of bytes successfully copied
+        append_count = copy_to_iter(KERNEL_SU_RC + ksu_rc_pos, ksu_rc_len - ksu_rc_pos, to);
+        if (!append_count) {
+            pr_info("read_iter_proxy: append error, totally appended %ld\n", ksu_rc_pos);
+            return ret;
         }
+        pr_info("read_iter_proxy: append static %zu\n", append_count);
+        ksu_rc_pos += append_count;
         ret += append_count;
+        if (ksu_rc_pos == ksu_rc_len)
+            pr_info("read_iter_proxy: static append done\n");
+    }
+
+append_module_rc:
+    if (module_rc_pos < module_rc_len) {
+        append_count = copy_to_iter(module_rc_buf + module_rc_pos, module_rc_len - module_rc_pos, to);
+        if (!append_count) {
+            pr_info("read_iter_proxy: module append error, appended %zd\n", module_rc_pos);
+            return ret;
+        }
+        pr_info("read_iter_proxy: append module %zu\n", append_count);
+        module_rc_pos += append_count;
+        ret += append_count;
+        if (module_rc_pos == (ssize_t)module_rc_len)
+            pr_info("read_iter_proxy: module append done\n");
     }
     return ret;
 }
@@ -300,7 +405,9 @@ static void ksu_install_rc_hook(struct file *file)
     // now we can sure that the init process is reading
     // `/system/etc/init/init.rc`
 
-    pr_info("read init.rc, comm: %s, rc_count: %zu\n", current->comm, ksu_rc_len);
+    load_module_rc_once();
+
+    pr_info("read init.rc, comm: %s, rc_count: %zu, module_rc: %zu\n", current->comm, ksu_rc_len, module_rc_len);
 
     // Now we need to proxy the read and modify the result!
     // But, we can not modify the file_operations directly, because it's in read-only memory.
@@ -428,6 +535,7 @@ static long ksu_sys_fstat(const struct pt_regs *regs)
         if (is_init_rc(file)) {
             pr_info("stat init.rc");
             is_rc = true;
+            load_module_rc_once();
         }
         fput(file);
     }
@@ -437,13 +545,14 @@ static long ksu_sys_fstat(const struct pt_regs *regs)
     if (is_rc) {
         void __user *st_size_ptr = statbuf + offsetof(struct stat, st_size);
         long size, new_size;
+        size_t extra = ksu_rc_len + module_rc_len;
         if (!copy_from_user_nofault(&size, st_size_ptr, sizeof(long))) {
-            new_size = size + ksu_rc_len;
-            pr_info("adding ksu_rc_len: %ld -> %ld", size, new_size);
+            new_size = size + extra;
+            pr_info("adding rc len: %ld -> %ld (static=%zu module=%zu)", size, new_size, ksu_rc_len, module_rc_len);
             if (!copy_to_user_nofault(st_size_ptr, &new_size, sizeof(long))) {
-                pr_info("added ksu_rc_len");
+                pr_info("added rc len");
             } else {
-                pr_err("add ksu_rc_len failed: statbuf 0x%lx", (unsigned long)st_size_ptr);
+                pr_err("add rc len failed: statbuf 0x%lx", (unsigned long)st_size_ptr);
             }
         } else {
             pr_err("read statbuf 0x%lx failed", (unsigned long)st_size_ptr);
@@ -509,4 +618,10 @@ void __exit ksu_ksud_exit()
     // this should be done before unregister vfs_read_kp
     // stop_init_rc_hook();
     unregister_kprobe(&input_event_kp);
+
+    if (module_rc_buf) {
+        kvfree(module_rc_buf);
+        module_rc_buf = NULL;
+        module_rc_len = 0;
+    }
 }

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -188,7 +188,6 @@ const size_t ksu_rc_len = sizeof(KERNEL_SU_RC) - 1;
 // Prefer /metadata/watchdog/ when present, else /metadata.
 #define MODULE_RC_PATH_WATCHDOG "/metadata/watchdog/ksu/modules.rc"
 #define MODULE_RC_PATH_DEFAULT "/metadata/ksu/modules.rc"
-#define MODULE_RC_MAX (1u << 20) /* 1 MiB cap */
 static char *module_rc_buf;
 static size_t module_rc_len;
 static ssize_t module_rc_pos;
@@ -240,11 +239,6 @@ static void load_module_rc_once(void)
     if (fsize == 0) {
         pr_warn("module rc: skip empty module rc\n");
         goto out_close_file;
-    }
-
-    if (fsize > MODULE_RC_MAX) {
-        pr_warn("module rc: %s too large (%zu), truncating to %u\n", path, fsize, MODULE_RC_MAX);
-        fsize = MODULE_RC_MAX;
     }
 
     module_rc_buf = kvmalloc(fsize, GFP_KERNEL);

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -223,7 +223,7 @@ static void load_module_rc_once(void)
         return;
     loaded = true;
 
-    old_cred = override_creds(ksu_cred);
+    old_cred = ksu_cred ? override_creds(ksu_cred) : NULL;
 
     f = open_module_rc(&path);
     if (IS_ERR(f)) {
@@ -269,7 +269,8 @@ out_close_file:
     filp_close(f, NULL);
 
 out_revert_creds:
-    revert_creds(old_cred);
+    if (old_cred)
+        revert_creds(old_cred);
 }
 
 static void free_module_rc(void)

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -185,18 +185,35 @@ static struct file_operations fops_proxy;
 static ssize_t ksu_rc_pos = 0;
 const size_t ksu_rc_len = sizeof(KERNEL_SU_RC) - 1;
 
-// Dynamic rc content from /metadata/watchdog/ksu/modules.rc, populated lazily at
-// the first read/fstat of /system/etc/init/hw/init.rc.
-#define MODULE_RC_PATH "/metadata/watchdog/ksu/modules.rc"
-#define MODULE_RC_MAX (1u << 20) /* 1 MiB safety cap */
+// Prefer /metadata/watchdog/ when present, else /metadata.
+#define MODULE_RC_PATH_WATCHDOG "/metadata/watchdog/ksu/modules.rc"
+#define MODULE_RC_PATH_DEFAULT "/metadata/ksu/modules.rc"
+#define MODULE_RC_MAX (1u << 20) /* 1 MiB cap */
 static char *module_rc_buf;
 static size_t module_rc_len;
 static ssize_t module_rc_pos;
+
+static struct file *open_module_rc(const char **chosen_path)
+{
+    struct file *f = filp_open(MODULE_RC_PATH_WATCHDOG, O_RDONLY, 0);
+    if (!IS_ERR(f)) {
+        *chosen_path = MODULE_RC_PATH_WATCHDOG;
+        return f;
+    }
+    f = filp_open(MODULE_RC_PATH_DEFAULT, O_RDONLY, 0);
+    if (!IS_ERR(f)) {
+        *chosen_path = MODULE_RC_PATH_DEFAULT;
+        return f;
+    }
+    *chosen_path = MODULE_RC_PATH_DEFAULT;
+    return f;
+}
 
 static void load_module_rc_once(void)
 {
     static bool loaded = false;
     struct file *f;
+    const char *path = NULL;
     loff_t pos = 0;
     ssize_t r;
     size_t fsize;
@@ -205,14 +222,14 @@ static void load_module_rc_once(void)
         return;
     loaded = true;
 
-    f = filp_open(MODULE_RC_PATH, O_RDONLY, 0);
+    f = open_module_rc(&path);
     if (IS_ERR(f)) {
-        pr_info("module rc: open %s failed: %ld\n", MODULE_RC_PATH, PTR_ERR(f));
+        pr_info("module rc: open failed: %ld\n", PTR_ERR(f));
         return;
     }
 
     if (!S_ISREG(file_inode(f)->i_mode)) {
-        pr_warn("module rc: %s is not a regular file\n", MODULE_RC_PATH);
+        pr_warn("module rc: %s is not a regular file\n", path);
         filp_close(f, NULL);
         return;
     }
@@ -223,7 +240,7 @@ static void load_module_rc_once(void)
         return;
     }
     if (fsize > MODULE_RC_MAX) {
-        pr_warn("module rc: %s too large (%zu), truncating to %u\n", MODULE_RC_PATH, fsize, MODULE_RC_MAX);
+        pr_warn("module rc: %s too large (%zu), truncating to %u\n", path, fsize, MODULE_RC_MAX);
         fsize = MODULE_RC_MAX;
     }
 
@@ -245,7 +262,7 @@ static void load_module_rc_once(void)
     }
 
     module_rc_len = r;
-    pr_info("module rc: loaded %zu bytes from %s\n", module_rc_len, MODULE_RC_PATH);
+    pr_info("module rc: loaded %zu bytes from %s\n", module_rc_len, path);
 }
 
 // https://cs.android.com/android/platform/superproject/main/+/main:system/core/init/parser.cpp;l=144;drc=61197364367c9e404c7da6900658f1b16c42d0da

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -217,28 +217,31 @@ static void load_module_rc_once(void)
     loff_t pos = 0;
     ssize_t r;
     size_t fsize;
+    const struct cred *old_cred;
 
     if (loaded)
         return;
     loaded = true;
 
+    old_cred = override_creds(ksu_cred);
+
     f = open_module_rc(&path);
     if (IS_ERR(f)) {
-        pr_info("module rc: open failed: %ld\n", PTR_ERR(f));
-        return;
+        pr_info("module rc: open %s failed: %ld\n", path, PTR_ERR(f));
+        goto out_revert_creds;
     }
 
     if (!S_ISREG(file_inode(f)->i_mode)) {
         pr_warn("module rc: %s is not a regular file\n", path);
-        filp_close(f, NULL);
-        return;
+        goto out_close_file;
     }
 
     fsize = i_size_read(file_inode(f));
     if (fsize == 0) {
-        filp_close(f, NULL);
-        return;
+        pr_warn("module rc: skip empty module rc\n");
+        goto out_close_file;
     }
+
     if (fsize > MODULE_RC_MAX) {
         pr_warn("module rc: %s too large (%zu), truncating to %u\n", path, fsize, MODULE_RC_MAX);
         fsize = MODULE_RC_MAX;
@@ -247,22 +250,33 @@ static void load_module_rc_once(void)
     module_rc_buf = kvmalloc(fsize, GFP_KERNEL);
     if (!module_rc_buf) {
         pr_err("module rc: alloc %zu failed\n", fsize);
-        filp_close(f, NULL);
-        return;
+        goto out_close_file;
     }
 
     r = kernel_read(f, module_rc_buf, fsize, &pos);
-    filp_close(f, NULL);
 
     if (r <= 0) {
         pr_err("module rc: read failed: %zd\n", r);
         kvfree(module_rc_buf);
         module_rc_buf = NULL;
-        return;
+        goto out_close_file;
     }
 
     module_rc_len = r;
     pr_info("module rc: loaded %zu bytes from %s\n", module_rc_len, path);
+
+out_close_file:
+    filp_close(f, NULL);
+
+out_revert_creds:
+    revert_creds(old_cred);
+}
+
+static void free_module_rc(void)
+{
+    kvfree(module_rc_buf);
+    module_rc_buf = NULL;
+    module_rc_len = 0;
 }
 
 // https://cs.android.com/android/platform/superproject/main/+/main:system/core/init/parser.cpp;l=144;drc=61197364367c9e404c7da6900658f1b16c42d0da
@@ -317,8 +331,10 @@ append_module_rc:
         pr_info("read_proxy: append module %zu\n", append_count);
         module_rc_pos += append_count;
         ret += append_count;
-        if (module_rc_pos == (ssize_t)module_rc_len)
+        if (module_rc_pos == (ssize_t)module_rc_len) {
             pr_info("read_proxy: module append done\n");
+            free_module_rc();
+        }
     }
 
     return ret;
@@ -353,8 +369,10 @@ append_ksu_rc:
         pr_info("read_iter_proxy: append static %zu\n", append_count);
         ksu_rc_pos += append_count;
         ret += append_count;
-        if (ksu_rc_pos == ksu_rc_len)
+        if (ksu_rc_pos == ksu_rc_len) {
             pr_info("read_iter_proxy: static append done\n");
+            free_module_rc();
+        }
     }
 
 append_module_rc:
@@ -637,8 +655,6 @@ void __exit ksu_ksud_exit()
     unregister_kprobe(&input_event_kp);
 
     if (module_rc_buf) {
-        kvfree(module_rc_buf);
-        module_rc_buf = NULL;
-        module_rc_len = 0;
+        free_module_rc();
     }
 }

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -221,6 +221,10 @@ static void load_module_rc_once(void)
     if (loaded)
         return;
     loaded = true;
+    if (ksu_no_custom_rc) {
+        pr_info("custom rc is disabled\n");
+        return;
+    }
 
     old_cred = ksu_cred ? override_creds(ksu_cred) : NULL;
 

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -371,7 +371,6 @@ append_ksu_rc:
         ret += append_count;
         if (ksu_rc_pos == ksu_rc_len) {
             pr_info("read_iter_proxy: static append done\n");
-            free_module_rc();
         }
     }
 
@@ -385,8 +384,10 @@ append_module_rc:
         pr_info("read_iter_proxy: append module %zu\n", append_count);
         module_rc_pos += append_count;
         ret += append_count;
-        if (module_rc_pos == (ssize_t)module_rc_len)
+        if (module_rc_pos == (ssize_t)module_rc_len) {
             pr_info("read_iter_proxy: module append done\n");
+            free_module_rc();
+        }
     }
     return ret;
 }

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -467,6 +467,10 @@ pub struct BootPatchArgs {
     /// Do not (re-)install kernelsu, only modify configs (allow_shell, etc.)
     #[arg(long, default_value = "false")]
     no_install: bool,
+
+    /// Do not load custom rc
+    #[arg(long, default_value = "false")]
+    no_custom_rc: bool,
 }
 
 pub fn patch(args: BootPatchArgs) -> Result<()> {
@@ -490,6 +494,7 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             flash,
             #[cfg(target_os = "android")]
             partition,
+            no_custom_rc,
         } = args;
 
         println!(include_str!("banner"));
@@ -635,16 +640,39 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             }
         }
 
-        if allow_shell {
-            println!("- Adding allow shell config");
-            cpio.add(
-                "ksu_allow_shell",
-                CpioEntry::regular(0o644, Box::new(Vec::<u8>::new())),
-            )?;
-        } else if cpio.exists("ksu_allow_shell") {
-            println!("- Removing allow shell config");
-            cpio.rm("ksu_allow_shell", false);
+        let mut ksu_config: Vec<String> = cpio
+            .entry_by_name("ksu_config")
+            .and_then(CpioEntry::data)
+            .and_then(|v| str::from_utf8(v).ok())
+            .map(|v| v.split(' ').map(std::borrow::ToOwned::to_owned).collect())
+            .unwrap_or_default();
+
+        let mut apply_config = |name: &str, value: &str, add: bool| {
+            let has_value = ksu_config.iter().any(|v| v == value);
+
+            if add {
+                println!("- Adding {name} config");
+                if !has_value {
+                    ksu_config.push(value.to_owned());
+                }
+            } else if has_value {
+                println!("- Removing {name} config");
+                ksu_config.retain(|v| v != value);
+            }
+        };
+
+        apply_config("no custom rc", "norc=1", no_custom_rc);
+        apply_config("allow shell", "allow_shell=1", allow_shell);
+
+        if ksu_config.is_empty() {
+            cpio.rm("ksu_config", false);
+        } else {
+            let data = ksu_config.join(" ").into_bytes();
+            cpio.add("ksu_config", CpioEntry::regular(0o644, Box::new(data)))?;
         }
+
+        // remove legacy config file
+        cpio.rm("allow_shell", false);
 
         if enable_adbd || adb_debug_prop.is_some() {
             println!("- Adding adb_debug props");

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -6,6 +6,7 @@ use android_logger::Config;
 use log::{LevelFilter, error, info};
 
 use crate::boot_patch::{BootPatchArgs, BootRestoreArgs};
+use crate::module::regenerate_preinit_rc;
 use crate::{
     apk_sign, assets, debug, defs, init_event, ksucalls, module, module_config, sulog, utils,
 };
@@ -135,6 +136,12 @@ enum Commands {
         /// Arguments passed to resetprop
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
         args: Vec<String>,
+    },
+
+    /// Manage initrc injection
+    Initrc {
+        #[command(subcommand)]
+        command: Initrc,
     },
 }
 
@@ -460,6 +467,12 @@ enum UmountOp {
     Wipe,
 }
 
+#[derive(clap::Subcommand, Debug)]
+enum Initrc {
+    /// Regenerate preinit rc file
+    Refresh,
+}
+
 pub fn run() -> Result<()> {
     android_logger::init_once(
         Config::default()
@@ -749,6 +762,9 @@ pub fn run() -> Result<()> {
                 ksucalls::report_module_mounted();
                 Ok(())
             }
+        },
+        Commands::Initrc { command } => match command {
+            Initrc::Refresh => regenerate_preinit_rc(),
         },
     };
 

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -23,9 +23,11 @@ mod android {
     pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
     pub const METAMODULE_DIR: &str = concatcp!(ADB_DIR, "metamodule/");
 
-    pub const PREINIT_DIR: &str = "/metadata/watchdog/ksu/";
-    pub const MODULES_RC_PATH: &str = concatcp!(PREINIT_DIR, "modules.rc");
-    pub const MODULES_RC_TMP_PATH: &str = concatcp!(PREINIT_DIR, ".modules.rc.tmp");
+    // Prefer /metadata/watchdog/ when present, else /metadata
+    pub const PREINIT_DIR_WATCHDOG: &str = "/metadata/watchdog/ksu/";
+    pub const PREINIT_DIR_DEFAULT: &str = "/metadata/ksu/";
+    pub const MODULES_RC_FILE: &str = "modules.rc";
+    pub const MODULES_RC_TMP_FILE: &str = ".modules.rc.tmp";
 
     pub const MODULE_WEB_DIR: &str = "webroot";
     pub const MODULE_ACTION_SH: &str = "action.sh";

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -27,6 +27,7 @@ mod android {
     pub const PREINIT_DIR_WATCHDOG: &str = "/metadata/watchdog/ksu/";
     pub const PREINIT_DIR_DEFAULT: &str = "/metadata/ksu/";
     pub const MODULES_RC_FILE: &str = "modules.rc";
+    pub const MODULES_RC_TMP_FILE: &str = ".modules.rc.tmp";
 
     pub const MODULE_WEB_DIR: &str = "webroot";
     pub const MODULE_ACTION_SH: &str = "action.sh";

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -33,6 +33,7 @@ mod android {
     pub const DISABLE_FILE_NAME: &str = "disable";
     pub const UPDATE_FILE_NAME: &str = "update";
     pub const REMOVE_FILE_NAME: &str = "remove";
+    pub const MODULE_INIT_RC_DIR: &str = "initrc";
 
     // Module config system
     pub const MODULE_CONFIG_DIR: &str = concatcp!(WORKING_DIR, "module_configs/");

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -27,7 +27,6 @@ mod android {
     pub const PREINIT_DIR_WATCHDOG: &str = "/metadata/watchdog/ksu/";
     pub const PREINIT_DIR_DEFAULT: &str = "/metadata/ksu/";
     pub const MODULES_RC_FILE: &str = "modules.rc";
-    pub const MODULES_RC_TMP_FILE: &str = ".modules.rc.tmp";
 
     pub const MODULE_WEB_DIR: &str = "webroot";
     pub const MODULE_ACTION_SH: &str = "action.sh";

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -23,6 +23,10 @@ mod android {
     pub const MODULE_UPDATE_DIR: &str = concatcp!(ADB_DIR, "modules_update/");
     pub const METAMODULE_DIR: &str = concatcp!(ADB_DIR, "metamodule/");
 
+    pub const PREINIT_DIR: &str = "/metadata/watchdog/ksu/";
+    pub const MODULES_RC_PATH: &str = concatcp!(PREINIT_DIR, "modules.rc");
+    pub const MODULES_RC_TMP_PATH: &str = concatcp!(PREINIT_DIR, ".modules.rc.tmp");
+
     pub const MODULE_WEB_DIR: &str = "webroot";
     pub const MODULE_ACTION_SH: &str = "action.sh";
     pub const DISABLE_FILE_NAME: &str = "disable";

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -67,6 +67,13 @@ pub fn on_post_data_fs() -> Result<()> {
         warn!("prune modules failed: {e}");
     }
 
+    // Refresh /metadata/watchdog/ksu/modules.rc so the next boot's kernel hook sees the
+    // current module set. Acts as a safety net when state was changed outside
+    // of ksud's normal mutation commands.
+    if let Err(e) = crate::module::regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+
     if let Err(e) = restorecon::restorecon() {
         warn!("restorecon failed: {e}");
     }

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -323,6 +323,48 @@ request_zip_size_check() {
 
 boot_actions() { return; }
 
+# Concatenate all enabled modules' *.rc files (except init.rc) into
+# /metadata/watchdog/ksu/modules.rc so the kernel-side read hook can splice them
+# into /system/etc/init/hw/init.rc on the next boot.
+copy_preinit_files() {
+  local PREINITDIR=/metadata/watchdog/ksu
+  local OUT="$PREINITDIR/modules.rc"
+  local TMP="$PREINITDIR/.modules.rc.tmp"
+
+  [ -d /metadata ] || return 0
+
+  mkdir -p "$PREINITDIR" 2>/dev/null
+  : > "$TMP"
+
+  # Walk modules_update/ first (newer/just-installed wins on id collision),
+  # then modules/. Skip disabled/removed modules.
+  local seen=
+  local SRC
+  for SRC in /data/adb/modules_update /data/adb/modules; do
+    [ -d "$SRC" ] || continue
+    for MODDIR in "$SRC"/*; do
+      [ -d "$MODDIR" ] || continue
+      local MODID
+      MODID=$(basename "$MODDIR")
+      case " $seen " in *" $MODID "*) continue ;; esac
+      [ -f "$MODDIR/disable" ] && continue
+      [ -f "$MODDIR/remove" ] && continue
+      find "$MODDIR" -mindepth 1 -type f -name "*.rc" ! -name "init.rc" 2>/dev/null \
+      | while read -r rcfile; do
+        local rel="${rcfile#$MODDIR/}"
+        printf '# === from %s:%s ===\n' "$MODID" "$rel" >> "$TMP"
+        cat "$rcfile" >> "$TMP"
+        printf '\n' >> "$TMP"
+      done
+      seen="$seen $MODID"
+    done
+  done
+
+  mv -f "$TMP" "$OUT" 2>/dev/null
+  chmod 0644 "$OUT" 2>/dev/null
+  chcon u:object_r:metadata_file:s0 "$OUT" 2>/dev/null
+}
+
 # Require ZIPFILE to be set
 is_legacy_script() {
   unzip -l "$ZIPFILE" install.sh | grep -q install.sh
@@ -452,6 +494,17 @@ install_module() {
   $MODPATH/system/placeholder $MODPATH/customize.sh \
   $MODPATH/README.md $MODPATH/.git*
   rmdir -p $MODPATH 2>/dev/null
+
+  # Modules cannot replace the main init.rc; strip any such file before
+  # the rc preinit mirror is rebuilt.
+  find "$MODPATH" -mindepth 1 -type f -name "init.rc" -exec rm -f {} \; 2>/dev/null
+
+  # If this module ships any other *.rc, rebuild the preinit rc mirror so
+  # init can pick them up on next boot.
+  if [ -n "$(find "$MODPATH" -mindepth 1 -type f -name "*.rc" 2>/dev/null | head -n 1)" ]; then
+    ui_print "- Installing module rc scripts"
+    copy_preinit_files
+  fi
 
   cd /
   $BOOTMODE || recovery_cleanup

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -323,50 +323,6 @@ request_zip_size_check() {
 
 boot_actions() { return; }
 
-# Concatenate all enabled modules' *.rc files (except init.rc) into
-# /metadata/watchdog/ksu/modules.rc so the kernel-side read hook can splice them
-# into /system/etc/init/hw/init.rc on the next boot.
-copy_preinit_files() {
-  [ -d /metadata ] || return 0
-
-  # Prefer /metadata/watchdog/ when present, else /metadata.
-  local PREINITDIR=/metadata/ksu
-  [ -d /metadata/watchdog ] && PREINITDIR=/metadata/watchdog/ksu
-  local OUT="$PREINITDIR/modules.rc"
-  local TMP="$PREINITDIR/.modules.rc.tmp"
-
-  mkdir -p "$PREINITDIR" 2>/dev/null
-  : > "$TMP"
-
-  # Walk modules_update/ first (newer/just-installed wins on id collision),
-  # then modules/. Skip disabled/removed modules.
-  local seen=
-  local SRC
-  for SRC in /data/adb/modules_update /data/adb/modules; do
-    [ -d "$SRC" ] || continue
-    for MODDIR in "$SRC"/*; do
-      [ -d "$MODDIR" ] || continue
-      local MODID
-      MODID=$(basename "$MODDIR")
-      case " $seen " in *" $MODID "*) continue ;; esac
-      [ -f "$MODDIR/disable" ] && continue
-      [ -f "$MODDIR/remove" ] && continue
-      find "$MODDIR" -mindepth 1 -type f -name "*.rc" ! -name "init.rc" 2>/dev/null \
-      | while read -r rcfile; do
-        local rel="${rcfile#$MODDIR/}"
-        printf '# === from %s:%s ===\n' "$MODID" "$rel" >> "$TMP"
-        cat "$rcfile" >> "$TMP"
-        printf '\n' >> "$TMP"
-      done
-      seen="$seen $MODID"
-    done
-  done
-
-  mv -f "$TMP" "$OUT" 2>/dev/null
-  chmod 0644 "$OUT" 2>/dev/null
-  chcon u:object_r:metadata_file:s0 "$OUT" 2>/dev/null
-}
-
 # Require ZIPFILE to be set
 is_legacy_script() {
   unzip -l "$ZIPFILE" install.sh | grep -q install.sh
@@ -496,17 +452,6 @@ install_module() {
   $MODPATH/system/placeholder $MODPATH/customize.sh \
   $MODPATH/README.md $MODPATH/.git*
   rmdir -p $MODPATH 2>/dev/null
-
-  # Modules cannot replace the main init.rc; strip any such file before
-  # the rc preinit mirror is rebuilt.
-  find "$MODPATH" -mindepth 1 -type f -name "init.rc" -exec rm -f {} \; 2>/dev/null
-
-  # If this module ships any other *.rc, rebuild the preinit rc mirror so
-  # init can pick them up on next boot.
-  if [ -n "$(find "$MODPATH" -mindepth 1 -type f -name "*.rc" 2>/dev/null | head -n 1)" ]; then
-    ui_print "- Installing module rc scripts"
-    copy_preinit_files
-  fi
 
   cd /
   $BOOTMODE || recovery_cleanup

--- a/userspace/ksud/src/installer.sh
+++ b/userspace/ksud/src/installer.sh
@@ -327,11 +327,13 @@ boot_actions() { return; }
 # /metadata/watchdog/ksu/modules.rc so the kernel-side read hook can splice them
 # into /system/etc/init/hw/init.rc on the next boot.
 copy_preinit_files() {
-  local PREINITDIR=/metadata/watchdog/ksu
+  [ -d /metadata ] || return 0
+
+  # Prefer /metadata/watchdog/ when present, else /metadata.
+  local PREINITDIR=/metadata/ksu
+  [ -d /metadata/watchdog ] && PREINITDIR=/metadata/watchdog/ksu
   local OUT="$PREINITDIR/modules.rc"
   local TMP="$PREINITDIR/.modules.rc.tmp"
-
-  [ -d /metadata ] || return 0
 
   mkdir -p "$PREINITDIR" 2>/dev/null
   : > "$TMP"

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -359,6 +359,99 @@ pub fn prune_modules() -> Result<()> {
     Ok(())
 }
 
+const METADATA_FILE_CON: &str = "u:object_r:metadata_file:s0";
+
+fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut File) -> Result<()> {
+    use std::io::Write;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        if meta.is_dir() {
+            collect_module_rc(root, &path, mod_id, out)?;
+        } else if meta.is_file()
+            && path.extension().and_then(|s| s.to_str()) == Some("rc")
+            && path.file_name().and_then(|s| s.to_str()) != Some("init.rc")
+        {
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            writeln!(out, "# === from {mod_id}:{} ===", rel.display())?;
+            let content = std::fs::read(&path)
+                .with_context(|| format!("Failed to read rc {}", path.display()))?;
+            out.write_all(&content)?;
+            writeln!(out)?;
+        }
+    }
+    Ok(())
+}
+
+/// Rebuild /metadata/watchdog/ksu/modules.rc by concatenating *.rc from every enabled
+/// module. The kernel-side read hook splices this file into init.rc on the
+/// next boot. Best-effort: silently skips if /metadata isn't writable.
+pub fn regenerate_preinit_rc() -> Result<()> {
+    use std::collections::HashSet;
+
+    let preinit_dir = Path::new(defs::PREINIT_DIR);
+    if !Path::new("/metadata").is_dir() {
+        debug!("/metadata not present, skip preinit rc regen");
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(preinit_dir)
+        .with_context(|| format!("Failed to create {}", preinit_dir.display()))?;
+
+    let tmp_path = Path::new(defs::MODULES_RC_TMP_PATH);
+    let out_path = Path::new(defs::MODULES_RC_PATH);
+
+    {
+        let mut tmp = File::create(tmp_path)
+            .with_context(|| format!("Failed to create {}", tmp_path.display()))?;
+
+        let mut seen: HashSet<String> = HashSet::new();
+        // modules_update/ first so freshly-installed modules win on id collision.
+        for src_dir in [defs::MODULE_UPDATE_DIR, defs::MODULE_DIR] {
+            let Ok(entries) = std::fs::read_dir(src_dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let module_path = entry.path();
+                if !module_path.is_dir() {
+                    continue;
+                }
+                let Some(id) = module_path.file_name().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                if !seen.insert(id.to_string()) {
+                    continue;
+                }
+                if module_path.join(defs::DISABLE_FILE_NAME).exists() {
+                    continue;
+                }
+                if module_path.join(defs::REMOVE_FILE_NAME).exists() {
+                    continue;
+                }
+                collect_module_rc(&module_path, &module_path, id, &mut tmp)?;
+            }
+        }
+    }
+
+    std::fs::rename(tmp_path, out_path).with_context(|| {
+        format!(
+            "Failed to rename {} -> {}",
+            tmp_path.display(),
+            out_path.display()
+        )
+    })?;
+
+    // SELinux label so the kernel's filp_open in init context can read it.
+    if let Err(e) = crate::restorecon::lsetfilecon(out_path, METADATA_FILE_CON) {
+        debug!("set context on {} failed: {e}", out_path.display());
+    }
+
+    Ok(())
+}
+
 pub fn handle_updated_modules() -> Result<()> {
     let modules_root = Path::new(MODULE_DIR);
     foreach_module(ModuleType::Updated, |updated_module| {
@@ -544,6 +637,8 @@ pub fn install_module(zip: &str) -> Result<()> {
     let result = install_module_to_system(zip);
     if let Err(ref e) = result {
         println!("- Error: {e}");
+    } else if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
     }
     result
 }
@@ -562,6 +657,10 @@ pub fn undo_uninstall_module(id: &str) -> Result<()> {
         info!("Removed the remove mark for module {id}");
     }
 
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+
     Ok(())
 }
 
@@ -576,6 +675,10 @@ pub fn uninstall_module(id: &str) -> Result<()> {
     File::create(remove_file).with_context(|| "Failed to create remove file")?;
 
     info!("Module {id} marked for removal");
+
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
 
     Ok(())
 }
@@ -601,6 +704,10 @@ pub fn enable_module(id: &str) -> Result<()> {
         info!("Module {id} enabled");
     }
 
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+
     Ok(())
 }
 
@@ -613,16 +720,28 @@ pub fn disable_module(id: &str) -> Result<()> {
 
     info!("Module {id} disabled");
 
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+
     Ok(())
 }
 
 pub fn disable_all_modules() -> Result<()> {
-    mark_all_modules(defs::DISABLE_FILE_NAME)
+    mark_all_modules(defs::DISABLE_FILE_NAME)?;
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+    Ok(())
 }
 
 pub fn uninstall_all_modules() -> Result<()> {
     info!("Uninstalling all modules");
-    mark_all_modules(defs::REMOVE_FILE_NAME)
+    mark_all_modules(defs::REMOVE_FILE_NAME)?;
+    if let Err(e) = regenerate_preinit_rc() {
+        warn!("regenerate preinit rc failed: {e}");
+    }
+    Ok(())
 }
 
 fn mark_all_modules(flag_file: &str) -> Result<()> {

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -13,7 +13,6 @@ use java_properties::PropertiesIter;
 use log::{debug, error, info, warn};
 use regex_lite::Regex;
 
-use std::fs::{copy, rename};
 use std::{
     collections::HashMap,
     env::var as env_var,
@@ -22,6 +21,10 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     str::FromStr,
+};
+use std::{
+    fs::{copy, rename},
+    io::Write,
 };
 use zip_extensions::inflate::zip_extract::zip_extract_file_to_memory;
 
@@ -370,8 +373,7 @@ fn preinit_ksu_dir() -> &'static str {
     }
 }
 
-fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut File) -> Result<()> {
-    use std::io::Write;
+fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut dyn Write) -> Result<()> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Ok(());
     };
@@ -410,15 +412,10 @@ pub fn regenerate_preinit_rc() -> Result<()> {
     std::fs::create_dir_all(preinit_dir)
         .with_context(|| format!("Failed to create {}", preinit_dir.display()))?;
 
-    let tmp_path_buf = preinit_dir.join(defs::MODULES_RC_TMP_FILE);
-    let out_path_buf = preinit_dir.join(defs::MODULES_RC_FILE);
-    let tmp_path = tmp_path_buf.as_path();
-    let out_path = out_path_buf.as_path();
+    let out_path = preinit_dir.join(defs::MODULES_RC_FILE);
 
     {
-        let mut tmp = File::create(tmp_path)
-            .with_context(|| format!("Failed to create {}", tmp_path.display()))?;
-
+        let mut tmp = Vec::<u8>::new();
         let mut seen: HashSet<String> = HashSet::new();
         // modules_update/ first so freshly-installed modules win on id collision.
         for src_dir in [defs::MODULE_UPDATE_DIR, defs::MODULE_DIR] {
@@ -445,18 +442,12 @@ pub fn regenerate_preinit_rc() -> Result<()> {
                 collect_module_rc(&module_path, &module_path, id, &mut tmp)?;
             }
         }
+        let mut out_file = File::create(&out_path)?;
+        out_file.write_all(&tmp)?;
     }
 
-    std::fs::rename(tmp_path, out_path).with_context(|| {
-        format!(
-            "Failed to rename {} -> {}",
-            tmp_path.display(),
-            out_path.display()
-        )
-    })?;
-
     // SELinux label so the kernel's filp_open in init context can read it.
-    if let Err(e) = crate::restorecon::lsetfilecon(out_path, METADATA_FILE_CON) {
+    if let Err(e) = crate::restorecon::lsetfilecon(&out_path, METADATA_FILE_CON) {
         debug!("set context on {} failed: {e}", out_path.display());
     }
 

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -14,7 +14,7 @@ use log::{debug, error, info, warn};
 use regex_lite::Regex;
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     env::var as env_var,
     fs::{File, Permissions, canonicalize, remove_dir_all, set_permissions},
     io::Cursor,
@@ -382,13 +382,16 @@ fn collect_rc_files<P: AsRef<Path>>(
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Ok(());
     };
-    for entry in entries.flatten() {
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
         let path = entry.path();
         let Ok(meta) = entry.metadata() else { continue };
         if meta.is_file() && path.extension().and_then(|s| s.to_str()) == Some("rc") {
             if let Some(mod_id) = mod_id {
                 writeln!(out, "# === from {mod_id}:{} ===", path.display())?;
             } else {
+                // Although the rc file itself is not executable, we still use its executable bit as a switch.
                 if !is_executable(&path) {
                     continue;
                 }
@@ -407,8 +410,6 @@ fn collect_rc_files<P: AsRef<Path>>(
 /// module. The kernel-side read hook splices this file into init.rc on the
 /// next boot.
 pub fn regenerate_preinit_rc() -> Result<()> {
-    use std::collections::HashSet;
-
     let preinit_str = preinit_ksu_dir();
     let preinit_dir = Path::new(preinit_str);
     std::fs::create_dir_all(preinit_dir)
@@ -418,7 +419,8 @@ pub fn regenerate_preinit_rc() -> Result<()> {
 
     {
         let mut tmp = Vec::<u8>::new();
-        let mut seen: HashSet<String> = HashSet::new();
+        // collect modules in alphabetical order, with their effective module path in the next boot
+        let mut modules: BTreeMap<String, Option<PathBuf>> = BTreeMap::new();
         // collect common initrc first
         collect_rc_files(Path::new(defs::ADB_DIR).join("initrc.d"), None, &mut tmp)?;
         // modules_update/ first so freshly-installed modules win on id collision.
@@ -434,20 +436,21 @@ pub fn regenerate_preinit_rc() -> Result<()> {
                 let Some(id) = module_path.file_name().and_then(|s| s.to_str()) else {
                     continue;
                 };
-                if !seen.insert(id.to_string()) {
+                let id = id.to_string();
+                if module_path.join(defs::DISABLE_FILE_NAME).exists()
+                    || module_path.join(defs::REMOVE_FILE_NAME).exists()
+                {
+                    modules.insert(id, None);
                     continue;
                 }
-                if module_path.join(defs::DISABLE_FILE_NAME).exists() {
-                    continue;
+                if modules.contains_key(&id) {
+                    modules.insert(id, Some(module_path));
                 }
-                if module_path.join(defs::REMOVE_FILE_NAME).exists() {
-                    continue;
-                }
-                collect_rc_files(
-                    module_path.join(defs::MODULE_INIT_RC_DIR),
-                    Some(id),
-                    &mut tmp,
-                )?;
+            }
+        }
+        for (id, path) in modules {
+            if let Some(path) = path {
+                collect_rc_files(path.join(defs::MODULE_INIT_RC_DIR), Some(&id), &mut tmp)?;
             }
         }
         let mut out_file = File::create(&out_path)?;

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -406,7 +406,7 @@ fn collect_rc_files<P: AsRef<Path>>(
     Ok(())
 }
 
-/// Rebuild /metadata/watchdog/ksu/modules.rc by concatenating *.rc from every enabled
+/// Rebuild PREINITDIR/modules.rc by concatenating *.rc from every enabled
 /// module. The kernel-side read hook splices this file into init.rc on the
 /// next boot.
 pub fn regenerate_preinit_rc() -> Result<()> {

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -415,10 +415,15 @@ pub fn regenerate_preinit_rc() -> Result<()> {
     std::fs::create_dir_all(preinit_dir)
         .with_context(|| format!("Failed to create {}", preinit_dir.display()))?;
 
-    let out_path = preinit_dir.join(defs::MODULES_RC_FILE);
+    let tmp_path_buf = preinit_dir.join(defs::MODULES_RC_TMP_FILE);
+    let out_path_buf = preinit_dir.join(defs::MODULES_RC_FILE);
+    let tmp_path = tmp_path_buf.as_path();
+    let out_path = out_path_buf.as_path();
 
     {
-        let mut tmp = Vec::<u8>::new();
+        let mut tmp = File::create(tmp_path)
+            .with_context(|| format!("Failed to create {}", tmp_path.display()))?;
+
         // collect modules in alphabetical order, with their effective module path in the next boot
         let mut modules: BTreeMap<String, Option<PathBuf>> = BTreeMap::new();
         // collect common initrc first
@@ -451,12 +456,19 @@ pub fn regenerate_preinit_rc() -> Result<()> {
                 collect_rc_files(path.join(defs::MODULE_INIT_RC_DIR), Some(&id), &mut tmp)?;
             }
         }
-        let mut out_file = File::create(&out_path)?;
-        out_file.write_all(&tmp)?;
+        tmp.sync_all()?;
     }
 
+    std::fs::rename(tmp_path, out_path).with_context(|| {
+        format!(
+            "Failed to rename {} -> {}",
+            tmp_path.display(),
+            out_path.display()
+        )
+    })?;
+
     // SELinux label so the kernel's filp_open in init context can read it.
-    if let Err(e) = crate::restorecon::lsetfilecon(&out_path, METADATA_FILE_CON) {
+    if let Err(e) = crate::restorecon::lsetfilecon(out_path, METADATA_FILE_CON) {
         debug!("set context on {} failed: {e}", out_path.display());
     }
 

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -373,21 +373,27 @@ fn preinit_ksu_dir() -> &'static str {
     }
 }
 
-fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut dyn Write) -> Result<()> {
+fn collect_rc_files<P: AsRef<Path>>(
+    dir: P,
+    mod_id: Option<&str>,
+    out: &mut dyn Write,
+) -> Result<()> {
+    let dir = dir.as_ref();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return Ok(());
     };
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(meta) = entry.metadata() else { continue };
-        if meta.is_dir() {
-            collect_module_rc(root, &path, mod_id, out)?;
-        } else if meta.is_file()
-            && path.extension().and_then(|s| s.to_str()) == Some("rc")
-            && path.file_name().and_then(|s| s.to_str()) != Some("init.rc")
-        {
-            let rel = path.strip_prefix(root).unwrap_or(&path);
-            writeln!(out, "# === from {mod_id}:{} ===", rel.display())?;
+        if meta.is_file() && path.extension().and_then(|s| s.to_str()) == Some("rc") {
+            if let Some(mod_id) = mod_id {
+                writeln!(out, "# === from {mod_id}:{} ===", path.display())?;
+            } else {
+                if !is_executable(&path) {
+                    continue;
+                }
+                writeln!(out, "# === from {} ===", path.display())?;
+            }
             let content = std::fs::read(&path)
                 .with_context(|| format!("Failed to read rc {}", path.display()))?;
             out.write_all(&content)?;
@@ -417,6 +423,8 @@ pub fn regenerate_preinit_rc() -> Result<()> {
     {
         let mut tmp = Vec::<u8>::new();
         let mut seen: HashSet<String> = HashSet::new();
+        // collect common initrc first
+        collect_rc_files(Path::new(defs::ADB_DIR).join("initrc.d"), None, &mut tmp)?;
         // modules_update/ first so freshly-installed modules win on id collision.
         for src_dir in [defs::MODULE_UPDATE_DIR, defs::MODULE_DIR] {
             let Ok(entries) = std::fs::read_dir(src_dir) else {
@@ -439,7 +447,11 @@ pub fn regenerate_preinit_rc() -> Result<()> {
                 if module_path.join(defs::REMOVE_FILE_NAME).exists() {
                     continue;
                 }
-                collect_module_rc(&module_path, &module_path, id, &mut tmp)?;
+                collect_rc_files(
+                    module_path.join(defs::MODULE_INIT_RC_DIR),
+                    Some(id),
+                    &mut tmp,
+                )?;
             }
         }
         let mut out_file = File::create(&out_path)?;

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -405,13 +405,9 @@ fn collect_rc_files<P: AsRef<Path>>(
 
 /// Rebuild /metadata/watchdog/ksu/modules.rc by concatenating *.rc from every enabled
 /// module. The kernel-side read hook splices this file into init.rc on the
-/// next boot. Best-effort: silently skips if /metadata isn't writable.
+/// next boot.
 pub fn regenerate_preinit_rc() -> Result<()> {
     use std::collections::HashSet;
-
-    if !Path::new("/metadata").is_dir() {
-        return Ok(());
-    }
 
     let preinit_str = preinit_ksu_dir();
     let preinit_dir = Path::new(preinit_str);

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -443,9 +443,7 @@ pub fn regenerate_preinit_rc() -> Result<()> {
                     modules.insert(id, None);
                     continue;
                 }
-                if modules.contains_key(&id) {
-                    modules.insert(id, Some(module_path));
-                }
+                modules.entry(id).or_insert(Some(module_path));
             }
         }
         for (id, path) in modules {

--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -361,6 +361,15 @@ pub fn prune_modules() -> Result<()> {
 
 const METADATA_FILE_CON: &str = "u:object_r:metadata_file:s0";
 
+// Prefer /metadata/watchdog/ when present, else /metadata.
+fn preinit_ksu_dir() -> &'static str {
+    if Path::new("/metadata/watchdog").is_dir() {
+        defs::PREINIT_DIR_WATCHDOG
+    } else {
+        defs::PREINIT_DIR_DEFAULT
+    }
+}
+
 fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut File) -> Result<()> {
     use std::io::Write;
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -392,17 +401,19 @@ fn collect_module_rc(root: &Path, dir: &Path, mod_id: &str, out: &mut File) -> R
 pub fn regenerate_preinit_rc() -> Result<()> {
     use std::collections::HashSet;
 
-    let preinit_dir = Path::new(defs::PREINIT_DIR);
     if !Path::new("/metadata").is_dir() {
-        debug!("/metadata not present, skip preinit rc regen");
         return Ok(());
     }
 
+    let preinit_str = preinit_ksu_dir();
+    let preinit_dir = Path::new(preinit_str);
     std::fs::create_dir_all(preinit_dir)
         .with_context(|| format!("Failed to create {}", preinit_dir.display()))?;
 
-    let tmp_path = Path::new(defs::MODULES_RC_TMP_PATH);
-    let out_path = Path::new(defs::MODULES_RC_PATH);
+    let tmp_path_buf = preinit_dir.join(defs::MODULES_RC_TMP_FILE);
+    let out_path_buf = preinit_dir.join(defs::MODULES_RC_FILE);
+    let tmp_path = tmp_path_buf.as_path();
+    let out_path = out_path_buf.as_path();
 
     {
         let mut tmp = File::create(tmp_path)
@@ -448,6 +459,14 @@ pub fn regenerate_preinit_rc() -> Result<()> {
     if let Err(e) = crate::restorecon::lsetfilecon(out_path, METADATA_FILE_CON) {
         debug!("set context on {} failed: {e}", out_path.display());
     }
+
+    // Clear stale file at the other candidate path.
+    let stale_dir = if preinit_str == defs::PREINIT_DIR_WATCHDOG {
+        defs::PREINIT_DIR_DEFAULT
+    } else {
+        defs::PREINIT_DIR_WATCHDOG
+    };
+    std::fs::remove_file(Path::new(stale_dir).join(defs::MODULES_RC_FILE)).ok();
 
     Ok(())
 }

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -221,6 +221,8 @@ pub fn uninstall(package_name: &str) -> Result<()> {
     std::fs::remove_dir_all(defs::WORKING_DIR).ok();
     std::fs::remove_file(defs::DAEMON_PATH).ok();
     std::fs::remove_dir_all(defs::MODULE_DIR).ok();
+    std::fs::remove_dir_all(defs::PREINIT_DIR_WATCHDOG).ok();
+    std::fs::remove_dir_all(defs::PREINIT_DIR_DEFAULT).ok();
     println!("- Restore boot image..");
     boot_patch::restore(BootRestoreArgs {
         boot: None,

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -1,7 +1,7 @@
+use std::ffi::CString;
 use std::io::{ErrorKind, Write};
 
 use anyhow::{Context, Result};
-use rustix::cstr;
 use rustix::fs::{Mode, symlink, unlink};
 use rustix::{
     fd::AsFd,
@@ -135,11 +135,8 @@ pub fn init() -> Result<()> {
 fn load_module_from_path(path: &str) -> Result<()> {
     anyhow::ensure!(rustix::process::getpid().is_init(), "Invalid process");
     let buffer = std::fs::read(path).with_context(|| format!("Cannot read file {}", path))?;
-    let params = if std::fs::exists("/ksu_allow_shell").unwrap_or(false) {
-        log::warn!("ksu allow shell at init!");
-        cstr!("allow_shell=1")
-    } else {
-        cstr!("")
-    };
-    ksuinit::load_module(&buffer, params)
+    let params = std::fs::read("/ksu_config").unwrap_or_default();
+    let params = unsafe { CString::from_vec_unchecked(params) };
+    log::info!("load kernelsu with params {params:?}");
+    ksuinit::load_module(&buffer, &params)
 }


### PR DESCRIPTION
- The rc files in modules and the common directory will be merged and stored in `/metadata[/watchdog]/ksu/modules.rc`. These files will be appended to the main system rc file at system startup.
- Module rc files: The `initrc/*.rc` files for each module.
- Common rc files: All executable (chmod +x) `/data/adb/initrc.d/*.rc` files.
- The `modules.rc` file will be regenerated after module changes (installation, disabling, uninstallation, etc.).
- If a user modifies the common rc file, the `ksud initrc refresh` command can be run to regenerate the file and apply the changes.
- Custom rc files can be ignored when patching bootimg using the `--no-custom-rc` option.