### PR TITLE
Run boot recevier in separated process

### DIFF
--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -98,7 +98,8 @@
             android:name=".magica.BootCompletedReceiver"
             android:directBootAware="true"
             android:enabled="false"
-            android:exported="true">
+            android:exported="true"
+            android:process=":magica_boot">
             <intent-filter>
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />


### PR DESCRIPTION
Or okhttpClient may be not initialized if magica starts before boot completed.