### PR TITLE
manager: improve snackbar and fix dialog

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -57,7 +57,7 @@ import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.bottombar.BottomBar
 import me.weishu.kernelsu.ui.component.bottombar.MainPagerState
 import me.weishu.kernelsu.ui.component.bottombar.SideRail

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -57,6 +57,7 @@ import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.bottombar.BottomBar
 import me.weishu.kernelsu.ui.component.bottombar.MainPagerState
 import me.weishu.kernelsu.ui.component.bottombar.SideRail
@@ -88,7 +89,6 @@ import me.weishu.kernelsu.ui.theme.LocalColorMode
 import me.weishu.kernelsu.ui.theme.LocalEnableBlur
 import me.weishu.kernelsu.ui.theme.LocalEnableFloatingBottomBar
 import me.weishu.kernelsu.ui.theme.LocalEnableFloatingBottomBarBlur
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.getFileName
 import me.weishu.kernelsu.ui.util.install
 import me.weishu.kernelsu.ui.util.rememberBlurBackdrop

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -57,7 +56,6 @@ import androidx.navigationevent.compose.rememberNavigationEventState
 import kotlinx.coroutines.flow.MutableStateFlow
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.bottombar.BottomBar
 import me.weishu.kernelsu.ui.component.bottombar.MainPagerState
 import me.weishu.kernelsu.ui.component.bottombar.SideRail
@@ -137,7 +135,6 @@ class MainActivity : ComponentActivity() {
             }
 
             val navigator = rememberNavigator(Route.Main)
-            val snackBarHostState = remember { SnackbarHostState() }
             val systemDensity = LocalDensity.current
             val density = remember(systemDensity, uiState.pageScale) {
                 Density(systemDensity.density * uiState.pageScale, systemDensity.fontScale)
@@ -151,7 +148,6 @@ class MainActivity : ComponentActivity() {
                 LocalEnableFloatingBottomBar provides uiState.enableFloatingBottomBar,
                 LocalEnableFloatingBottomBarBlur provides uiState.enableFloatingBottomBarBlur,
                 LocalUiMode provides uiMode,
-                LocalSnackbarHost provides snackBarHostState
             ) {
                 KernelSUTheme(appSettings = appSettings, uiMode = uiMode) {
                     HandleDeepLink(intentState = intentState.collectAsStateWithLifecycle())

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/M3SnackBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/M3SnackBar.kt
@@ -1,0 +1,178 @@
+package me.weishu.kernelsu.ui.component
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.AccessibilityManager
+import androidx.compose.ui.platform.LocalAccessibilityManager
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+private const val ANIMATION_DURATION = 450
+private const val ANIMATION_FADE_DURATION = 200
+
+val LocalSnackbarHost = compositionLocalOf<SnackbarHostState> {
+    error("CompositionLocal LocalSnackBarController not present")
+}
+
+class OvershootEasing(private val tension: Float = 2.0f) : Easing {
+    override fun transform(fraction: Float): Float {
+        val t = fraction - 1.0f
+        return t * t * ((tension + 1) * t + tension) + 1.0f
+    }
+}
+
+private fun getSnackBarEnterTransition() = slideInVertically(
+    initialOffsetY = { fullHeight -> fullHeight }, animationSpec = tween(
+        durationMillis = ANIMATION_DURATION, easing = OvershootEasing()
+    )
+) + scaleIn(
+    initialScale = 1.1f, animationSpec = tween(
+        durationMillis = ANIMATION_DURATION, easing = FastOutSlowInEasing
+    )
+) + fadeIn(
+    animationSpec = tween(durationMillis = ANIMATION_FADE_DURATION)
+)
+
+private fun getSnackBarExitTransition() = slideOutVertically(
+    targetOffsetY = { fullHeight -> fullHeight }, animationSpec = tween(durationMillis = ANIMATION_DURATION, easing = FastOutSlowInEasing)
+) + fadeOut(
+    animationSpec = tween(durationMillis = ANIMATION_FADE_DURATION)
+)
+
+
+@Composable
+private fun FadeInFadeOutWithScale(
+    current: SnackbarData?,
+    modifier: Modifier = Modifier,
+    content: @Composable (SnackbarData) -> Unit,
+) {
+    AnimatedContent(
+        targetState = current,
+        transitionSpec = {
+            (getSnackBarEnterTransition() togetherWith getSnackBarExitTransition()).using(sizeTransform = null)
+        },
+        modifier = modifier,
+        label = "breeze_snackbar_animation"
+    ) { data ->
+        if (data != null) {
+            content(data)
+        }
+    }
+}
+
+@Composable
+fun M3SnackBarHost(
+    hostState: SnackbarHostState,
+    modifier: Modifier = Modifier,
+    snackBar: @Composable (SnackbarData) -> Unit = { M3SnackBar(it) },
+) {
+    val currentSnackBarData = hostState.currentSnackbarData
+    val accessibilityManager = LocalAccessibilityManager.current
+    LaunchedEffect(currentSnackBarData) {
+        if (currentSnackBarData != null) {
+            val duration = currentSnackBarData.visuals.duration.toMillis(
+                currentSnackBarData.visuals.actionLabel != null,
+                accessibilityManager,
+            )
+            delay(duration)
+            currentSnackBarData.dismiss()
+        }
+    }
+    FadeInFadeOutWithScale(
+        current = hostState.currentSnackbarData,
+        modifier = modifier,
+        content = snackBar,
+    )
+}
+
+private fun SnackbarDuration.toMillis(
+    hasAction: Boolean,
+    accessibilityManager: AccessibilityManager?,
+): Long {
+    val original = when (this) {
+        SnackbarDuration.Indefinite -> Long.MAX_VALUE
+        SnackbarDuration.Long -> 10000L
+        SnackbarDuration.Short -> 4000L
+    }
+    if (accessibilityManager == null) {
+        return original
+    }
+    return accessibilityManager.calculateRecommendedTimeoutMillis(
+        original,
+        containsIcons = true,
+        containsText = true,
+        containsControls = hasAction,
+    )
+}
+
+@Composable
+fun M3SnackBar(
+    snackBarData: SnackbarData,
+    modifier: Modifier = Modifier
+) {
+    val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val offsetY = remember(snackBarData) { Animatable(0f) }
+    // SingleLineContainerHeight
+    val dismissThresholdPx = remember(density) {
+        with(density) { 48.dp.toPx() }
+    }
+
+    Snackbar(
+        snackbarData = snackBarData,
+        modifier = modifier
+            .offset {
+                IntOffset(0, offsetY.value.roundToInt())
+            }
+            .pointerInput(snackBarData) {
+                detectVerticalDragGestures(
+                    onDragEnd = {
+                        if (offsetY.value > dismissThresholdPx) {
+                            snackBarData.dismiss()
+                        } else {
+                            scope.launch {
+                                offsetY.animateTo(0f)
+                            }
+                        }
+                    },
+                    onDragCancel = {
+                        scope.launch {
+                            offsetY.animateTo(0f)
+                        }
+                    }
+                ) { change, dragAmount ->
+                    change.consume()
+                    val newOffset = (offsetY.value + dragAmount).coerceAtLeast(0f)
+                    scope.launch {
+                        offsetY.snapTo(newOffset)
+                    }
+                }
+            }
+    )
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/MarkdownContent.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/markdown/MarkdownContent.kt
@@ -30,6 +30,7 @@ fun MarkdownContent(
     content: String,
     isMarkdown: Boolean,
 ) {
+    val uiMode = LocalUiMode.current
     var loaded by remember(content, isMarkdown) { mutableStateOf(false) }
     val alpha by animateFloatAsState(
         targetValue = if (loaded) 1f else 0f,
@@ -41,14 +42,14 @@ fun MarkdownContent(
         animationSpec = tween(durationMillis = 150),
         label = "MarkdownContentPlaceholderAlpha",
     )
-    val containerColor = when (LocalUiMode.current) {
+    val containerColor = when (uiMode) {
         UiMode.Material -> MaterialTheme.colorScheme.surfaceContainerHigh
         UiMode.Miuix -> null
     }
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .animateContentSize(animationSpec = tween(durationMillis = 300))
+            .let { if (uiMode == UiMode.Miuix) it.animateContentSize(animationSpec = tween(durationMillis = 300)) else it }
     ) {
         Box(
             modifier = Modifier

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
@@ -65,7 +65,7 @@ fun SearchAppBar(
     searchText: String,
     onSearchTextChange: (String) -> Unit,
     onClearClick: () -> Unit,
-    snackbarHostState: SnackbarHostState = LocalSnackbarHost.current,
+    snackbarHostState: SnackbarHostState,
     navigationIcon: @Composable (() -> Unit)? = null,
     actions: @Composable (() -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
@@ -225,7 +225,7 @@ fun SearchAppBar(
                     defaultContent(bottomPadding, collapseAndClear)
                 }
                 SnackBarHost(
-                    hostState = snackBarHostState,
+                    hostState = snackbarHostState,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .navigationBarsPadding()

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
@@ -56,8 +56,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -225,7 +223,7 @@ fun SearchAppBar(
                 } else {
                     defaultContent(bottomPadding, collapseAndClear)
                 }
-                M3SnackBarHost(
+                SnackBarHost(
                     hostState = snackBarHostState,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarValue
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -64,6 +65,7 @@ fun SearchAppBar(
     searchText: String,
     onSearchTextChange: (String) -> Unit,
     onClearClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = LocalSnackbarHost.current,
     navigationIcon: @Composable (() -> Unit)? = null,
     actions: @Composable (() -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior? = null,
@@ -215,7 +217,6 @@ fun SearchAppBar(
             )
         ),
         content = {
-            val snackBarHostState = LocalSnackbarHost.current
             val bottomPadding = SearchBarDefaults.fullScreenWindowInsets.asPaddingValues().calculateBottomPadding()
             Box(modifier = Modifier.fillMaxSize()) {
                 if (currentQuery.isNotEmpty()) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SearchBar.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SearchBarValue
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -57,7 +56,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -225,7 +225,7 @@ fun SearchAppBar(
                 } else {
                     defaultContent(bottomPadding, collapseAndClear)
                 }
-                SnackbarHost(
+                M3SnackBarHost(
                     hostState = snackBarHostState,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
@@ -42,8 +42,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.BuildConfig
 import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.getBugreportFile
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -57,12 +58,14 @@ private tailrec fun Context.findComponentActivity(): ComponentActivity? {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SendLogBottomSheet(onDismiss: () -> Unit) {
+fun SendLogBottomSheet(
+    onDismiss: () -> Unit,
+    snackbarHostState: SnackbarHostState = LocalSnackbarHost.current,
+) {
     val context = LocalContext.current
     val activity = context.findComponentActivity()
     val logSaved = stringResource(R.string.log_saved)
     val sendLog = stringResource(R.string.send_log)
-    val snackBarHost = LocalSnackbarHost.current
     val loadingDialog = rememberLoadingDialog()
     val haptic = LocalHapticFeedback.current
     val sheetState = rememberModalBottomSheetState()
@@ -94,8 +97,8 @@ fun SendLogBottomSheet(onDismiss: () -> Unit) {
                 loadingDialog.hide()
             }
             dismiss()
-            snackBarHost.currentSnackbarData?.dismiss()
-            snackBarHost.showSnackbar(logSaved)
+            snackbarHostState.currentSnackbarData?.dismiss()
+            snackbarHostState.showSnackbar(logSaved)
         }
     }
     ModalBottomSheet(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.BuildConfig
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.util.getBugreportFile
 import java.time.LocalDateTime

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SendLogBottomSheet.kt
@@ -60,7 +60,7 @@ private tailrec fun Context.findComponentActivity(): ComponentActivity? {
 @Composable
 fun SendLogBottomSheet(
     onDismiss: () -> Unit,
-    snackbarHostState: SnackbarHostState = LocalSnackbarHost.current,
+    snackbarHostState: SnackbarHostState,
 ) {
     val context = LocalContext.current
     val activity = context.findComponentActivity()

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SnackBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SnackBar.kt
@@ -1,4 +1,4 @@
-package me.weishu.kernelsu.ui.component
+package me.weishu.kernelsu.ui.component.material
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Animatable
@@ -87,10 +87,10 @@ private fun FadeInFadeOutWithScale(
 }
 
 @Composable
-fun M3SnackBarHost(
+fun SnackBarHost(
     hostState: SnackbarHostState,
     modifier: Modifier = Modifier,
-    snackBar: @Composable (SnackbarData) -> Unit = { M3SnackBar(it) },
+    snackBar: @Composable (SnackbarData) -> Unit = { SnackBar(it) },
 ) {
     val currentSnackBarData = hostState.currentSnackbarData
     val accessibilityManager = LocalAccessibilityManager.current
@@ -132,7 +132,7 @@ private fun SnackbarDuration.toMillis(
 }
 
 @Composable
-fun M3SnackBar(
+fun SnackBar(
     snackBarData: SnackbarData,
     modifier: Modifier = Modifier
 ) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SnackBar.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/material/SnackBar.kt
@@ -1,178 +1,38 @@
 package me.weishu.kernelsu.ui.component.material
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.Easing
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
-import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarData
-import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.AccessibilityManager
-import androidx.compose.ui.platform.LocalAccessibilityManager
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
-
-private const val ANIMATION_DURATION = 450
-private const val ANIMATION_FADE_DURATION = 200
-
-val LocalSnackbarHost = compositionLocalOf<SnackbarHostState> {
-    error("CompositionLocal LocalSnackBarController not present")
-}
-
-class OvershootEasing(private val tension: Float = 2.0f) : Easing {
-    override fun transform(fraction: Float): Float {
-        val t = fraction - 1.0f
-        return t * t * ((tension + 1) * t + tension) + 1.0f
-    }
-}
-
-private fun getSnackBarEnterTransition() = slideInVertically(
-    initialOffsetY = { fullHeight -> fullHeight }, animationSpec = tween(
-        durationMillis = ANIMATION_DURATION, easing = OvershootEasing()
-    )
-) + scaleIn(
-    initialScale = 1.1f, animationSpec = tween(
-        durationMillis = ANIMATION_DURATION, easing = FastOutSlowInEasing
-    )
-) + fadeIn(
-    animationSpec = tween(durationMillis = ANIMATION_FADE_DURATION)
-)
-
-private fun getSnackBarExitTransition() = slideOutVertically(
-    targetOffsetY = { fullHeight -> fullHeight }, animationSpec = tween(durationMillis = ANIMATION_DURATION, easing = FastOutSlowInEasing)
-) + fadeOut(
-    animationSpec = tween(durationMillis = ANIMATION_FADE_DURATION)
-)
-
-
-@Composable
-private fun FadeInFadeOutWithScale(
-    current: SnackbarData?,
-    modifier: Modifier = Modifier,
-    content: @Composable (SnackbarData) -> Unit,
-) {
-    AnimatedContent(
-        targetState = current,
-        transitionSpec = {
-            (getSnackBarEnterTransition() togetherWith getSnackBarExitTransition()).using(sizeTransform = null)
-        },
-        modifier = modifier,
-        label = "breeze_snackbar_animation"
-    ) { data ->
-        if (data != null) {
-            content(data)
-        }
-    }
-}
 
 @Composable
 fun SnackBarHost(
-    hostState: SnackbarHostState,
     modifier: Modifier = Modifier,
-    snackBar: @Composable (SnackbarData) -> Unit = { SnackBar(it) },
+    hostState: SnackbarHostState,
+    snackBar: @Composable (SnackbarData) -> Unit = { Snackbar(it) },
 ) {
-    val currentSnackBarData = hostState.currentSnackbarData
-    val accessibilityManager = LocalAccessibilityManager.current
-    LaunchedEffect(currentSnackBarData) {
-        if (currentSnackBarData != null) {
-            val duration = currentSnackBarData.visuals.duration.toMillis(
-                currentSnackBarData.visuals.actionLabel != null,
-                accessibilityManager,
-            )
-            delay(duration)
-            currentSnackBarData.dismiss()
+    val state = rememberSwipeToDismissBoxState()
+    SwipeToDismissBox(
+        state = state,
+        backgroundContent = {},
+        onDismiss = {
+            hostState.currentSnackbarData?.dismiss()
         }
+    ) {
+        SnackbarHost(
+            modifier = modifier,
+            hostState = hostState,
+            snackbar = snackBar,
+        )
     }
-    FadeInFadeOutWithScale(
-        current = hostState.currentSnackbarData,
-        modifier = modifier,
-        content = snackBar,
-    )
-}
-
-private fun SnackbarDuration.toMillis(
-    hasAction: Boolean,
-    accessibilityManager: AccessibilityManager?,
-): Long {
-    val original = when (this) {
-        SnackbarDuration.Indefinite -> Long.MAX_VALUE
-        SnackbarDuration.Long -> 10000L
-        SnackbarDuration.Short -> 4000L
+    LaunchedEffect(hostState.currentSnackbarData) {
+        if (hostState.currentSnackbarData == null) return@LaunchedEffect
+        state.snapTo(SwipeToDismissBoxValue.Settled)
     }
-    if (accessibilityManager == null) {
-        return original
-    }
-    return accessibilityManager.calculateRecommendedTimeoutMillis(
-        original,
-        containsIcons = true,
-        containsText = true,
-        containsControls = hasAction,
-    )
-}
-
-@Composable
-fun SnackBar(
-    snackBarData: SnackbarData,
-    modifier: Modifier = Modifier
-) {
-    val scope = rememberCoroutineScope()
-    val density = LocalDensity.current
-    val offsetY = remember(snackBarData) { Animatable(0f) }
-    // SingleLineContainerHeight
-    val dismissThresholdPx = remember(density) {
-        with(density) { 48.dp.toPx() }
-    }
-
-    Snackbar(
-        snackbarData = snackBarData,
-        modifier = modifier
-            .offset {
-                IntOffset(0, offsetY.value.roundToInt())
-            }
-            .pointerInput(snackBarData) {
-                detectVerticalDragGestures(
-                    onDragEnd = {
-                        if (offsetY.value > dismissThresholdPx) {
-                            snackBarData.dismiss()
-                        } else {
-                            scope.launch {
-                                offsetY.animateTo(0f)
-                            }
-                        }
-                    },
-                    onDragCancel = {
-                        scope.launch {
-                            offsetY.animateTo(0f)
-                        }
-                    }
-                ) { change, dragAmount ->
-                    change.consume()
-                    val newOffset = (offsetY.value + dragAmount).coerceAtLeast(0f)
-                    scope.launch {
-                        offsetY.snapTo(newOffset)
-                    }
-                }
-            }
-    )
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
@@ -63,11 +63,11 @@ import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.AppIconImage
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.component.profile.AppProfileConfig
 import me.weishu.kernelsu.ui.component.profile.RootProfileConfig
 import me.weishu.kernelsu.ui.component.profile.TemplateConfig
@@ -105,7 +105,7 @@ fun AppProfileScreenMaterial(
                 onRestartApp = actions.onRestartApp,
             )
         },
-        snackbarHost = { M3SnackBarHost(hostState = snackBarHost, modifier = Modifier.safeDrawingPadding()) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost, modifier = Modifier.safeDrawingPadding()) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { paddingValues ->
         AppProfileInner(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -63,7 +64,6 @@ import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.AppIconImage
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
@@ -84,9 +84,9 @@ import me.weishu.kernelsu.ui.viewmodel.SuperUserViewModel
 fun AppProfileScreenMaterial(
     state: AppProfileUiState,
     actions: AppProfileActions,
+    snackBarHost: SnackbarHostState,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
-    val snackBarHost = LocalSnackbarHost.current
 
     LaunchedEffect(Unit) {
         scrollBehavior.state.heightOffset = scrollBehavior.state.heightOffsetLimit

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileMaterial.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -36,7 +37,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -63,6 +63,8 @@ import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.AppIconImage
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
@@ -70,7 +72,6 @@ import me.weishu.kernelsu.ui.component.profile.AppProfileConfig
 import me.weishu.kernelsu.ui.component.profile.RootProfileConfig
 import me.weishu.kernelsu.ui.component.profile.TemplateConfig
 import me.weishu.kernelsu.ui.component.statustag.StatusTag
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.ownerNameForUid
 import me.weishu.kernelsu.ui.viewmodel.SuperUserViewModel
 
@@ -104,7 +105,7 @@ fun AppProfileScreenMaterial(
                 onRestartApp = actions.onRestartApp,
             )
         },
-        snackbarHost = { SnackbarHost(hostState = snackBarHost) },
+        snackbarHost = { M3SnackBarHost(hostState = snackBarHost, modifier = Modifier.safeDrawingPadding()) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { paddingValues ->
         AppProfileInner(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
@@ -19,9 +19,9 @@ import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.forceStopApp
 import me.weishu.kernelsu.ui.util.getSepolicy
 import me.weishu.kernelsu.ui.util.launchApp

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
@@ -1,6 +1,7 @@
 package me.weishu.kernelsu.ui.screen.appprofile
 
 import android.widget.Toast
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -19,7 +20,6 @@ import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.util.forceStopApp
@@ -35,7 +35,7 @@ fun AppProfileScreen(uid: Int) {
     val uiMode = LocalUiMode.current
     val navigator = LocalNavigator.current
     val context = LocalContext.current
-    val snackbarHost = LocalSnackbarHost.current
+    val snackbarHost = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val viewModel: SuperUserViewModel = viewModel()
     val appGroupState = remember(uid) {
@@ -141,6 +141,7 @@ fun AppProfileScreen(uid: Int) {
         UiMode.Material -> AppProfileScreenMaterial(
             state = state,
             actions = actions,
+            snackBarHost = snackbarHost,
         )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/appprofile/AppProfileScreen.kt
@@ -19,7 +19,7 @@ import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.util.forceStopApp

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -49,7 +50,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SnackBarHost
 
 @SuppressLint("LocalContextGetResourceValueCall")
@@ -58,9 +58,9 @@ import me.weishu.kernelsu.ui.component.material.SnackBarHost
 fun ExecuteModuleActionScreenMaterial(
     state: ExecuteModuleActionUiState,
     actions: ExecuteModuleActionScreenActions,
+    snackBarHost: SnackbarHostState,
 ) {
     val scrollState = rememberScrollState()
-    val snackBarHost = LocalSnackbarHost.current
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
     val fabExpanded by remember {
         var previousScroll = 0
@@ -88,7 +88,7 @@ fun ExecuteModuleActionScreenMaterial(
     BackHandler(enabled = !state.isComplete) { }
 
     Scaffold(
-        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.isComplete) it else it.safeDrawingPadding() }) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost, modifier = Modifier.let { if (state.isComplete) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.action)) },

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -48,6 +49,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 
 @SuppressLint("LocalContextGetResourceValueCall")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -57,6 +60,7 @@ fun ExecuteModuleActionScreenMaterial(
     actions: ExecuteModuleActionScreenActions,
 ) {
     val scrollState = rememberScrollState()
+    val snackBarHost = LocalSnackbarHost.current
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
     val fabExpanded by remember {
         var previousScroll = 0
@@ -84,6 +88,7 @@ fun ExecuteModuleActionScreenMaterial(
     BackHandler(enabled = !state.isComplete) { }
 
     Scaffold(
+        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.isComplete) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.action)) },

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionMaterial.kt
@@ -49,8 +49,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 
 @SuppressLint("LocalContextGetResourceValueCall")
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -88,7 +88,7 @@ fun ExecuteModuleActionScreenMaterial(
     BackHandler(enabled = !state.isComplete) { }
 
     Scaffold(
-        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.isComplete) it else it.safeDrawingPadding() }) },
+        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.isComplete) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.action)) },

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.compose.dropUnlessResumed
 import kotlinx.coroutines.launch
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 
 @Composable

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
@@ -1,5 +1,6 @@
 package me.weishu.kernelsu.ui.screen.executemoduleaction
 
+import android.widget.Toast
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -11,8 +12,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.dropUnlessResumed
+import kotlinx.coroutines.launch
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 
 @Composable
@@ -24,12 +27,23 @@ fun ExecuteModuleActionScreen(moduleId: String, fromShortcut: Boolean = false) {
     var text by rememberSaveable { mutableStateOf("") }
     val logContent = remember { StringBuilder() }
     var isComplete by rememberSaveable { mutableStateOf(false) }
-
+    val uiMode = LocalUiMode.current
+    val snackbarHost = LocalSnackbarHost.current
     val exitExecute = {
         if (fromShortcut && activity != null) {
             activity.finishAndRemoveTask()
         } else {
             navigator.pop()
+        }
+    }
+
+    fun showMessage(message: String) {
+        scope.launch {
+            if (uiMode == UiMode.Material) {
+                snackbarHost.showSnackbar(message)
+            } else {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
         }
     }
 
@@ -58,11 +72,11 @@ fun ExecuteModuleActionScreen(moduleId: String, fromShortcut: Boolean = false) {
     )
     val actions = ExecuteModuleActionScreenActions(
         onBack = dropUnlessResumed { navigator.pop() },
-        onSaveLog = saveLog(logContent, context, scope),
+        onSaveLog = saveLog(logContent, scope) { showMessage(it) },
         onClose = exitExecute,
     )
 
-    when (LocalUiMode.current) {
+    when (uiMode) {
         UiMode.Miuix -> ExecuteModuleActionScreenMiuix(state, actions)
         UiMode.Material -> ExecuteModuleActionScreenMaterial(state, actions)
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionScreen.kt
@@ -2,6 +2,7 @@ package me.weishu.kernelsu.ui.screen.executemoduleaction
 
 import android.widget.Toast
 import androidx.activity.compose.LocalActivity
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,7 +16,6 @@ import androidx.lifecycle.compose.dropUnlessResumed
 import kotlinx.coroutines.launch
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 
 @Composable
@@ -28,7 +28,7 @@ fun ExecuteModuleActionScreen(moduleId: String, fromShortcut: Boolean = false) {
     val logContent = remember { StringBuilder() }
     var isComplete by rememberSaveable { mutableStateOf(false) }
     val uiMode = LocalUiMode.current
-    val snackbarHost = LocalSnackbarHost.current
+    val snackbarHost = remember { SnackbarHostState() }
     val exitExecute = {
         if (fromShortcut && activity != null) {
             activity.finishAndRemoveTask()
@@ -78,6 +78,6 @@ fun ExecuteModuleActionScreen(moduleId: String, fromShortcut: Boolean = false) {
 
     when (uiMode) {
         UiMode.Miuix -> ExecuteModuleActionScreenMiuix(state, actions)
-        UiMode.Material -> ExecuteModuleActionScreenMaterial(state, actions)
+        UiMode.Material -> ExecuteModuleActionScreenMaterial(state, actions, snackbarHost)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionUtils.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/executemoduleaction/ExecuteModuleActionUtils.kt
@@ -1,6 +1,5 @@
 package me.weishu.kernelsu.ui.screen.executemoduleaction
 
-import android.content.Context
 import android.os.Environment
 import android.os.Handler
 import android.os.Looper
@@ -95,8 +94,8 @@ fun ExecuteModuleActionEffect(
 
 fun saveLog(
     logContent: StringBuilder,
-    context: Context,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    showMessage: (String) -> Unit
 ): () -> Unit {
     return {
         scope.launch {
@@ -107,7 +106,7 @@ fun saveLog(
                 "KernelSU_module_action_log_${date}.log"
             )
             file.writeText(logContent.toString())
-            Toast.makeText(context, "Log saved to ${file.absolutePath}", Toast.LENGTH_SHORT).show()
+            showMessage("Log saved to ${file.absolutePath}")
         }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
@@ -42,8 +42,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -61,7 +61,7 @@ fun FlashScreenMaterial(
     }
 
     Scaffold(
-        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.showRebootAction) it else it.safeDrawingPadding() }) },
+        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.showRebootAction) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -42,7 +43,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SnackBarHost
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -50,8 +50,8 @@ import me.weishu.kernelsu.ui.component.material.SnackBarHost
 fun FlashScreenMaterial(
     state: FlashUiState,
     actions: FlashScreenActions,
+    snackBarHost: SnackbarHostState,
 ) {
-    val snackBarHost = LocalSnackbarHost.current
     val scrollState = rememberScrollState()
     if (state.showJailbreakWarning) {
         JailbreakFlashWarningDialog(
@@ -61,7 +61,7 @@ fun FlashScreenMaterial(
     }
 
     Scaffold(
-        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.showRebootAction) it else it.safeDrawingPadding() }) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost, modifier = Modifier.let { if (state.showRebootAction) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashMaterial.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -41,6 +42,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.KeyEventBlocker
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -48,6 +51,7 @@ fun FlashScreenMaterial(
     state: FlashUiState,
     actions: FlashScreenActions,
 ) {
+    val snackBarHost = LocalSnackbarHost.current
     val scrollState = rememberScrollState()
     if (state.showJailbreakWarning) {
         JailbreakFlashWarningDialog(
@@ -57,6 +61,7 @@ fun FlashScreenMaterial(
     }
 
     Scaffold(
+        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.let { if (state.showRebootAction) it else it.safeDrawingPadding() }) },
         topBar = {
             TopAppBar(
                 title = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
@@ -1,5 +1,6 @@
 package me.weishu.kernelsu.ui.screen.flash
 
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,6 +16,7 @@ import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.util.reboot
 
@@ -29,6 +31,18 @@ fun FlashScreen(flashIt: FlashIt) {
     var flashingStatus by rememberSaveable { mutableStateOf(FlashingStatus.FLASHING) }
     val needJailbreakWarning = flashIt is FlashIt.FlashBoot && Natives.isLateLoadMode
     var flashingEnabled by rememberSaveable { mutableStateOf(!needJailbreakWarning) }
+    val uiMode = LocalUiMode.current
+    val snackbarHost = LocalSnackbarHost.current
+
+    fun showMessage(message: String) {
+        scope.launch {
+            if (uiMode == UiMode.Material) {
+                snackbarHost.showSnackbar(message)
+            } else {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 
     FlashEffect(
         flashIt = flashIt,
@@ -48,7 +62,7 @@ fun FlashScreen(flashIt: FlashIt) {
     )
     val actions = FlashScreenActions(
         onBack = dropUnlessResumed { navigator.pop() },
-        onSaveLog = saveLog(logContent, context, scope),
+        onSaveLog = saveLog(logContent, scope) { showMessage(it) },
         onReboot = {
             scope.launch {
                 withContext(Dispatchers.IO) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
@@ -1,6 +1,7 @@
 package me.weishu.kernelsu.ui.screen.flash
 
 import android.widget.Toast
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,7 +17,6 @@ import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.util.reboot
 
@@ -32,7 +32,7 @@ fun FlashScreen(flashIt: FlashIt) {
     val needJailbreakWarning = flashIt is FlashIt.FlashBoot && Natives.isLateLoadMode
     var flashingEnabled by rememberSaveable { mutableStateOf(!needJailbreakWarning) }
     val uiMode = LocalUiMode.current
-    val snackbarHost = LocalSnackbarHost.current
+    val snackbarHost = remember { SnackbarHostState() }
 
     fun showMessage(message: String) {
         scope.launch {
@@ -76,6 +76,6 @@ fun FlashScreen(flashIt: FlashIt) {
 
     when (LocalUiMode.current) {
         UiMode.Miuix -> FlashScreenMiuix(state, actions)
-        UiMode.Material -> FlashScreenMaterial(state, actions)
+        UiMode.Material -> FlashScreenMaterial(state, actions, snackbarHost)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashScreen.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.Natives
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.util.reboot
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashUtils.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/flash/FlashUtils.kt
@@ -1,12 +1,10 @@
 package me.weishu.kernelsu.ui.screen.flash
 
-import android.content.Context
 import android.net.Uri
 import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.os.Parcelable
-import android.widget.Toast
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Adb
 import androidx.compose.material.icons.rounded.DeleteForever
@@ -184,8 +182,8 @@ fun FlashEffect(
 
 fun saveLog(
     logContent: StringBuilder,
-    context: Context,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    showMessage: (String) -> Unit
 ): () -> Unit {
     return {
         scope.launch {
@@ -196,7 +194,7 @@ fun saveLog(
                 "KernelSU_install_log_${date}.log"
             )
             file.writeText(logContent.toString())
-            Toast.makeText(context, "Log saved to ${file.absolutePath}", Toast.LENGTH_SHORT).show()
+            showMessage("Log saved to ${file.absolutePath}")
         }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -44,6 +45,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.material.SegmentedCheckboxItem
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
@@ -62,6 +65,7 @@ internal fun InstallScreenMaterial(
     actions: InstallScreenActions,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+    val snackBarHost = LocalSnackbarHost.current
 
     LaunchedEffect(Unit) {
         scrollBehavior.state.heightOffset = scrollBehavior.state.heightOffsetLimit
@@ -74,6 +78,7 @@ internal fun InstallScreenMaterial(
                 scrollBehavior = scrollBehavior,
             )
         },
+        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.safeDrawingPadding()) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
@@ -45,14 +45,14 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedCheckboxItem
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedDropdownItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedRadioItem
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.util.LkmSelection
 
 /**
@@ -78,7 +78,7 @@ internal fun InstallScreenMaterial(
                 scrollBehavior = scrollBehavior,
             )
         },
-        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.safeDrawingPadding()) },
+        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.safeDrawingPadding()) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallMaterial.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -46,7 +47,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedCheckboxItem
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedDropdownItem
@@ -63,9 +63,9 @@ import me.weishu.kernelsu.ui.util.LkmSelection
 internal fun InstallScreenMaterial(
     uiState: InstallUiState,
     actions: InstallScreenActions,
+    snackBarHost: SnackbarHostState,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
-    val snackBarHost = LocalSnackbarHost.current
 
     LaunchedEffect(Unit) {
         scrollBehavior.state.heightOffset = scrollBehavior.state.heightOffsetLimit
@@ -78,7 +78,7 @@ internal fun InstallScreenMaterial(
                 scrollBehavior = scrollBehavior,
             )
         },
-        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.safeDrawingPadding()) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost, modifier = Modifier.safeDrawingPadding()) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { innerPadding ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
@@ -12,15 +12,19 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.dropUnlessResumed
+import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.getKernelVersion
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.choosekmidialog.ChooseKmiDialog
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
@@ -37,6 +41,10 @@ import me.weishu.kernelsu.ui.util.rootAvailable
 fun InstallScreen() {
     val navigator = LocalNavigator.current
     val context = LocalContext.current
+    val snackbarHost = LocalSnackbarHost.current
+    val uiMode = LocalUiMode.current
+    val scope = rememberCoroutineScope()
+    val resources = LocalResources.current
 
     var installMethod by rememberSaveable { mutableStateOf<InstallMethod?>(null) }
     var lkmSelection by rememberSaveable { mutableStateOf<LkmSelection>(LkmSelection.KmiNone) }
@@ -85,6 +93,16 @@ fun InstallScreen() {
         partitions.map { name -> if (defaultPartition == name) "$name (default)" else name }
     }
 
+    fun showMessage(message: String) {
+        scope.launch {
+            if (uiMode == UiMode.Material) {
+                snackbarHost.showSnackbar(message)
+            } else {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     val onInstall = {
         installMethod?.let { method ->
             navigator.push(
@@ -122,7 +140,7 @@ fun InstallScreen() {
                     lkmSelection = LkmSelection.LkmUri(uri)
                 } else {
                     lkmSelection = LkmSelection.KmiNone
-                    Toast.makeText(context, R.string.install_only_support_ko_file, Toast.LENGTH_SHORT).show()
+                    showMessage(resources.getString(R.string.install_only_support_ko_file))
                 }
             }
         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
@@ -24,8 +24,8 @@ import me.weishu.kernelsu.R
 import me.weishu.kernelsu.getKernelVersion
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.choosekmidialog.ChooseKmiDialog
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.screen.flash.FlashIt

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/install/InstallScreen.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,7 +26,6 @@ import me.weishu.kernelsu.getKernelVersion
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.choosekmidialog.ChooseKmiDialog
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.screen.flash.FlashIt
@@ -41,7 +41,7 @@ import me.weishu.kernelsu.ui.util.rootAvailable
 fun InstallScreen() {
     val navigator = LocalNavigator.current
     val context = LocalContext.current
-    val snackbarHost = LocalSnackbarHost.current
+    val snackbarHost = remember { SnackbarHostState() }
     val uiMode = LocalUiMode.current
     val scope = rememberCoroutineScope()
     val resources = LocalResources.current
@@ -205,6 +205,6 @@ fun InstallScreen() {
 
     when (LocalUiMode.current) {
         UiMode.Miuix -> InstallScreenMiuix(state, actions)
-        UiMode.Material -> InstallScreenMaterial(state, actions)
+        UiMode.Material -> InstallScreenMaterial(state, actions, snackbarHost)
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
@@ -78,7 +78,6 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -126,6 +125,8 @@ import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.Module
 import me.weishu.kernelsu.data.model.ModuleUpdateInfo
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.component.material.ExpressiveSwitch
@@ -133,7 +134,6 @@ import me.weishu.kernelsu.ui.component.material.SearchAppBar
 import me.weishu.kernelsu.ui.component.material.TonalCard
 import me.weishu.kernelsu.ui.component.rebootlistpopup.RebootListPopup
 import me.weishu.kernelsu.ui.component.statustag.StatusTag
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 import me.weishu.kernelsu.ui.util.reboot
 
 @SuppressLint("StringFormatInvalid")
@@ -373,7 +373,7 @@ fun ModulePagerMaterial(
             }
         },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
-        snackbarHost = { SnackbarHost(hostState = snackBarHost) }
+        snackbarHost = { M3SnackBarHost(hostState = snackBarHost) }
     ) { innerPadding ->
         PullToRefreshBox(
             modifier = Modifier

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
@@ -78,6 +78,7 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -125,7 +126,6 @@ import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.Module
 import me.weishu.kernelsu.data.model.ModuleUpdateInfo
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.component.material.ExpressiveSwitch
@@ -146,7 +146,7 @@ fun ModulePagerMaterial(
     actions: ModuleActions,
     bottomInnerPadding: Dp,
 ) {
-    val snackBarHost = LocalSnackbarHost.current
+    val snackBarHost = remember { SnackbarHostState() }
     val haptic = LocalHapticFeedback.current
 
     val context = LocalContext.current
@@ -264,6 +264,7 @@ fun ModulePagerMaterial(
                 searchText = uiState.searchStatus.searchText,
                 onSearchTextChange = actions.onSearchTextChange,
                 onClearClick = actions.onClearSearch,
+                snackbarHostState = snackBarHost,
                 navigationIcon = {
                     IconButton(
                         onClick = { actions.onOpenRepo() }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
@@ -126,11 +126,11 @@ import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.Module
 import me.weishu.kernelsu.data.model.ModuleUpdateInfo
 import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.component.material.ExpressiveSwitch
 import me.weishu.kernelsu.ui.component.material.SearchAppBar
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.component.material.TonalCard
 import me.weishu.kernelsu.ui.component.rebootlistpopup.RebootListPopup
 import me.weishu.kernelsu.ui.component.statustag.StatusTag
@@ -373,7 +373,7 @@ fun ModulePagerMaterial(
             }
         },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
-        snackbarHost = { M3SnackBarHost(hostState = snackBarHost) }
+        snackbarHost = { SnackBarHost(hostState = snackBarHost) }
     ) { innerPadding ->
         PullToRefreshBox(
             modifier = Modifier

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
@@ -66,6 +66,7 @@ import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -123,10 +124,12 @@ fun ModuleRepoScreenMaterial(
     val searchListState = rememberLazyListState()
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
+    val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
         topBar = {
             SearchAppBar(
+                snackbarHostState = snackbarHostState,
                 title = { Text(text = stringResource(R.string.module_repos)) },
                 searchText = state.searchStatus.searchText,
                 onSearchTextChange = actions.onSearchTextChange,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
@@ -99,9 +99,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.RepoModule
-import me.weishu.kernelsu.ui.component.markdown.GithubMarkdown
 import me.weishu.kernelsu.ui.component.dialog.ConfirmDialogHandle
 import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
+import me.weishu.kernelsu.ui.component.markdown.GithubMarkdown
 import me.weishu.kernelsu.ui.component.material.SearchAppBar
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
@@ -84,7 +84,7 @@ fun SettingPagerMaterial(
         topBar = {
             TopBar(scrollBehavior = scrollBehavior)
         },
-        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.padding(bottom = bottomInnerPadding)) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost, modifier = Modifier.padding(bottom = bottomInnerPadding)) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { paddingValues ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -52,13 +51,14 @@ import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.KsuIsValid
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedDropdownItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
 import me.weishu.kernelsu.ui.component.material.SendLogBottomSheet
 import me.weishu.kernelsu.ui.component.uninstalldialog.UninstallDialog
-import me.weishu.kernelsu.ui.util.LocalSnackbarHost
 
 /**
  * @author weishu
@@ -84,7 +84,7 @@ fun SettingPagerMaterial(
         topBar = {
             TopBar(scrollBehavior = scrollBehavior)
         },
-        snackbarHost = { SnackbarHost(snackBarHost) },
+        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.padding(bottom = bottomInnerPadding)) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { paddingValues ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
@@ -52,12 +52,12 @@ import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.KsuIsValid
 import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedDropdownItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
 import me.weishu.kernelsu.ui.component.material.SendLogBottomSheet
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.component.uninstalldialog.UninstallDialog
 
 /**
@@ -84,7 +84,7 @@ fun SettingPagerMaterial(
         topBar = {
             TopBar(scrollBehavior = scrollBehavior)
         },
-        snackbarHost = { M3SnackBarHost(snackBarHost, modifier = Modifier.padding(bottom = bottomInnerPadding)) },
+        snackbarHost = { SnackBarHost(snackBarHost, modifier = Modifier.padding(bottom = bottomInnerPadding)) },
         contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
     ) { paddingValues ->
         Column(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -51,7 +52,6 @@ import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.KsuIsValid
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedColumn
 import me.weishu.kernelsu.ui.component.material.SegmentedDropdownItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
@@ -71,7 +71,7 @@ fun SettingPagerMaterial(
     bottomInnerPadding: Dp,
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
-    val snackBarHost = LocalSnackbarHost.current
+    val snackBarHost = remember { SnackbarHostState() }
     val showUninstallDialog = rememberSaveable { mutableStateOf(false) }
     var showBottomSheet by remember { mutableStateOf(false) }
 
@@ -344,7 +344,10 @@ fun SettingPagerMaterial(
             Spacer(modifier = Modifier.height(8.dp))
 
             if (showBottomSheet) {
-                SendLogBottomSheet { showBottomSheet = false }
+                SendLogBottomSheet(
+                    onDismiss = { showBottomSheet = false },
+                    snackbarHostState = snackBarHost,
+                )
             }
             Spacer(modifier = Modifier.height(bottomInnerPadding))
         }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMaterial.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
@@ -105,9 +106,12 @@ fun SulogScreenMaterial(
         )
     }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+
     Scaffold(
         topBar = {
             SearchAppBar(
+                snackbarHostState = snackbarHostState,
                 title = { Text(stringResource(R.string.settings_sulog)) },
                 searchText = localSearchText,
                 onSearchTextChange = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserMaterial.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -87,10 +88,12 @@ fun SuperUserPagerMaterial(
     }
 
     val haptic = LocalHapticFeedback.current
+    val snackbarHostState = remember { SnackbarHostState() }
 
     Scaffold(
         topBar = {
             SearchAppBar(
+                snackbarHostState = snackbarHostState,
                 title = { Text(stringResource(R.string.superuser)) },
                 searchText = localSearchText,
                 onSearchTextChange = {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
@@ -60,10 +60,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.TemplateInfo
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
-import me.weishu.kernelsu.ui.component.M3SnackBarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
+import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.component.statustag.StatusTag
 
 /**
@@ -128,7 +128,7 @@ fun AppProfileTemplateScreenMaterial(
                 scrollBehavior = scrollBehavior
             )
         },
-        snackbarHost = { M3SnackBarHost(snackBarHost) },
+        snackbarHost = { SnackBarHost(snackBarHost) },
         floatingActionButton = {
             SmallExtendedFloatingActionButton(
                 expanded = fabExpanded,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
@@ -60,6 +60,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.TemplateInfo
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.M3SnackBarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.statustag.StatusTag
@@ -80,6 +82,7 @@ fun AppProfileTemplateScreenMaterial(
     val pullToRefreshState = rememberPullToRefreshState()
     val listState = rememberLazyListState()
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
+    val snackBarHost = LocalSnackbarHost.current
     val fabExpanded by remember {
         var lastIndex = 0
         var lastOffset = 0
@@ -125,6 +128,7 @@ fun AppProfileTemplateScreenMaterial(
                 scrollBehavior = scrollBehavior
             )
         },
+        snackbarHost = { M3SnackBarHost(snackBarHost) },
         floatingActionButton = {
             SmallExtendedFloatingActionButton(
                 expanded = fabExpanded,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -60,7 +61,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.model.TemplateInfo
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.component.material.SegmentedItem
 import me.weishu.kernelsu.ui.component.material.SegmentedListItem
 import me.weishu.kernelsu.ui.component.material.SnackBarHost
@@ -76,13 +76,13 @@ import me.weishu.kernelsu.ui.component.statustag.StatusTag
 fun AppProfileTemplateScreenMaterial(
     state: TemplateUiState,
     actions: TemplateActions,
+    snackBarHost: SnackbarHostState,
 ) {
     val haptic = LocalHapticFeedback.current
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(rememberTopAppBarState())
     val pullToRefreshState = rememberPullToRefreshState()
     val listState = rememberLazyListState()
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
-    val snackBarHost = LocalSnackbarHost.current
     val fabExpanded by remember {
         var lastIndex = 0
         var lastOffset = 0
@@ -128,7 +128,7 @@ fun AppProfileTemplateScreenMaterial(
                 scrollBehavior = scrollBehavior
             )
         },
-        snackbarHost = { SnackBarHost(snackBarHost) },
+        snackbarHost = { SnackBarHost(hostState = snackBarHost) },
         floatingActionButton = {
             SmallExtendedFloatingActionButton(
                 expanded = fabExpanded,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
@@ -13,11 +13,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.lifecycle.viewmodel.compose.viewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
+import me.weishu.kernelsu.ui.component.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.util.isNetworkAvailable
@@ -33,6 +33,7 @@ fun AppProfileTemplateScreen() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val requestKey = "template_edit"
+    val snackBarHost = LocalSnackbarHost.current
 
     LaunchedEffect(Unit) {
         if (screenState.templateList.isEmpty()) {
@@ -55,9 +56,13 @@ fun AppProfileTemplateScreen() {
     val importSuccessText = stringResource(R.string.app_profile_template_import_success)
     val exportEmptyText = stringResource(R.string.app_profile_template_export_empty)
 
-    val showToast: (String) -> Unit = { message ->
-        scope.launch(Dispatchers.Main) {
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    fun showMessage(message: String) {
+        scope.launch {
+            if (uiMode == UiMode.Material) {
+                snackBarHost.showSnackbar(message)
+            } else {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            }
         }
     }
 
@@ -73,16 +78,16 @@ fun AppProfileTemplateScreen() {
             scope.launch {
                 clipboard.getClipEntry()?.clipData?.getItemAt(0)?.text?.toString()?.let { templateText ->
                     if (templateText.isEmpty()) {
-                        showToast(importEmptyText)
+                        showMessage(importEmptyText)
                         return@let
                     }
                     viewModel.importTemplates(
                         templateText,
                         onSuccess = {
-                            showToast(importSuccessText)
+                            showMessage(importSuccessText)
                             viewModel.fetchTemplates(false)
                         },
-                        onFailure = showToast,
+                        onFailure = { showMessage(it) },
                     )
                 }
             }
@@ -91,7 +96,7 @@ fun AppProfileTemplateScreen() {
             scope.launch {
                 viewModel.exportTemplates(
                     onTemplateEmpty = {
-                        showToast(exportEmptyText)
+                        showMessage(exportEmptyText)
                     },
                     callback = { templateText ->
                         clipboard.setClipEntry(

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.LocalSnackbarHost
+import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.util.isNetworkAvailable

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateScreen.kt
@@ -2,9 +2,11 @@ package me.weishu.kernelsu.ui.screen.template
 
 import android.content.ClipData
 import android.widget.Toast
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
@@ -17,7 +19,6 @@ import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
-import me.weishu.kernelsu.ui.component.material.LocalSnackbarHost
 import me.weishu.kernelsu.ui.navigation3.LocalNavigator
 import me.weishu.kernelsu.ui.navigation3.Route
 import me.weishu.kernelsu.ui.util.isNetworkAvailable
@@ -33,7 +34,7 @@ fun AppProfileTemplateScreen() {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val requestKey = "template_edit"
-    val snackBarHost = LocalSnackbarHost.current
+    val snackBarHost = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         if (screenState.templateList.isEmpty()) {
@@ -141,6 +142,7 @@ fun AppProfileTemplateScreen() {
         UiMode.Material -> AppProfileTemplateScreenMaterial(
             state = uiState,
             actions = actions,
+            snackBarHost = snackBarHost,
         )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/CompositionProvider.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/CompositionProvider.kt
@@ -1,8 +1,0 @@
-package me.weishu.kernelsu.ui.util
-
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.compositionLocalOf
-
-val LocalSnackbarHost = compositionLocalOf<SnackbarHostState> {
-    error("CompositionLocal LocalSnackbarHost not present")
-}


### PR DESCRIPTION
- Add M3SnackBarHost with slide-in overshoot animation and swipe-down-to-dismiss gesture, replacing the standard SnackbarHost across all Material screens.
- Unify message display: Material UI uses the new SnackBar, Miuix UI falls back to Toast.
- Fix animateContentSize in MarkdownContent breaking Material dialog animations by only applying it in Miuix mode.