### PR TITLE
ksud: Relax regex for module ID/config key

### DIFF
--- a/userspace/ksud/src/module.rs
+++ b/userspace/ksud/src/module.rs
@@ -44,17 +44,17 @@ const INSTALL_MODULE_SCRIPT: &str = concatcp!(
 );
 
 /// Validate module_id format and security
-/// Module ID must match: ^[a-zA-Z][a-zA-Z0-9._-]+$
-/// - Must start with a letter (a-zA-Z)
+/// Module ID must match: ^[a-zA-Z0-9][a-zA-Z0-9._-]+$
+/// - Must start with a letter or number (a-zA-Z0-9)
 /// - Followed by one or more alphanumeric, dot, underscore, or hyphen characters
 /// - Minimum length: 2 characters
 pub fn validate_module_id(module_id: &str) -> Result<()> {
-    let re = Regex::new(r"^[a-zA-Z][a-zA-Z0-9._-]+$")?;
+    let re = Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9._-]+$")?;
     if re.is_match(module_id) {
         Ok(())
     } else {
         Err(anyhow!(
-            "Invalid module ID: '{module_id}'. Must match /^[a-zA-Z][a-zA-Z0-9._-]+$/"
+            "Invalid module ID: '{module_id}'. Must match /^[a-zA-Z0-9][a-zA-Z0-9._-]+$/"
         ))
     }
 }

--- a/userspace/ksud/src/module_config.rs
+++ b/userspace/ksud/src/module_config.rs
@@ -40,8 +40,8 @@ pub fn parse_bool_config(value: &str) -> bool {
 }
 
 /// Validate config key
-/// Uses the same validation rules as module_id: ^[a-zA-Z][a-zA-Z0-9._-]+$
-/// - Must start with a letter (a-zA-Z)
+/// Uses the same validation rules as module_id: ^[a-zA-Z0-9][a-zA-Z0-9._-]+$
+/// - Must start with a letter or number (a-zA-Z0-9)
 /// - Followed by one or more alphanumeric, dot, underscore, or hyphen characters
 /// - Minimum length: 2 characters
 pub fn validate_config_key(key: &str) -> Result<()> {
@@ -58,9 +58,9 @@ pub fn validate_config_key(key: &str) -> Result<()> {
     }
 
     // Use same pattern as module_id for consistency
-    let re = regex_lite::Regex::new(r"^[a-zA-Z][a-zA-Z0-9._-]+$")?;
+    let re = regex_lite::Regex::new(r"^[a-zA-Z0-9][a-zA-Z0-9._-]+$")?;
     if !re.is_match(key) {
-        bail!("Invalid config key: '{key}'. Must match /^[a-zA-Z][a-zA-Z0-9._-]+$/");
+        bail!("Invalid config key: '{key}'. Must match /^[a-zA-Z0-9][a-zA-Z0-9._-]+$/");
     }
 
     Ok(())


### PR DESCRIPTION
-allow leading numbers for: module ID/config key (module/module_config)
 -https://github.com/KernelSU-Next/KernelSU-Next/issues/1268