### PR TITLE
manager: dismiss current snackbar before showing new one

### DIFF
--- a/manager/app/src/main/cpp/CMakeLists.txt
+++ b/manager/app/src/main/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(kernelsu
         ksu.cc
         )
 
-target_include_directories(kernelsu PRIVATE .)
+target_include_directories(kernelsu PRIVATE . ../../../../..)
 
 find_library(log-lib log)
 

--- a/manager/app/src/main/cpp/CMakeLists.txt
+++ b/manager/app/src/main/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(kernelsu
         ksu.cc
         )
 
-target_include_directories(kernelsu PRIVATE . ../../../../..)
+target_include_directories(kernelsu PRIVATE .)
 
 find_library(log-lib log)
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
@@ -255,6 +255,7 @@ fun ModulePagerMaterial(
             is ModuleEffect.SnackBar -> {
                 // Cancel the previous reboot snackbar so a new one replaces it instead of queueing
                 snackbarJob.value?.cancel()
+                snackBarHost.currentSnackbarData?.dismiss()
                 snackbarJob.value = scope.launch {
                     val result = snackBarHost.showSnackbar(
                         message = event.message,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
@@ -238,6 +238,7 @@ fun ModulePagerMiuix(
                 // Cancel the previous reboot snackbar so a new one replaces it instead of queueing
                 snackbarJob.value?.cancel()
                 snackbarJob.value = scope.launch {
+                    snackbarHostState.newestSnackbarData()?.dismiss()
                     val result = snackbarHostState.showSnackbar(
                         message = event.message,
                         actionLabel = context.getString(R.string.reboot),

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMiuix.kt
@@ -237,8 +237,8 @@ fun ModulePagerMiuix(
             is ModuleEffect.SnackBar -> {
                 // Cancel the previous reboot snackbar so a new one replaces it instead of queueing
                 snackbarJob.value?.cancel()
+                snackbarHostState.newestSnackbarData()?.dismiss()
                 snackbarJob.value = scope.launch {
-                    snackbarHostState.newestSnackbarData()?.dismiss()
                     val result = snackbarHostState.showSnackbar(
                         message = event.message,
                         actionLabel = context.getString(R.string.reboot),


### PR DESCRIPTION
When rapidly toggling modules, multiple snackbars would stack visually because cancelling the previous coroutine does not dismiss the already-displayed snackbar. Dismiss the current snackbar before showing a new one to prevent queuing.