### PR TITLE
ksud: validate lengths when loading module config

### DIFF
--- a/userspace/ksud/src/module_config.rs
+++ b/userspace/ksud/src/module_config.rs
@@ -149,7 +149,11 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
     let mut count_buf = [0u8; 4];
     file.read_exact(&mut count_buf)
         .with_context(|| "Failed to read count")?;
-    let count = u32::from_le_bytes(count_buf);
+    let count = u32::from_le_bytes(count_buf) as usize;
+
+    if count > MAX_CONFIG_COUNT {
+        bail!("Too many config entries: {count} (max: {MAX_CONFIG_COUNT})");
+    }
 
     // Read entries
     let mut config = HashMap::new();
@@ -159,6 +163,10 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
         file.read_exact(&mut key_len_buf)
             .with_context(|| format!("Failed to read key length for entry {i}"))?;
         let key_len = u32::from_le_bytes(key_len_buf) as usize;
+
+        if key_len > MAX_CONFIG_KEY_LEN {
+            bail!("Config key too long for entry {i}: {key_len} bytes (max: {MAX_CONFIG_KEY_LEN})");
+        }
 
         // Read key data
         let mut key_buf = vec![0u8; key_len];
@@ -172,6 +180,12 @@ pub fn load_config(module_id: &str, config_type: ConfigType) -> Result<HashMap<S
         file.read_exact(&mut value_len_buf)
             .with_context(|| format!("Failed to read value length for entry {i}"))?;
         let value_len = u32::from_le_bytes(value_len_buf) as usize;
+
+        if value_len > MAX_CONFIG_VALUE_LEN {
+            bail!(
+                "Config value too long for entry {i}: {value_len} bytes (max: {MAX_CONFIG_VALUE_LEN})"
+            );
+        }
 
         // Read value data
         let mut value_buf = vec![0u8; value_len];


### PR DESCRIPTION
`save_config()` validates the entry count and every key/value against the limits at the top of the file:

```rust
pub const MAX_CONFIG_KEY_LEN: usize = 256;
pub const MAX_CONFIG_VALUE_LEN: usize = 1024 * 1024;
pub const MAX_CONFIG_COUNT: usize = 32;
```

`load_config()` doesn't check any of them. It reads `count`, `key_len` and `value_len` straight out of the file and uses them directly:

```rust
let key_len = u32::from_le_bytes(key_len_buf) as usize;
let mut key_buf = vec![0u8; key_len];
```

Since those are u32 fields, a damaged config file can ask us to allocate up to 4GB. The `read_exact()` right after would fail, but the allocation happens first, so ksud aborts instead of returning an error.

This applies the same three limits on the read path. Nothing changes for files written by `save_config()`, since it can't produce values above the limits in the first place.