### PR TITLE
manager: fix stray quote corrupting saved app profile templates

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -474,7 +474,7 @@ fun getAppProfileTemplate(id: String): String {
 fun setAppProfileTemplate(id: String, template: String): Boolean {
     val shell = getRootShell()
     val escapedTemplate = template.replace("\"", "\\\"")
-    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate'""""
+    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate""""
     return shell.newJob().add(cmd)
         .to(ArrayList(), null).exec().isSuccess
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -473,8 +473,8 @@ fun getAppProfileTemplate(id: String): String {
 
 fun setAppProfileTemplate(id: String, template: String): Boolean {
     val shell = getRootShell()
-    val escapedTemplate = template.replace("\"", "\\\"")
-    val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate""""
+    val escapedTemplate = template.replace("'", "'\\''")
+    val cmd = """${getKsuDaemonPath()} profile set-template "$id" '$escapedTemplate'"""
     return shell.newJob().add(cmd)
         .to(ArrayList(), null).exec().isSuccess
 }


### PR DESCRIPTION
## Problem

`setAppProfileTemplate` in `KsuCli.kt` builds the ksud command as:

```kotlin
val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate'""""
```

Note the stray `'` right before the closing `"`: `"$escapedTemplate'"`.

Inside double quotes the single quote is a literal character, so it is **not** shell quoting — it gets passed through to `ksud` as part of the template argument. `profile::set_template` then writes that argument verbatim to `PROFILE_TEMPLATE_DIR/<id>`, so every template saved through the manager gains a spurious trailing `'` in its content.

## Fix

Remove the stray quote so the template is passed through unchanged:

```kotlin
val cmd = """${getKsuDaemonPath()} profile set-template "$id" "$escapedTemplate""""
```

This matches the quoting used by the sibling helpers (`getAppProfileTemplate`, `deleteAppProfileTemplate`).