### PR TITLE
kernel: register tracepoint handler with minimum priority

### DIFF
--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -138,7 +138,7 @@ void __init ksu_syscall_hook_manager_init(void)
     ksu_register_syscall_hook(__NR_faccessat, ksu_hook_faccessat);
 
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
-    ret = register_trace_sys_enter(ksu_sys_enter_handler, NULL);
+    ret = register_trace_prio_sys_enter(ksu_sys_enter_handler, NULL, INT_MIN);
 #ifndef CONFIG_KRETPROBES
     ksu_mark_running_process_locked();
 #endif


### PR DESCRIPTION
This allows other tracepoint handler like perf/bpf to run before we corrupt the context