### PR TITLE
feat: add x64 lkm

### DIFF
--- a/.github/workflows/build-manager.yml
+++ b/.github/workflows/build-manager.yml
@@ -159,7 +159,7 @@ jobs:
               echo KEY_PASSWORD='${{ secrets.KEY_PASSWORD }}'
               echo KEYSTORE_FILE='key.jks'
             } >> gradle.properties
-            echo ${{ secrets.KEYSTORE }} | base64 -d > key.jks
+            echo "${{ secrets.KEYSTORE }}" | base64 -d > key.jks
           fi
 
       - name: Write PR key

--- a/.github/workflows/ddk-lkm.yml
+++ b/.github/workflows/ddk-lkm.yml
@@ -63,20 +63,91 @@ jobs:
         echo "=== Build completed ==="
 
         # Create output directory in GitHub workspace
-        mkdir -p /github/workspace/out
+        OUT_DIR=/github/workspace/out/aarch64
+        mkdir -p $OUT_DIR
 
         # Copy with KMI-specific naming
         OUTPUT_NAME="${{ inputs.kmi }}_kernelsu.ko"
-        cp kernelsu.ko "/github/workspace/out/$OUTPUT_NAME"
+        cp kernelsu.ko "$OUT_DIR/$OUTPUT_NAME"
         
-        echo "Copied to: /github/workspace/out/$OUTPUT_NAME"
-        ls -la "/github/workspace/out/$OUTPUT_NAME"
-        echo "Size: $(du -h "/github/workspace/out/$OUTPUT_NAME" | cut -f1)"
-        llvm-strip -d "/github/workspace/out/$OUTPUT_NAME"
-        echo "Size after stripping: $(du -h "/github/workspace/out/$OUTPUT_NAME" | cut -f1)"
+        echo "Copied to: $OUT_DIR/$OUTPUT_NAME"
+        ls -la "$OUT_DIR/$OUTPUT_NAME"
+        echo "Size: $(du -h "$OUT_DIR/$OUTPUT_NAME" | cut -f1)"
+        llvm-strip -d "$OUT_DIR/$OUTPUT_NAME"
+        echo "Size after stripping: $(du -h "$OUT_DIR/$OUTPUT_NAME" | cut -f1)"
 
     - name: Upload kernelsu.ko artifact
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ inputs.kmi }}-lkm
-        path: /github/workspace/out/${{ inputs.kmi }}_kernelsu.ko
+        name: aarch64-${{ inputs.kmi }}-lkm
+        path: /github/workspace/out/aarch64/${{ inputs.kmi }}_kernelsu.ko
+
+    - name: Build kernelsu.ko for x64
+      env:
+        EXPECTED_SIZE2: ${{ inputs.expected_size2 }}
+        EXPECTED_HASH2: ${{ inputs.expected_hash2 }}
+      run: |
+        cd kernel
+        make clean
+
+        echo "=== Preparing KDIR for x64 ==="
+
+        mkdir -p /opt/ddk/kdir-x64
+        unset ARCH
+        unset CROSS_COMPILE
+        export ARCH=x86_64
+        kmi=${{ inputs.kmi }}
+        pushd /opt/ddk/src/$kmi
+        export KDIR=/opt/ddk/kdir-x64/$kmi
+        make O=$KDIR gki_defconfig
+        scripts/config --file $KDIR/.config -d LTO_CLANG -e LTO_NONE -d LTO_CLANG_THIN -d LTO_CLANG_FULL -d THINLTO
+        if [ "$kmi" == "android16-6.12" ]; then
+            scripts/config --file $KDIR/.config -e CONFIG_CFI_ICALL_NORMALIZE_INTEGERS
+        fi
+        make O=$KDIR modules_prepare
+        popd
+        
+        SELINUX_PATH=security/selinux
+        mkdir -p $KDIR/$SELINUX_PATH
+        cp /opt/ddk/kdir/$kmi/$SELINUX_PATH/*.h $KDIR/$SELINUX_PATH
+
+        echo "=== Building x64 kernelsu.ko for KMI: ${{ inputs.kmi }} ==="
+
+        EXTRA_ARGS=""
+        if [ -n "$EXPECTED_SIZE2" ] && [ -z "$EXPECTED_HASH2" ]; then
+          echo "ERROR: expected_hash2 must be provided when expected_size2 is set."
+          exit 1
+        fi
+        if [ -z "$EXPECTED_SIZE2" ] && [ -n "$EXPECTED_HASH2" ]; then
+          echo "ERROR: expected_size2 must be provided when expected_hash2 is set."
+          exit 1
+        fi
+        if [ -n "$EXPECTED_SIZE2" ]; then
+          EXTRA_ARGS="KSU_EXPECTED_SIZE2=$EXPECTED_SIZE2 KSU_EXPECTED_HASH2=$EXPECTED_HASH2"
+        fi
+        
+        MDIR=$(realpath .)
+
+        make -C $KDIR M=$MDIR compile_commands.json modules CONFIG_KSU=m CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER=y $EXTRA_ARGS
+        
+        echo "=== Build completed ==="
+
+        # Create output directory in GitHub workspace
+        OUT_DIR=/github/workspace/out/x86_64
+        mkdir -p $OUT_DIR
+
+        # Copy with KMI-specific naming
+        OUTPUT_NAME="${{ inputs.kmi }}_kernelsu.ko"
+        cp kernelsu.ko "$OUT_DIR/$OUTPUT_NAME"
+        
+        echo "Copied to: $OUT_DIR/$OUTPUT_NAME"
+        ls -la "$OUT_DIR/$OUTPUT_NAME"
+        echo "Size: $(du -h "$OUT_DIR/$OUTPUT_NAME" | cut -f1)"
+        llvm-strip -d "$OUT_DIR/$OUTPUT_NAME"
+        echo "Size after stripping: $(du -h "$OUT_DIR/$OUTPUT_NAME" | cut -f1)"
+        
+    - name: Upload x64 kernelsu.ko artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: x86_64-${{ inputs.kmi }}-lkm
+        path: /github/workspace/out/x86_64/${{ inputs.kmi }}_kernelsu.ko

--- a/.github/workflows/ksud-extra.yml
+++ b/.github/workflows/ksud-extra.yml
@@ -31,12 +31,14 @@ jobs:
     - name: Prepare LKM files
       if: ${{ inputs.pack_lkm }}
       run: |
-        cp android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/aarch64/
+        cp aarch64-android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/aarch64/
+        cp x86_64-android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/x86_64/
     
     - name: Prepare ksuinit
       if: ${{ inputs.pack_ksuinit }}
       run: |
-        mv ksuinit/*/release/ksuinit ./userspace/ksud/bin/aarch64/
+        mv ksuinit-aarch64/ksuinit ./userspace/ksud/bin/aarch64/
+        mv ksuinit-x86_64/ksuinit ./userspace/ksud/bin/x86_64/
         
     - name: Setup rustup
       run: |

--- a/.github/workflows/ksud.yml
+++ b/.github/workflows/ksud.yml
@@ -27,12 +27,14 @@ jobs:
     - name: Prepare LKM files
       if: ${{ inputs.pack_lkm }}
       run: |
-        cp android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/aarch64/
+        cp aarch64-android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/aarch64/
+        cp x86_64-android*-lkm/*_kernelsu.ko ./userspace/ksud/bin/x86_64/
     
     - name: Prepare ksuinit
       if: ${{ inputs.pack_ksuinit }}
       run: |
-        mv ksuinit/*/release/ksuinit ./userspace/ksud/bin/aarch64/
+        mv ksuinit-aarch64/ksuinit ./userspace/ksud/bin/aarch64/
+        mv ksuinit-x86_64/ksuinit ./userspace/ksud/bin/x86_64/
         
     - name: Setup rustup
       run: |

--- a/.github/workflows/ksuinit.yml
+++ b/.github/workflows/ksuinit.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         rustup update stable
         rustup target add aarch64-unknown-linux-musl
+        rustup target add x86_64-unknown-linux-musl
 
     - uses: Swatinem/rust-cache@v2
       with:
@@ -34,5 +35,17 @@ jobs:
     - name: Upload ksuinit artifact
       uses: actions/upload-artifact@v7
       with:
-        name: ksuinit
-        path: target/**/release/ksuinit
+        name: ksuinit-aarch64
+        path: target/aarch64-unknown-linux-musl/release/ksuinit
+
+    - name: Build ksuinit x64
+      run: |
+        LLVM_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$LLVM_BIN/x86_64-linux-android26-clang"
+        cargo build --package ksuinit --target=x86_64-unknown-linux-musl --release
+
+    - name: Upload x64 ksuinit artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ksuinit-x86_64
+        path: target/x86_64-unknown-linux-musl/release/ksuinit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "android-bootimg"
 version = "0.1.0"
-source = "git+https://github.com/5ec1cff/android_bootimg?rev=153423f6310fd4ae187e32da48e97b9fc613b783#153423f6310fd4ae187e32da48e97b9fc613b783"
+source = "git+https://github.com/5ec1cff/android_bootimg?rev=150425b027c76ea104c82e408571651f2181b2c2#150425b027c76ea104c82e408571651f2181b2c2"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/kernel/build-all-x64.sh
+++ b/kernel/build-all-x64.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+    TARGETS="android12-5.10 android13-5.10 android13-5.15 android14-5.15 android14-6.1 android15-6.6 android16-6.12"
+    #KMIS="android16-6.12"
+else
+    TARGETS=$1
+fi
+
+KMIS=(android12-5.10 android13-5.10 android13-5.15 android14-5.15 android14-6.1 android15-6.6 android16-6.12)
+CLANGS=(clang-r416183b clang-r450784e clang-r450784e clang-r487747c clang-r487747c clang-r510928 clang-r536225)
+RUSTS=(none none none none none none rust-1.82.0)
+
+# Some patch is required to use separate build dir when building for android16-6.12, see:
+# https://github.com/5ec1cff/ddk#local-%E6%A8%A1%E5%BC%8F%E6%9E%84%E5%BB%BA%E9%80%82%E7%94%A8%E4%BA%8E%E5%A4%9A%E4%B8%AA-target-%E7%89%88%E6%9C%AC%E7%9A%84%E5%86%85%E6%A0%B8%E6%A8%A1%E5%9D%97
+
+export ARCH=x86_64
+export LLVM=1
+export LLVM_IAS=1
+
+#mv .ddk-version .ddk-version.bak 2> /dev/null || true
+
+for i in ${!KMIS[@]}; do
+    kmi=${KMIS[i]}
+    skip=true
+    for t in $TARGETS; do
+        if [ "$t" == "$kmi" ]; then
+            skip=false
+            break
+        fi
+    done
+    if $skip; then
+        continue
+    fi
+    clangv=${CLANGS[i]}
+    rustv=${RUSTS[i]}
+    echo "========== Building $kmi =========="
+    ODIR="$(realpath .)/out-x64/$kmi"
+    
+    ORIG_PATH="$PATH"
+
+    CLANG_PATH=$(realpath /opt/ddk/clang/$clangv/bin)
+    NEW_PATH=$CLANG_PATH
+
+    if [ "$rustv" != "none" ]; then
+        RUST_PATH=$(realpath /opt/ddk/rust/$rustv/bin)
+        NEW_PATH=$NEW_PATH:$RUST_PATH
+    fi
+    echo "$NEW_PATH"
+
+    NEW_PATH=$NEW_PATH:$PATH
+    export PATH=$NEW_PATH
+
+    ODIR=$(realpath .)/out-x64/$kmi
+    MDIR=$(realpath .)
+    KDIR=/opt/ddk/kdir-x64/$kmi
+
+    make -C $KDIR M=$ODIR src=$MDIR compile_commands.json modules CONFIG_KSU=m CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER=y
+
+    export PATH="$ORIG_PATH"
+    echo ""
+done
+
+#mv .ddk-version.bak .ddk-version 2> /dev/null || true
+
+echo "========== Final output =========="
+ls -l out-x64/*/kernelsu.ko

--- a/kernel/build-all-x64.sh
+++ b/kernel/build-all-x64.sh
@@ -19,9 +19,7 @@ export ARCH=x86_64
 export LLVM=1
 export LLVM_IAS=1
 
-#mv .ddk-version .ddk-version.bak 2> /dev/null || true
-
-for i in ${!KMIS[@]}; do
+for i in "${!KMIS[@]}"; do
     kmi=${KMIS[i]}
     skip=true
     for t in $TARGETS; do
@@ -40,11 +38,11 @@ for i in ${!KMIS[@]}; do
     
     ORIG_PATH="$PATH"
 
-    CLANG_PATH=$(realpath /opt/ddk/clang/$clangv/bin)
+    CLANG_PATH=$(realpath /opt/ddk/clang/"$clangv"/bin)
     NEW_PATH=$CLANG_PATH
 
     if [ "$rustv" != "none" ]; then
-        RUST_PATH=$(realpath /opt/ddk/rust/$rustv/bin)
+        RUST_PATH=$(realpath /opt/ddk/rust/"$rustv"/bin)
         NEW_PATH=$NEW_PATH:$RUST_PATH
     fi
     echo "$NEW_PATH"
@@ -56,13 +54,11 @@ for i in ${!KMIS[@]}; do
     MDIR=$(realpath .)
     KDIR=/opt/ddk/kdir-x64/$kmi
 
-    make -C $KDIR M=$ODIR src=$MDIR compile_commands.json modules CONFIG_KSU=m CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER=y
+    make -C "$KDIR" "M=$ODIR" "src=$MDIR" compile_commands.json modules CONFIG_KSU=m CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER=y
 
     export PATH="$ORIG_PATH"
     echo ""
 done
-
-#mv .ddk-version.bak .ddk-version 2> /dev/null || true
 
 echo "========== Final output =========="
 ls -l out-x64/*/kernelsu.ko

--- a/scripts/prepare-ddk-x64.sh
+++ b/scripts/prepare-ddk-x64.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/bash
+
+set -e
+
+KMIS=(android12-5.10 android13-5.10 android13-5.15 android14-5.15 android14-6.1 android15-6.6 android16-6.12)
+CLANGS=(clang-r416183b clang-r450784e clang-r450784e clang-r487747c clang-r487747c clang-r510928 clang-r536225)
+RUSTS=(none none none none none none rust-1.82.0)
+
+
+for i in ${!KMIS[@]}; do
+    kmi=${KMIS[i]}
+    clangv=${CLANGS[i]}
+    rustv=${RUSTS[i]}
+    echo "$kmi clang=$clangv rust=$rustv"
+
+    SRC=$(realpath /opt/ddk/src/$kmi)
+    KDIR=/opt/ddk/kdir-x64/$kmi
+    mkdir -p $KDIR
+    ARM64_KDIR=$(realpath /opt/ddk/kdir/$kmi)
+
+    export CROSS_COMPILE=x86_64-linux-gnu-
+    export ARCH=x86_64
+    export LLVM=1
+    export LLVM_IAS=1
+
+    ORIG_PATH=$PATH
+
+    CLANG_PATH=$(realpath /opt/ddk/clang/$clangv/bin)
+    NEW_PATH=$CLANG_PATH
+
+    if [ "$rustv" != "none" ]; then
+        RUST_PATH=$(realpath /opt/ddk/rust/$rustv/bin)
+        NEW_PATH=$NEW_PATH:$RUST_PATH
+    fi
+    echo "$NEW_PATH"
+
+    NEW_PATH=$NEW_PATH:$PATH
+    export PATH=$NEW_PATH
+
+    pushd $SRC
+    make O=$KDIR gki_defconfig
+    scripts/config --file $KDIR/.config -d LTO_CLANG -e LTO_NONE -d LTO_CLANG_THIN -d LTO_CLANG_FULL -d THINLTO
+    if [ "$kmi" == "android16-6.12" ]; then
+        scripts/config --file $KDIR/.config -e CONFIG_CFI_ICALL_NORMALIZE_INTEGERS
+    fi
+    make O=$KDIR modules_prepare
+    popd
+
+    SELINUX_PATH=security/selinux
+    mkdir -p $KDIR/$SELINUX_PATH
+    cp $ARM64_KDIR/$SELINUX_PATH/*.h $KDIR/$SELINUX_PATH
+
+    PATH=$ORIG_PATH
+done

--- a/scripts/prepare-ddk-x64.sh
+++ b/scripts/prepare-ddk-x64.sh
@@ -7,16 +7,16 @@ CLANGS=(clang-r416183b clang-r450784e clang-r450784e clang-r487747c clang-r48774
 RUSTS=(none none none none none none rust-1.82.0)
 
 
-for i in ${!KMIS[@]}; do
+for i in "${!KMIS[@]}"; do
     kmi=${KMIS[i]}
     clangv=${CLANGS[i]}
     rustv=${RUSTS[i]}
     echo "$kmi clang=$clangv rust=$rustv"
 
-    SRC=$(realpath /opt/ddk/src/$kmi)
+    SRC=$(realpath /opt/ddk/src/"$kmi")
     KDIR=/opt/ddk/kdir-x64/$kmi
-    mkdir -p $KDIR
-    ARM64_KDIR=$(realpath /opt/ddk/kdir/$kmi)
+    mkdir -p "$KDIR"
+    ARM64_KDIR=$(realpath /opt/ddk/kdir/"$kmi")
 
     export CROSS_COMPILE=x86_64-linux-gnu-
     export ARCH=x86_64
@@ -25,11 +25,11 @@ for i in ${!KMIS[@]}; do
 
     ORIG_PATH=$PATH
 
-    CLANG_PATH=$(realpath /opt/ddk/clang/$clangv/bin)
+    CLANG_PATH=$(realpath /opt/ddk/clang/"$clangv"/bin)
     NEW_PATH=$CLANG_PATH
 
     if [ "$rustv" != "none" ]; then
-        RUST_PATH=$(realpath /opt/ddk/rust/$rustv/bin)
+        RUST_PATH=$(realpath /opt/ddk/rust/"$rustv"/bin)
         NEW_PATH=$NEW_PATH:$RUST_PATH
     fi
     echo "$NEW_PATH"
@@ -37,18 +37,18 @@ for i in ${!KMIS[@]}; do
     NEW_PATH=$NEW_PATH:$PATH
     export PATH=$NEW_PATH
 
-    pushd $SRC
-    make O=$KDIR gki_defconfig
-    scripts/config --file $KDIR/.config -d LTO_CLANG -e LTO_NONE -d LTO_CLANG_THIN -d LTO_CLANG_FULL -d THINLTO
+    pushd "$SRC"
+    make "O=$KDIR" gki_defconfig
+    scripts/config --file "$KDIR/.config" -d LTO_CLANG -e LTO_NONE -d LTO_CLANG_THIN -d LTO_CLANG_FULL -d THINLTO
     if [ "$kmi" == "android16-6.12" ]; then
-        scripts/config --file $KDIR/.config -e CONFIG_CFI_ICALL_NORMALIZE_INTEGERS
+        scripts/config --file "$KDIR/.config" -e CONFIG_CFI_ICALL_NORMALIZE_INTEGERS
     fi
-    make O=$KDIR modules_prepare
+    make "O=$KDIR" modules_prepare
     popd
 
     SELINUX_PATH=security/selinux
-    mkdir -p $KDIR/$SELINUX_PATH
-    cp $ARM64_KDIR/$SELINUX_PATH/*.h $KDIR/$SELINUX_PATH
+    mkdir -p "$KDIR/$SELINUX_PATH"
+    cp "$ARM64_KDIR"/$SELINUX_PATH/*.h "$KDIR"/$SELINUX_PATH
 
     PATH=$ORIG_PATH
 done

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -23,7 +23,7 @@ tempfile = "3"
 chrono = "0.4"
 regex-lite = "0.1"
 memmap2 = "0.9"
-android-bootimg = { git = "https://github.com/5ec1cff/android_bootimg", rev = "153423f6310fd4ae187e32da48e97b9fc613b783" }
+android-bootimg = { git = "https://github.com/5ec1cff/android_bootimg", rev = "150425b027c76ea104c82e408571651f2181b2c2" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 rustix = { version = "1", features = [

--- a/userspace/ksud/src/assets.rs
+++ b/userspace/ksud/src/assets.rs
@@ -40,10 +40,15 @@ pub use android::*;
 #[folder = "bin/x86_64"]
 struct Asset;
 
-// IF NOT x86_64 ANDROID, ie. macos, linux, windows, always use aarch64
-#[cfg(not(all(target_arch = "x86_64", target_os = "android")))]
+#[cfg(all(target_arch = "aarch64", target_os = "android"))]
 #[derive(RustEmbed)]
 #[folder = "bin/aarch64"]
+struct Asset;
+
+// If not Android, ie. macos, linux, windows, include both
+#[cfg(not(target_os = "android"))]
+#[derive(RustEmbed)]
+#[folder = "bin"]
 struct Asset;
 
 #[allow(unused)]

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -504,6 +504,14 @@ pub struct BootPatchArgs {
     /// Do not load custom rc
     #[arg(long, default_value = "false")]
     no_custom_rc: bool,
+
+    #[cfg(not(target_os = "android"))]
+    #[arg(long, default_value = "x86_64")]
+    arch: String,
+
+    /// Patching ramdisk instead of boot image. This is used for AVD ramdisk
+    #[arg(long, default_value = "false")]
+    ramdisk: bool,
 }
 
 pub fn patch(args: BootPatchArgs) -> Result<()> {
@@ -530,6 +538,9 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             #[cfg(target_os = "android")]
             partition,
             no_custom_rc,
+            #[cfg(not(target_os = "android"))]
+            arch,
+            ramdisk,
         } = args;
 
         println!(include_str!("banner"));
@@ -543,6 +554,15 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         }
 
         let is_replace_kernel = kernel.is_some();
+
+        if ramdisk && is_replace_kernel {
+            bail!("incompatiable option: --ramdisk and --kernel")
+        }
+
+        #[cfg(target_os = "android")]
+        if ramdisk && flash {
+            bail!("incompatiable option: --ramdisk and --flash")
+        }
 
         if is_replace_kernel {
             ensure!(
@@ -616,7 +636,11 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         println!("- Preparing assets");
         println!("- Unpacking boot image");
         let boot_image_data = map_file(&boot_image_file)?;
-        let boot_image = BootImage::parse(&boot_image_data)?;
+        let boot_image = if ramdisk {
+            BootImage::parse_raw_ramdisk(&boot_image_data)?
+        } else {
+            BootImage::parse(&boot_image_data)?
+        };
         enforce_bootimage_version(&boot_image)?;
 
         let mut patcher = BootImagePatchOption::new(&boot_image);
@@ -637,9 +661,19 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         } else if let Some(kmod_path) = kmod {
             Box::new(map_file(&kmod_path)?)
         } else {
-            println!("- KMI: {kmi}");
-            let name = format!("{kmi}_kernelsu.ko");
-            assets::get_asset(&name).with_context(|| format!("Failed to load {name}"))?
+            #[cfg(target_os = "android")]
+            {
+                println!("- KMI: {kmi}");
+                let name = format!("{kmi}_kernelsu.ko");
+                assets::get_asset(&name).with_context(|| format!("Failed to load {name}"))?
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                println!("- KMI: {kmi}");
+                println!("- Arch: {arch}");
+                let name = format!("{arch}/{kmi}_kernelsu.ko");
+                assets::get_asset(&name).with_context(|| format!("Failed to load {name}"))?
+            }
         };
 
         let ksu_init: Box<dyn AsRef<[u8]>> = if no_install {
@@ -647,7 +681,14 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
         } else if let Some(init_path) = init {
             Box::new(map_file(&init_path)?)
         } else {
-            assets::get_asset("ksuinit").context("Failed to load ksuinit")?
+            #[cfg(not(target_os = "android"))]
+            {
+                assets::get_asset(&format!("{arch}/ksuinit")).context("Failed to load ksuinit")?
+            }
+            #[cfg(target_os = "android")]
+            {
+                assets::get_asset("ksuinit").context("Failed to load ksuinit")?
+            }
         };
 
         let (mut cpio, vendor_ramdisk_idx) =

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -506,7 +506,7 @@ pub struct BootPatchArgs {
     no_custom_rc: bool,
 
     #[cfg(not(target_os = "android"))]
-    #[arg(long, default_value = "x86_64")]
+    #[arg(long, default_value = "aarch64")]
     arch: String,
 
     /// Patching ramdisk instead of boot image. This is used for AVD ramdisk

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -593,7 +593,9 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
                         println!("- {e}");
                     }
                 }
-                Ok(if let Some(image_path) = &image {
+                Ok(if ramdisk {
+                    bail!("please specify kmi manually")
+                } else if let Some(image_path) = &image {
                     println!(
                         "- Trying to auto detect KMI version for {}",
                         image_path.display()


### PR DESCRIPTION
- ksud: support patch raw ramdisk
- ksud: embed both arm64 and x64 lkm in non-android ksud and add
`--arch` option to boot-patch for selecting lkm (aarch64 by default)
- actions: build x64 ksuinit and lkm

The following commands can be run on the host to patch x86-64 AVD ramdisk to load KernelSU LKM, and launch AVD with the patched ramdisk:

```sh
AVD_SYSTEM_PATH=$ANDROID_HOME/system-images/android-<VER>/<VARIANT>/x86_64
./ksud boot-patch --ramdisk -b $AVD_SYSTEM_PATH/ramdisk.img --out $AVD_SYSTEM_PATH --out-name ramdisk.img.kernelsu --arch x86_64 --kmi <KMI of your AVD kernel>
emulator @<AVD NAME> -ramdisk $AVD_SYSTEM_PATH/ramdisk.img.kernelsu
```

X64 lkm can be installed directly on AVD. Currently, these AVD and KMI versions were tested:

A13 (android13-5.15) worked
A14 (android14-6.1) not worked
A15 (android15-6.6) worked
A16 (android15-6.6) worked
A16.1 (android16-6.12) worked
