### PR TITLE
kernel: add missing NULL checks on allocation paths

### DIFF
--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -143,6 +143,10 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name, int name
                 }
             } else {
                 struct apk_path_hash *apk_data = kzalloc(sizeof(struct apk_path_hash), GFP_KERNEL);
+                if (!apk_data) {
+                    pr_err("Failed to allocate apk_path_hash for %s\n", dirpath);
+                    return FILLDIR_ACTOR_CONTINUE;
+                }
                 apk_data->hash = hash;
                 apk_data->exists = true;
                 list_add_tail(&apk_data->list, &apk_path_hash_list);

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -542,6 +542,8 @@ static bool add_filename_trans(struct policydb *db, const char *s, const char *t
 {
     struct type_datum *src, *tgt, *def;
     struct class_datum *cls;
+    struct filename_trans_key *new_key = NULL;
+    int rc;
 
     src = symtab_search(&db->p_types, s);
     if (src == NULL) {
@@ -588,29 +590,39 @@ static bool add_filename_trans(struct policydb *db, const char *s, const char *t
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans), GFP_KERNEL);
         if (!trans) {
             pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
-            return false;
+            goto out;
         }
-        struct filename_trans_key *new_key = (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        new_key = (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
         if (!new_key) {
             pr_err("add_filename_trans: alloc filename_trans_key failed\n");
-            kfree(trans);
-            return false;
+            goto free_trans;
         }
         *new_key = key;
         new_key->name = kstrdup(key.name, GFP_KERNEL);
         if (!new_key->name) {
             pr_err("add_filename_trans: kstrdup name failed\n");
-            kfree(new_key);
-            kfree(trans);
-            return false;
+            goto free_key;
         }
         trans->next = last;
         trans->otype = def->value;
-        hashtab_insert(&db->filename_trans, new_key, trans, filenametr_key_params);
+        rc = hashtab_insert(&db->filename_trans, new_key, trans, filenametr_key_params);
+        if (rc) {
+            pr_err("add_filename_trans: hashtab_insert failed: %d\n", rc);
+            goto free_name;
+        }
     }
 
     db->compat_filename_trans_count++;
     return ebitmap_set_bit(&trans->stypes, src->value - 1, 1) == 0;
+
+free_name:
+    kfree(new_key->name);
+free_key:
+    kfree(new_key);
+free_trans:
+    kfree(trans);
+out:
+    return false;
 }
 
 static bool add_genfscon(struct policydb *db, const char *fs_name, const char *path, const char *context)

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -586,9 +586,24 @@ static bool add_filename_trans(struct policydb *db, const char *s, const char *t
 
     if (trans == NULL) {
         trans = (struct filename_trans_datum *)kcalloc(1, sizeof(*trans), GFP_KERNEL);
+        if (!trans) {
+            pr_err("add_filename_trans: alloc filename_trans_datum failed\n");
+            return false;
+        }
         struct filename_trans_key *new_key = (struct filename_trans_key *)kzalloc(sizeof(*new_key), GFP_KERNEL);
+        if (!new_key) {
+            pr_err("add_filename_trans: alloc filename_trans_key failed\n");
+            kfree(trans);
+            return false;
+        }
         *new_key = key;
         new_key->name = kstrdup(key.name, GFP_KERNEL);
+        if (!new_key->name) {
+            pr_err("add_filename_trans: kstrdup name failed\n");
+            kfree(new_key);
+            kfree(trans);
+            return false;
+        }
         trans->next = last;
         trans->otype = def->value;
         hashtab_insert(&db->filename_trans, new_key, trans, filenametr_key_params);


### PR DESCRIPTION
Two kernel allocation sites dereference their result without checking for failure, which panics the kernel under memory pressure.

### 1. `kernel/manager/throne_tracker.c` — `my_actor()`

```c
struct apk_path_hash *apk_data = kzalloc(sizeof(struct apk_path_hash), GFP_KERNEL);
apk_data->hash = hash;   // NULL deref if kzalloc fails
```

Every other allocation in this file is checked (e.g. the `data_path` alloc a few lines above skips the entry on failure). This one wasn't. Fixed by skipping the entry (`FILLDIR_ACTOR_CONTINUE`) when the allocation fails.

### 2. `kernel/selinux/sepolicy.c` — `add_filename_trans()`

```c
trans = kcalloc(1, sizeof(*trans), GFP_KERNEL);
struct filename_trans_key *new_key = kzalloc(sizeof(*new_key), GFP_KERNEL);
*new_key = key;                        // NULL deref
new_key->name = kstrdup(key.name, ..); // unchecked
trans->next = last;                    // NULL deref
```

Three unchecked allocations, all dereferenced immediately. Fixed by checking each and bailing out (`return false`, matching the function's existing error style), freeing the partial allocations on the way out.

Both are OOM-only robustness fixes; no behavior change on the success path.