### PR TITLE
kernel: check kernel_read() results when verifying the APK signing block

### DIFF
--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -74,19 +74,25 @@ static int ksu_sha256(const unsigned char *data, unsigned int datalen, unsigned 
 static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset, unsigned expected_size,
                         const char *expected_sha256)
 {
-    kernel_read(fp, size4, 0x4, pos); // signer-sequence length
-    kernel_read(fp, size4, 0x4, pos); // signer length
-    kernel_read(fp, size4, 0x4, pos); // signed data length
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // signer-sequence length
+        return false;
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // signer length
+        return false;
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // signed data length
+        return false;
 
     *offset += 0x4 * 3;
 
-    kernel_read(fp, size4, 0x4, pos); // digests-sequence length
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // digests-sequence length
+        return false;
 
     *pos += *size4;
     *offset += 0x4 + *size4;
 
-    kernel_read(fp, size4, 0x4, pos); // certificates length
-    kernel_read(fp, size4, 0x4, pos); // certificate length
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // certificates length
+        return false;
+    if (kernel_read(fp, size4, 0x4, pos) != 0x4) // certificate length
+        return false;
     *offset += 0x4 * 2;
 
     if (*size4 == expected_size) {
@@ -98,7 +104,10 @@ static bool check_block(struct file *fp, u32 *size4, loff_t *pos, u32 *offset, u
             pr_info("cert length overlimit\n");
             return false;
         }
-        kernel_read(fp, cert, *size4, pos);
+        if (kernel_read(fp, cert, *size4, pos) != *size4) {
+            pr_info("read cert failed\n");
+            return false;
+        }
         unsigned char digest[SHA256_DIGEST_SIZE];
         if (IS_ERR(ksu_sha256(cert, *size4, digest))) {
             pr_info("sha256 error\n");
@@ -209,17 +218,25 @@ static __always_inline bool check_v2_signature(char *path, unsigned expected_siz
 
     pos += 12;
     // offset
-    kernel_read(fp, &size4, 0x4, &pos);
+    if (kernel_read(fp, &size4, 0x4, &pos) != 0x4) {
+        goto clean;
+    }
     pos = size4 - 0x18;
 
-    kernel_read(fp, &size8, 0x8, &pos);
-    kernel_read(fp, buffer, 0x10, &pos);
+    if (kernel_read(fp, &size8, 0x8, &pos) != 0x8) {
+        goto clean;
+    }
+    if (kernel_read(fp, buffer, 0x10, &pos) != 0x10) {
+        goto clean;
+    }
     if (strcmp((char *)buffer, "APK Sig Block 42")) {
         goto clean;
     }
 
     pos = size4 - (size8 + 0x8);
-    kernel_read(fp, &size_of_block, 0x8, &pos);
+    if (kernel_read(fp, &size_of_block, 0x8, &pos) != 0x8) {
+        goto clean;
+    }
     if (size_of_block != size8) {
         goto clean;
     }
@@ -228,12 +245,17 @@ static __always_inline bool check_v2_signature(char *path, unsigned expected_siz
     while (loop_count++ < 10) {
         uint32_t id;
         uint32_t offset;
-        kernel_read(fp, &size8, 0x8,
-                    &pos); // sequence length
+        if (kernel_read(fp, &size8, 0x8, &pos) != 0x8) { // sequence length
+            v2_signing_valid = false;
+            goto clean;
+        }
         if (size8 == size_of_block) {
             break;
         }
-        kernel_read(fp, &id, 0x4, &pos); // id
+        if (kernel_read(fp, &id, 0x4, &pos) != 0x4) { // id
+            v2_signing_valid = false;
+            goto clean;
+        }
         offset = 4;
         if (id == 0x7109871au) {
             v2_signing_blocks++;


### PR DESCRIPTION
`check_block()` and `check_v2_signature()` in `apk_sign.c` read the APK v2 signing block field by field with `kernel_read()`, but none of those calls check how many bytes actually came back. On a truncated or otherwise malformed APK the code keeps doing offset arithmetic on whatever happened to be on the stack.

It's bounded by the `CERT_MAX_LENGTH` guard so this isn't a memory-safety hole, but relying on uninitialized/stale values on the manager-verification path isn't great.

This adds the length checks:
- in `check_block`, every field read plus the certificate read now bail out (`return false`) on a short read;
- in `check_v2_signature`, the reads after the EOCD scan `goto clean`, and the two reads inside the id-block loop invalidate the result first.

A properly signed manager APK reads every field back in full, so nothing changes for the normal case — only truncated/garbage input is now rejected explicitly instead of processed. I deliberately left the EOCD-search loop untouched since it already tolerates short reads via its `n == i` check.