### PR TITLE
fix(ui): AMOLED theme container fix and hardcoded color cleanup

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/component/miuix/WarningCard.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/component/miuix/WarningCard.kt
@@ -33,8 +33,8 @@ fun WarningCard(
         colors = CardDefaults.defaultColors(
             color = color ?: when {
                 isDynamicColor -> colorScheme.errorContainer
-                isInDarkTheme() -> Color(0XFF310808)
-                else -> Color(0xFFF8E2E2)
+                isInDarkTheme() -> colorScheme.errorContainer.copy(alpha = 0.3f)
+                else -> colorScheme.errorContainer
             }
         ),
         showIndication = onClick != null,
@@ -49,7 +49,7 @@ fun WarningCard(
         ) {
             Text(
                 text = message,
-                color = if (isDynamicColor) colorScheme.onErrorContainer else Color(0xFFF72727),
+                color = if (isDynamicColor) colorScheme.onErrorContainer else colorScheme.error,
                 fontSize = 14.sp
             )
             action?.invoke()

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMiuix.kt
@@ -402,7 +402,7 @@ private fun SulogStatusSection(
                             cornerRadius = 50.dp,
                             insideMargin = PaddingValues(horizontal = 16.dp, vertical = 6.dp),
                             colors = ButtonDefaults.textButtonColors(
-                                color = if (isDynamicColor) colorScheme.onErrorContainer else Color(0xFFF72727),
+                                color = if (isDynamicColor) colorScheme.onErrorContainer else colorScheme.error,
                                 textColor = colorScheme.onError,
                             ),
                         )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/ThemeExt.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/theme/ThemeExt.kt
@@ -21,6 +21,8 @@ fun ColorScheme.amoledBackground(amoled: Boolean): ColorScheme =
         surfaceContainerLowest = Color.Black,
         surfaceContainerLow = Color.Black,
         surfaceContainer = Color.Black,
+        surfaceContainerHigh = Color.Black,
+        surfaceContainerHighest = Color.Black,
     )
 
 @Composable


### PR DESCRIPTION
## Summary
- Fix AMOLED dark mode missing \ and \ in ThemeExt.kt
- Replace hardcoded colors with theme colors in WarningCard
- Replace hardcoded color with theme error color in SulogMiuix

## Details

### 1. AMOLED background incomplete surface container list
\ set \, \, and \ to \, but omitted \ and \. Higher-elevation surface containers retained their dynamic colors in AMOLED mode, creating visual inconsistency on true-black AMOLED devices.

### 2. WarningCard hardcoded colors
Three hex color values (\, \, \) bypassed the dynamic and static theme system entirely. Replaced with \ and \ which adapt to the current palette's error color scheme.

### 3. SulogMiuix enable button hardcoded color
The SU log enable button used \colorScheme.error`.

## Changed files
- manager/.../ui/theme/ThemeExt.kt
- manager/.../ui/component/miuix/WarningCard.kt
- manager/.../ui/screen/sulog/SulogMiuix.kt

Generated with Claude Code