### PR TITLE
ksud: don't panic on a broken zip in get_zip_uncompressed_size

### DIFF
--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -126,9 +126,10 @@ pub fn is_safe_mode() -> bool {
 
 pub fn get_zip_uncompressed_size(zip_path: &str) -> Result<u64> {
     let mut zip = zip::ZipArchive::new(std::fs::File::open(zip_path)?)?;
-    let total: u64 = (0..zip.len())
-        .map(|i| zip.by_index(i).unwrap().size())
-        .sum();
+    let mut total: u64 = 0;
+    for i in 0..zip.len() {
+        total += zip.by_index(i)?.size();
+    }
     Ok(total)
 }
 


### PR DESCRIPTION
`get_zip_uncompressed_size` iterates the archive with `by_index(i).unwrap()`. If any entry can't be read the `unwrap()` panics and the whole ksud process dies.

This is reachable from `module install`: hand it a truncated or corrupted zip and instead of a clean "failed to read module" error you get a panic.

Since the function already returns `Result<u64>`, the simple fix is to propagate the error with `?`:

```rust
let mut total: u64 = 0;
for i in 0..zip.len() {
    total += zip.by_index(i)?.size();
}
Ok(total)
```

No behavior change for valid archives.