### PR TITLE
manager: Avoid corner crash in Material superuser rows

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/superuser/SuperUserMaterial.kt
@@ -1,12 +1,19 @@
 package me.weishu.kernelsu.ui.screen.superuser
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -37,6 +44,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -54,6 +62,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -437,36 +446,60 @@ private fun SimpleAppItem(
     matched: Boolean = false,
     onNavigate: () -> Unit,
 ) {
-    ListItem(
-        onClick = onNavigate,
-        modifier = Modifier.padding(horizontal = 4.dp),
-        shapes = ListItemDefaults.shapes(shape = RoundedCornerShape(0.dp)),
-        colors = ListItemDefaults.colors(
-            containerColor = if (matched) {
-                colorScheme.secondaryContainer
-            } else {
-                colorScheme.surfaceColorAtElevation(3.dp)
-            }
-        ),
-        content = { Text(app.label, overflow = TextOverflow.Ellipsis, maxLines = 1) },
-        supportingContent = { Text(app.packageName, overflow = TextOverflow.Ellipsis, maxLines = 1) },
-        leadingContent = {
-            AppIconImage(
-                packageInfo = app.packageInfo,
-                label = app.label,
-                modifier = Modifier
-                    .size(40.dp)
-                    .padding(start = 4.dp)
-            )
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
+    val animatedCorner by animateDpAsState(
+        targetValue = if (pressed) 16.dp else 0.dp,
+        animationSpec = spring(dampingRatio = 1f, stiffness = 800f),
+        label = "SimpleAppItemCorner"
+    )
+
+    Surface(
+        modifier = Modifier
+            .padding(horizontal = 4.dp),
+        shape = RoundedCornerShape(animatedCorner),
+        color = if (matched) {
+            colorScheme.secondaryContainer
+        } else {
+            colorScheme.surfaceColorAtElevation(3.dp)
         },
-        trailingContent = {
-            Icon(
-                Icons.Filled.Remove,
-                contentDescription = null,
-                modifier = Modifier.padding(end = 4.dp)
+        shadowElevation = 0.dp,
+        tonalElevation = 0.dp,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = androidx.compose.material3.ripple(),
+                    onClick = onNavigate,
+                )
+        ) {
+            ListItem(
+                headlineContent = { Text(app.label, overflow = TextOverflow.Ellipsis, maxLines = 1) },
+                supportingContent = { Text(app.packageName, overflow = TextOverflow.Ellipsis, maxLines = 1) },
+                leadingContent = {
+                    AppIconImage(
+                        packageInfo = app.packageInfo,
+                        label = app.label,
+                        modifier = Modifier
+                            .size(40.dp)
+                            .padding(start = 4.dp)
+                    )
+                },
+                trailingContent = {
+                    Icon(
+                        Icons.Filled.Remove,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 4.dp)
+                    )
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                tonalElevation = 0.dp,
+                shadowElevation = 0.dp,
             )
         }
-    )
+    }
 }
 
 @Composable


### PR DESCRIPTION
Repro:
- switch the Manager UI to Material mode
- open the superuser app list
- long-press a collapsed shared-UID group to expand it
- press and hold one of the expanded child rows

The crash only happened on the expanded child rows. Those rows were forced to use `RoundedCornerShape(0.dp)` at rest, but still went through Material3's interactive list-item shape morph.

Compose throws on negative resolved corners in `CornerBasedShape`: https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/shape/CornerBasedShape.kt

Material3 animates list-item shapes across interaction states here: https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ListItemDefaults.kt https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/internal/AnimatedShape.kt

Material3 normally animates between positive corner tokens; this row changed the resting shape to zero while keeping the larger pressed shape. On release, that spring could overshoot slightly below zero and Compose would throw `Corner size in Px can't be negative`.

Move the pressed corner animation out of `ListItem` and onto the outer container instead. The child row now owns its pressed-state corner radius directly, while the inner `ListItem` is only used for content layout. Keep the existing ripple and normal click behavior.