### PR TITLE
manager:支持设置启动管理器时验证身份

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepository.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepository.kt
@@ -16,6 +16,7 @@ interface SettingsRepository {
     var pageScale: Float
     var enableWebDebugging: Boolean
     var autoJailbreak: Boolean
+    var launchVerify: Boolean
 
     suspend fun getSuCompatStatus(): String
     suspend fun getSuCompatPersistValue(): Long?

--- a/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepositoryImpl.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/data/repository/SettingsRepositoryImpl.kt
@@ -74,6 +74,10 @@ class SettingsRepositoryImpl : SettingsRepository {
         get() = prefs.getFloat("page_scale", 1.0f)
         set(value) = prefs.edit { putFloat("page_scale", value) }
 
+    override var launchVerify: Boolean
+        get() = prefs.getBoolean("launch_verify", false)
+        set(value) = prefs.edit { putBoolean("launch_verify", value) }
+
     override var enableWebDebugging: Boolean
         get() = prefs.getBoolean("enable_web_debugging", false)
         set(value) = prefs.edit { putBoolean("enable_web_debugging", value) }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/MainActivity.kt
@@ -87,11 +87,15 @@ import me.weishu.kernelsu.ui.theme.LocalColorMode
 import me.weishu.kernelsu.ui.theme.LocalEnableBlur
 import me.weishu.kernelsu.ui.theme.LocalEnableFloatingBottomBar
 import me.weishu.kernelsu.ui.theme.LocalEnableFloatingBottomBarBlur
+import me.weishu.kernelsu.ui.util.BiometricBlockingDialogMaterial
+import me.weishu.kernelsu.ui.util.BiometricBlockingDialogMiuix
 import me.weishu.kernelsu.ui.util.getFileName
 import me.weishu.kernelsu.ui.util.install
+import me.weishu.kernelsu.ui.util.isSupportBiometric
 import me.weishu.kernelsu.ui.util.rememberBlurBackdrop
 import me.weishu.kernelsu.ui.util.rememberContentReady
 import me.weishu.kernelsu.ui.util.rootAvailable
+import me.weishu.kernelsu.ui.util.startBiometric
 import me.weishu.kernelsu.ui.viewmodel.MainActivityViewModel
 import me.weishu.kernelsu.ui.viewmodel.MainPagerConfig
 import me.weishu.kernelsu.ui.webui.WebUIActivity
@@ -204,6 +208,39 @@ class MainActivity : ComponentActivity() {
                     when (uiMode) {
                         UiMode.Material -> androidx.compose.material3.Scaffold { navDisplay() }
                         UiMode.Miuix -> Scaffold { navDisplay() }
+                    }
+                    val context= LocalActivity.current!!
+                    if (!viewModel.isLaunchVerified and appSettings.launchVerify and isSupportBiometric(context)) {
+                        var showDialog by remember { mutableStateOf(true) }
+                        if (uiMode == UiMode.Material){
+                            BiometricBlockingDialogMaterial(
+                                startVerify = {
+                                    startBiometric(context){
+                                        if (it) {
+                                            showDialog = false
+                                            viewModel.isLaunchVerified = true
+                                        }else{
+                                            Toast.makeText(context, R.string.biometric_verify_failed, Toast.LENGTH_LONG).show()
+                                        }
+                                    }
+                                },
+                                show = showDialog
+                            )
+                        }else{
+                            BiometricBlockingDialogMiuix(
+                                startVerify = {
+                                    startBiometric(context){
+                                        if (it) {
+                                            showDialog = false
+                                            viewModel.isLaunchVerified = true
+                                        }else{
+                                            Toast.makeText(context, R.string.biometric_verify_failed, Toast.LENGTH_LONG).show()
+                                        }
+                                    }
+                                },
+                                show = showDialog
+                            )
+                        }
                     }
                 }
             }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMaterial.kt
@@ -1,5 +1,8 @@
 package me.weishu.kernelsu.ui.screen.settings
 
+import android.app.Activity
+import android.widget.Toast
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -20,6 +23,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeveloperMode
 import androidx.compose.material.icons.filled.ElectricalServices
 import androidx.compose.material.icons.filled.Fence
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.FolderDelete
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Policy
@@ -59,6 +63,8 @@ import me.weishu.kernelsu.ui.component.material.SegmentedSwitchItem
 import me.weishu.kernelsu.ui.component.material.SendLogBottomSheet
 import me.weishu.kernelsu.ui.component.material.SnackBarHost
 import me.weishu.kernelsu.ui.component.uninstalldialog.UninstallDialog
+import me.weishu.kernelsu.ui.util.isSupportBiometric
+import me.weishu.kernelsu.ui.util.startBiometric
 
 /**
  * @author weishu
@@ -177,7 +183,8 @@ fun SettingPagerMaterial(
                     stringResource(id = R.string.settings_mode_disable_until_reboot),
                     stringResource(id = R.string.settings_mode_disable_always),
                 )
-
+                val activityContext: Activity = LocalActivity.current!!
+                val supportBiometric=isSupportBiometric(activityContext)
                 SegmentedColumn(
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     content = listOf(
@@ -289,6 +296,26 @@ fun SettingPagerMaterial(
                                 enabled = uiState.isLateLoadMode,
                                 checked = uiState.autoJailbreak,
                                 onCheckedChange = actions.onSetAutoJailbreak
+                            )
+                        },
+                        {
+                            SegmentedSwitchItem(
+                                icon = Icons.Filled.Fingerprint,
+                                title = stringResource(id = R.string.settings_launch_verify),
+                                summary = stringResource(id = if(supportBiometric)R.string.settings_launch_verify_summary else R.string.settings_launch_verify_not_supported),
+                                enabled = supportBiometric,
+                                checked = uiState.launchVerify,
+                                onCheckedChange = { value ->
+                                    run {
+                                        startBiometric(activityContext){
+                                            if(it){
+                                                actions.onSetLaunchVerify(value)
+                                            }else{
+                                                Toast.makeText(activityContext, R.string.biometric_verify_failed, Toast.LENGTH_LONG).show()
+                                            }
+                                        }
+                                    }
+                                }
                             )
                         }
                     )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsMiuix.kt
@@ -1,5 +1,8 @@
 package me.weishu.kernelsu.ui.screen.settings
 
+import android.app.Activity
+import android.widget.Toast
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -23,6 +26,7 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DeveloperMode
 import androidx.compose.material.icons.rounded.ElectricalServices
 import androidx.compose.material.icons.rounded.Fence
+import androidx.compose.material.icons.rounded.Fingerprint
 import androidx.compose.material.icons.rounded.FolderDelete
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Policy
@@ -47,7 +51,9 @@ import me.weishu.kernelsu.ui.component.miuix.SendLogDialog
 import me.weishu.kernelsu.ui.component.uninstalldialog.UninstallDialog
 import me.weishu.kernelsu.ui.theme.LocalEnableBlur
 import me.weishu.kernelsu.ui.util.BlurredBar
+import me.weishu.kernelsu.ui.util.isSupportBiometric
 import me.weishu.kernelsu.ui.util.rememberBlurBackdrop
+import me.weishu.kernelsu.ui.util.startBiometric
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.Icon
 import top.yukonga.miuix.kmp.basic.MiuixScrollBehavior
@@ -324,6 +330,8 @@ fun SettingPagerMiuix(
                                 .padding(top = 12.dp)
                                 .fillMaxWidth(),
                         ) {
+                            val activityContext: Activity = LocalActivity.current!!
+                            val supportBiometric=isSupportBiometric(activityContext)
                             SwitchPreference(
                                 title = stringResource(id = R.string.settings_umount_modules_default),
                                 summary = stringResource(id = R.string.settings_umount_modules_default_summary),
@@ -367,6 +375,31 @@ fun SettingPagerMiuix(
                                 enabled = uiState.isLateLoadMode,
                                 checked = uiState.autoJailbreak,
                                 onCheckedChange = actions.onSetAutoJailbreak
+                            )
+                            SwitchPreference(
+                                title = stringResource(id = R.string.settings_launch_verify),
+                                summary = stringResource(id = if(supportBiometric)R.string.settings_launch_verify_summary else R.string.settings_launch_verify_not_supported),
+                                startAction = {
+                                    Icon(
+                                        Icons.Rounded.Fingerprint,
+                                        modifier = Modifier.padding(end = 6.dp),
+                                        contentDescription = stringResource(id = R.string.settings_launch_verify),
+                                        tint = if (supportBiometric) colorScheme.onBackground else colorScheme.disabledOnSecondaryVariant
+                                    )
+                                },
+                                enabled = supportBiometric,
+                                checked = uiState.launchVerify,
+                                onCheckedChange = { value ->
+                                    run {
+                                        startBiometric(activityContext){
+                                            if(it){
+                                                actions.onSetLaunchVerify(value)
+                                            }else{
+                                                Toast.makeText(activityContext, R.string.biometric_verify_failed, Toast.LENGTH_LONG).show()
+                                            }
+                                        }
+                                    }
+                                }
                             )
                         }
                     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsScreen.kt
@@ -41,6 +41,7 @@ fun SettingPager(
         onSetDefaultUmountModules = viewModel::setDefaultUmountModules,
         onSetEnableWebDebugging = viewModel::setEnableWebDebugging,
         onSetAutoJailbreak = viewModel::setAutoJailbreak,
+        onSetLaunchVerify = viewModel::setLaunchVerify,
         onOpenAbout = { navigator.push(Route.About) },
     )
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/settings/SettingsUiState.kt
@@ -50,7 +50,9 @@ data class SettingsUiState(
     val isLateLoadMode: Boolean = false,
 
     // Auto Jailbreak
-    val autoJailbreak: Boolean = false
+    val autoJailbreak: Boolean = false,
+
+    val launchVerify: Boolean = false,
 )
 
 @Immutable
@@ -69,4 +71,5 @@ data class SettingsScreenActions(
     val onSetEnableWebDebugging: (Boolean) -> Unit,
     val onSetAutoJailbreak: (Boolean) -> Unit,
     val onOpenAbout: () -> Unit,
+    val onSetLaunchVerify: (Boolean) -> Unit,
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/Theme.kt
@@ -49,6 +49,7 @@ data class AppSettings(
     val keyColor: Int,
     val paletteStyle: PaletteStyle,
     val colorSpec: ColorSpec.SpecVersion,
+    val launchVerify: Boolean
 )
 
 object ThemeController {
@@ -83,8 +84,8 @@ object ThemeController {
         } catch (_: Exception) {
             ColorSpec.SpecVersion.Default
         }
-
-        return AppSettings(colorMode, keyColor, paletteStyle, colorSpec)
+        val launchVerify = prefs.getBoolean("launch_verify", false)
+        return AppSettings(colorMode, keyColor, paletteStyle, colorSpec,launchVerify)
     }
 }
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/BiometricHelper.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/BiometricHelper.kt
@@ -1,0 +1,145 @@
+package me.weishu.kernelsu.ui.util
+
+import android.app.Activity
+import android.hardware.biometrics.BiometricManager
+import android.hardware.biometrics.BiometricPrompt
+import android.os.CancellationSignal
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import me.weishu.kernelsu.R
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import top.yukonga.miuix.kmp.basic.ButtonDefaults
+import top.yukonga.miuix.kmp.basic.TextButton
+import top.yukonga.miuix.kmp.window.WindowDialog
+import kotlin.system.exitProcess
+
+@Composable
+fun BiometricBlockingDialogMaterial(
+    show: Boolean,
+    startVerify: () -> Unit
+) {
+    LaunchedEffect(show) {
+        if (show) {
+            startVerify()
+        }
+    }
+    if (show) {
+        AlertDialog(
+            onDismissRequest = {},
+            properties = DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
+            ),
+            title = { Text(text=stringResource(id=R.string.biometric_verify_dialog_title)) },
+            text = { Text(text=stringResource(id=R.string.biometric_verify_dialog_description)) },
+            confirmButton = {
+                TextButton(
+                    content = { Text(text = stringResource(id = R.string.biometric_verify)) },
+                    onClick = {
+                        startVerify()
+                    }
+                )
+            },
+            dismissButton = {
+                TextButton(
+                    content = { Text(text = stringResource(id = R.string.exit)) },
+                    onClick = {
+                        exitProcess(0);
+                    }
+                )
+            }
+        )
+    }
+}
+
+@Composable
+fun BiometricBlockingDialogMiuix(
+    show: Boolean,
+    startVerify: () -> Unit
+) {
+    LaunchedEffect(show) {
+        if (show) {
+            startVerify()
+        }
+    }
+    if (show) {
+        WindowDialog(
+            show = show,
+            onDismissRequest = {},
+            title = stringResource(R.string.biometric_verify_dialog_title),
+            content = {
+                Column {
+                    top.yukonga.miuix.kmp.basic.Text(text = stringResource(R.string.biometric_verify_dialog_description))
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        TextButton(
+                            text = stringResource(id = R.string.exit),
+                            onClick = {
+                                exitProcess(0)
+                            },
+                            modifier = Modifier.weight(1f)
+                        )
+                        Spacer(modifier = Modifier.width(10.dp))
+                        TextButton(
+                            text = stringResource(id = R.string.biometric_verify),
+                            onClick = {
+                                startVerify()
+                            },
+                            modifier = Modifier.weight(1f),
+                            colors = ButtonDefaults.textButtonColorsPrimary()
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+fun startBiometric(context: Activity, callback: (result: Boolean) -> Unit) {
+    BiometricPrompt.Builder(context)
+        .setTitle(context.getString(R.string.biometric_verify_dialog_title))
+        .setSubtitle(context.getString(R.string.biometric_verify_dialog_description))
+        .setNegativeButton(context.getString(R.string.download_cancel), context.mainExecutor) { _, _ ->
+            callback(false)
+        }
+        .build()
+        .authenticate(
+            CancellationSignal(),
+            context.mainExecutor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult?) {
+                    super.onAuthenticationSucceeded(result)
+                    callback(true)
+                }
+
+                override fun onAuthenticationError(
+                    errorCode: Int,
+                    errString: CharSequence?
+                ) {
+                    super.onAuthenticationError(errorCode, errString)
+                    callback(false)
+                }
+            })
+}
+
+fun isSupportBiometric(context: Activity): Boolean {
+    val biometricService =
+        context.getSystemService(BiometricManager::class.java) as BiometricManager
+    return biometricService.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS
+}

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/MainActivityViewModel.kt
@@ -29,6 +29,8 @@ class MainActivityViewModel(
     private val _uiState = MutableStateFlow(readUiState())
     val uiState: StateFlow<MainActivityUiState> = _uiState.asStateFlow()
     val selectedMainPage: StateFlow<Int> = mainPageState.selectedPage
+    //防止ui重建后重复弹出验证
+    var isLaunchVerified = false
 
     init {
         prefs.registerOnSharedPreferenceChangeListener(listener)

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/SettingsViewModel.kt
@@ -46,6 +46,7 @@ class SettingsViewModel(
             val colorStyle = repo.colorStyle
             val colorSpec = repo.colorSpec
             val isLkmMode = repo.isLkmMode()
+            val launchVerify=repo.launchVerify
 
             // Async loading for natives/features
             val suCompatStatus = repo.getSuCompatStatus()
@@ -98,6 +99,7 @@ class SettingsViewModel(
                     isLkmMode = isLkmMode,
                     autoJailbreak = autoJailbreak,
                     isLateLoadMode = isLateLoadMode,
+                    launchVerify=launchVerify
                 )
             }
         }
@@ -280,6 +282,10 @@ class SettingsViewModel(
     fun setAutoJailbreak(enabled: Boolean) {
         repo.autoJailbreak = enabled
         _uiState.update { it.copy(autoJailbreak = enabled) }
+    }
+    fun setLaunchVerify(enabled: Boolean) {
+        repo.launchVerify = enabled
+        _uiState.update { it.copy(launchVerify = enabled) }
     }
 
     fun setSulogEnabled(enabled: Boolean) {

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -263,4 +263,12 @@
     <string name="sort_by_install_time">安装时间</string>
     <string name="sort_by_update_time">更新时间</string>
     <string name="sort_reverse">倒序</string>
+    <string name="settings_launch_verify">启动时验证身份</string>
+    <string name="settings_launch_verify_summary">在启动管理器时使用生物识别验证身份</string>
+    <string name="settings_launch_verify_not_supported">设备不支持或未录入生物识别特征</string>
+    <string name="biometric_verify_failed">验证失败</string>
+    <string name="exit">退出</string>
+    <string name="biometric_verify">验证</string>
+    <string name="biometric_verify_dialog_title">需要验证身份</string>
+    <string name="biometric_verify_dialog_description">我们需要确保您是机主</string>
 </resources>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -285,4 +285,12 @@
     <string name="sort_by_install_time">Install time</string>
     <string name="sort_by_update_time">Update time</string>
     <string name="sort_reverse">Reverse</string>
+    <string name="settings_launch_verify">Verify on launch</string>
+    <string name="settings_launch_verify_summary">Use biometrics to verify your identity when launching the manager</string>
+    <string name="settings_launch_verify_not_supported">Biometric authentication is not supported or no biometric data is enrolled</string>
+    <string name="biometric_verify_failed">Verification failed</string>
+    <string name="exit">Exit</string>
+    <string name="biometric_verify">Verify</string>
+    <string name="biometric_verify_dialog_title">Need verify</string>
+    <string name="biometric_verify_dialog_description">We need to verify that you are the device owner</string>
 </resources>


### PR DESCRIPTION
添加了一个设置 开启后可以在启动管理器时弹出生物识别验证 在通过验证前不允许操作管理器
部分类原生系统可能缺少"应用锁"之类功能 如果因为某些情况需要出借手机(亲戚家熊孩子belike)可能被一顿折腾然后设置全乱

不懂Compose 经测试可以运行 但不保证没有其他暗病 希望没问题...