### PR TITLE
ksud: validate resetprop --timeout to avoid a panic

### DIFF
--- a/userspace/ksud/src/resetprop.rs
+++ b/userspace/ksud/src/resetprop.rs
@@ -152,7 +152,11 @@ fn run_from_args(args: &[String]) -> Result<()> {
     // -w: wait mode
     if cli.wait {
         let name = cli.name().context("--wait requires a property name")?;
-        let timeout = cli.timeout.map(Duration::from_secs_f64);
+        let timeout = cli
+            .timeout
+            .map(Duration::try_from_secs_f64)
+            .transpose()
+            .map_err(|_| anyhow::anyhow!("invalid --timeout value"))?;
         let ok = rp
             .wait(name, cli.value().map(std::string::String::as_str), timeout)
             .context("wait failed")?;


### PR DESCRIPTION
`Duration::from_secs_f64` panics on negative, NaN, or out-of-range input. The `--timeout` value is parsed directly from the command line and passed straight into it:

```rust
let timeout = cli.timeout.map(Duration::from_secs_f64);
```

So something like `resetprop -w --timeout -1 sys.boot_completed` panics instead of printing an error.

Switched to the fallible `try_from_secs_f64` and mapped the error into a regular message, which matches how the rest of the argument handling reports bad input.