### PR TITLE
build: allow customize package name and app name when building

### DIFF
--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -14,6 +14,8 @@ on:
       - 'manager/**'
       - 'kernel/**'
       - 'userspace/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
   pull_request:
     branches: [ "main", "dev" ]
     paths:
@@ -27,6 +29,8 @@ on:
       - 'manager/**'
       - 'kernel/**'
       - 'userspace/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
   workflow_call:
 
 jobs:

--- a/.github/workflows/ksud.yml
+++ b/.github/workflows/ksud.yml
@@ -53,6 +53,9 @@ jobs:
       env:
         ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          export KSU_PACKAGE_NAME="me.weishu.kernelsu.pr"
+        fi
         source .github/scripts/setup-rust-build.sh ${{ inputs.target }} 26
         cargo build --target $TRIPLE --release --manifest-path ./userspace/ksud/Cargo.toml
 

--- a/manager/app/build.gradle.kts
+++ b/manager/app/build.gradle.kts
@@ -19,6 +19,12 @@ val androidTargetCompatibility = rootProject.extra["androidTargetCompatibility"]
 val managerVersionCode = rootProject.extra["managerVersionCode"] as Int
 val managerVersionName = rootProject.extra["managerVersionName"] as String
 
+val isPrBuild = project.findProperty("IS_PR_BUILD")?.toString()?.toBoolean() ?: false
+val defaultManagerPackageName = if (isPrBuild) "me.weishu.kernelsu.pr" else "me.weishu.kernelsu"
+val defaultManagerName = if (isPrBuild) "KernelSU PR" else "KernelSU"
+val managerPackageName = project.findProperty("KSU_PACKAGE_NAME")?.toString() ?: defaultManagerPackageName
+val managerName = project.findProperty("KSU_NAME")?.toString() ?: defaultManagerName
+
 apksign {
     storeFileProperty = "KEYSTORE_FILE"
     storePasswordProperty = "KEYSTORE_PASSWORD"
@@ -35,7 +41,6 @@ val baseCppFlags = baseCFlags + "-fno-rtti"
 
 android {
     namespace = "me.weishu.kernelsu"
-    val isPrBuild = project.findProperty("IS_PR_BUILD")?.toString()?.toBoolean() ?: false
 
     buildTypes {
         debug {
@@ -49,7 +54,6 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             vcsInfo.include = false
-            if (isPrBuild) applicationIdSuffix = ".dev"
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             externalNativeBuild {
                 cmake {
@@ -78,6 +82,7 @@ android {
     buildFeatures {
         aidl = true
         buildConfig = true
+        resValues = true
         compose = true
         prefab = true
     }
@@ -120,8 +125,10 @@ android {
         targetSdk = androidTargetSdkVersion
         versionCode = managerVersionCode
         versionName = managerVersionName
+        applicationId = managerPackageName
 
         buildConfigField("boolean", "IS_PR_BUILD", isPrBuild.toString())
+        resValue("string", "app_name", managerName)
 
         externalNativeBuild {
             cmake {
@@ -155,7 +162,7 @@ androidComponents {
 
 base {
     archivesName.set(
-        "KernelSU_${managerVersionName}_${managerVersionCode}"
+        "${managerName.replace(" ", "_")}_${managerVersionName}_${managerVersionCode}"
     )
 }
 

--- a/manager/app/src/main/res/values-pl/strings.xml
+++ b/manager/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">KernelSU</string>
     <string name="home">Strona główna</string>
     <string name="home_not_installed">Nie zainstalowano</string>
     <string name="home_click_to_install">Kliknij, aby zainstalować</string>

--- a/manager/app/src/main/res/values-tr/strings.xml
+++ b/manager/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">KernelSU</string>
     <string name="home">Ana Sayfa</string>
     <string name="home_not_installed">Kurulmadı</string>
     <string name="home_click_to_install">Yüklemek için dokunun</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">KernelSU</string>
     <string name="home">Home</string>
     <string name="home_not_installed">Not installed</string>
     <string name="home_click_to_install">Tap to install</string>

--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -1,7 +1,4 @@
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
 use std::process::Command;
 
 fn get_git_version() -> Result<(u32, String), std::io::Error> {
@@ -63,26 +60,11 @@ fn main() {
             (0, "0.0.0".to_string())
         }
     };
-    let out_dir = env::var("OUT_DIR").expect("Failed to get $OUT_DIR");
-    println!("cargo:rerun-if-changed={out_dir}/VERSION_CODE");
-    println!("cargo:rerun-if-changed={out_dir}/VERSION_NAME");
-    println!("cargo:rerun-if-changed={out_dir}/KSU_PACKAGE_NAME");
-
-    let out_dir = Path::new(&out_dir);
-    File::create(Path::new(out_dir).join("VERSION_CODE"))
-        .expect("Failed to create VERSION_CODE")
-        .write_all(code.to_string().as_bytes())
-        .expect("Failed to write VERSION_CODE");
-
-    File::create(Path::new(out_dir).join("VERSION_NAME"))
-        .expect("Failed to create VERSION_NAME")
-        .write_all(name.trim().as_bytes())
-        .expect("Failed to write VERSION_NAME");
-    let ksu_package_name = env::var("KSU_PACKAGE_NAME").unwrap_or("me.weishu.kernelsu".to_owned());
-    File::create(Path::new(out_dir).join("KSU_PACKAGE_NAME"))
-        .expect("Failed to create KSU_PACKAGE_NAME")
-        .write_all(ksu_package_name.trim().as_bytes())
-        .expect("Failed to write KSU_PACKAGE_NAME");
+    if env::var("KSU_PACKAGE_NAME").is_err() {
+        println!("cargo:rustc-env=KSU_PACKAGE_NAME=me.weishu.kernelsu");
+    }
+    println!("cargo:rustc-env=VERSION_CODE={code}");
+    println!("cargo:rustc-env=VERSION_NAME={name}");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
     if target_os == "android" {

--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -64,6 +64,10 @@ fn main() {
         }
     };
     let out_dir = env::var("OUT_DIR").expect("Failed to get $OUT_DIR");
+    println!("cargo:rerun-if-changed={out_dir}/VERSION_CODE");
+    println!("cargo:rerun-if-changed={out_dir}/VERSION_NAME");
+    println!("cargo:rerun-if-changed={out_dir}/KSU_PACKAGE_NAME");
+
     let out_dir = Path::new(&out_dir);
     File::create(Path::new(out_dir).join("VERSION_CODE"))
         .expect("Failed to create VERSION_CODE")
@@ -74,6 +78,11 @@ fn main() {
         .expect("Failed to create VERSION_NAME")
         .write_all(name.trim().as_bytes())
         .expect("Failed to write VERSION_NAME");
+    let ksu_package_name = env::var("KSU_PACKAGE_NAME").unwrap_or("me.weishu.kernelsu".to_owned());
+    File::create(Path::new(out_dir).join("KSU_PACKAGE_NAME"))
+        .expect("Failed to create KSU_PACKAGE_NAME")
+        .write_all(ksu_package_name.trim().as_bytes())
+        .expect("Failed to write KSU_PACKAGE_NAME");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
     if target_os == "android" {

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -60,7 +60,7 @@ enum Commands {
         kmi: Option<String>,
 
         /// manager package name
-        #[arg(long, default_value_t = String::from("me.weishu.kernelsu"))]
+        #[arg(long, default_value_t = String::from(defs::DEFAULT_PACKAGE_NAME))]
         package_name: String,
     },
 
@@ -87,7 +87,7 @@ enum Commands {
 
     /// Uninstall KernelSU modules and itself(LKM Only)
     Uninstall {
-        #[arg(long, default_value_t = String::from("me.weishu.kernelsu"))]
+        #[arg(long, default_value_t = String::from(defs::DEFAULT_PACKAGE_NAME))]
         package_name: String,
     },
 
@@ -176,7 +176,7 @@ enum Debug {
     /// Set the manager app, kernel CONFIG_KSU_DEBUG should be enabled.
     SetManager {
         /// manager package name
-        #[arg(default_value_t = String::from("me.weishu.kernelsu"))]
+        #[arg(default_value_t = String::from(defs::DEFAULT_PACKAGE_NAME))]
         apk: String,
     },
 
@@ -218,6 +218,9 @@ enum Debug {
 
     /// Get kernel info
     Info,
+
+    /// Print default package name
+    Package,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -717,6 +720,10 @@ pub fn run() -> Result<()> {
                     "pr_build: {}",
                     (info.flags & ksu_uapi::KSU_GET_INFO_FLAG_PR_BUILD) != 0
                 );
+                Ok(())
+            }
+            Debug::Package => {
+                println!("{}", defs::DEFAULT_PACKAGE_NAME);
                 Ok(())
             }
         },

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -49,6 +49,9 @@ mod android {
     pub const KSU_BACKUP_DIR: &str = WORKING_DIR;
     pub const KSU_BACKUP_FILE_PREFIX: &str = "ksu_backup_";
     pub const BACKUP_FILENAME: &str = "stock_image.sha1";
+
+    pub const DEFAULT_PACKAGE_NAME: &str =
+        include_str!(concat!(env!("OUT_DIR"), "/KSU_PACKAGE_NAME"));
 }
 
 #[allow(unused)]

--- a/userspace/ksud/src/defs.rs
+++ b/userspace/ksud/src/defs.rs
@@ -50,17 +50,15 @@ mod android {
     pub const KSU_BACKUP_FILE_PREFIX: &str = "ksu_backup_";
     pub const BACKUP_FILENAME: &str = "stock_image.sha1";
 
-    pub const DEFAULT_PACKAGE_NAME: &str =
-        include_str!(concat!(env!("OUT_DIR"), "/KSU_PACKAGE_NAME"));
+    pub const DEFAULT_PACKAGE_NAME: &str = env!("KSU_PACKAGE_NAME");
 }
 
 #[allow(unused)]
-pub const VERSION_CODE: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_CODE"));
-pub const VERSION_NAME: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION_NAME"));
+pub const VERSION_CODE: &str = env!("VERSION_CODE");
+pub const VERSION_NAME: &str = env!("VERSION_NAME");
 #[cfg(target_os = "android")]
 pub const FULL_VERSION: &str = const_format::formatcp!(
-    "{} (uapi: {})",
-    VERSION_NAME,
+    "{VERSION_NAME} (uapi: {})",
     crate::ksu_uapi::KERNEL_SU_UAPI_VERSION
 );
 


### PR DESCRIPTION
- ksud: The default package name can be changed by setting the KSU_PACKAGE_NAME environment variable when running cargo.
- manager: The package and application names can be changed by adding the parameters `-PKSU_PACKAGE_NAME=xxx` and `-PKSU_NAME=yyy` to the gradlew command.