### PR TITLE
fix(ui): resolve multiple UI bugs across home, module, template and sulog screens

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -281,16 +281,16 @@ private fun StatusCard(
                             Spacer(Modifier.width(8.dp))
                             StatusTag(
                                 label = stringResource(id = R.string.safe_mode),
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                backgroundColor = MaterialTheme.colorScheme.errorContainer
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                backgroundColor = MaterialTheme.colorScheme.secondaryContainer
                             )
                         }
                         if (ksuActive && state.isLateLoadMode) {
                             Spacer(Modifier.width(8.dp))
                             StatusTag(
                                 label = stringResource(id = R.string.jailbreak_mode),
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                                backgroundColor = MaterialTheme.colorScheme.errorContainer
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                                backgroundColor = MaterialTheme.colorScheme.secondaryContainer
                             )
                         }
                     }
@@ -437,7 +437,7 @@ private fun InfoCard(systemInfo: SystemInfo) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 16.dp, top = 14.dp, bottom = 12.dp)
+                .padding(all = 16.dp)
         ) {
             @Composable
             fun InfoCardItem(label: String, content: String) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
@@ -49,7 +49,6 @@ import me.weishu.kernelsu.ui.component.dialog.rememberConfirmDialog
 import me.weishu.kernelsu.ui.component.miuix.WarningCard
 import me.weishu.kernelsu.ui.component.rebootlistpopup.RebootListPopupMiuix
 import me.weishu.kernelsu.ui.theme.LocalEnableBlur
-import me.weishu.kernelsu.ui.theme.isInDarkTheme
 import me.weishu.kernelsu.ui.util.BlurredBar
 import me.weishu.kernelsu.ui.util.module.LatestVersionInfo
 import me.weishu.kernelsu.ui.util.rememberBlurBackdrop
@@ -70,7 +69,6 @@ import top.yukonga.miuix.kmp.icon.MiuixIcons
 import top.yukonga.miuix.kmp.icon.extended.Link
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import top.yukonga.miuix.kmp.theme.MiuixTheme.colorScheme
-import top.yukonga.miuix.kmp.theme.MiuixTheme.isDynamicColor
 import top.yukonga.miuix.kmp.utils.PressFeedbackType
 import top.yukonga.miuix.kmp.utils.overScrollVertical
 import top.yukonga.miuix.kmp.utils.scrollEndHaptic
@@ -267,11 +265,7 @@ private fun StatusCard(
                             .weight(1f)
                             .fillMaxHeight(),
                         colors = CardDefaults.defaultColors(
-                            color = when {
-                                isDynamicColor -> colorScheme.secondaryContainer
-                                isInDarkTheme() -> Color(0xFF1A3825)
-                                else -> Color(0xFFDFFAE4)
-                            }
+                            color = colorScheme.secondaryContainer
                         ),
                         onClick = {
                             if (!state.isLateLoadMode) {
@@ -291,11 +285,7 @@ private fun StatusCard(
                                 Icon(
                                     modifier = Modifier.size(170.dp),
                                     imageVector = Icons.Rounded.CheckCircleOutline,
-                                    tint = if (isDynamicColor) {
-                                        colorScheme.primary.copy(alpha = 0.8f)
-                                    } else {
-                                        Color(0xFF36D167)
-                                    },
+                                    tint = colorScheme.primary.copy(alpha = 0.8f),
                                     contentDescription = null
                                 )
                             }
@@ -482,7 +472,6 @@ private fun DonateCard(onOpenUrl: (String) -> Unit) {
                 )
             },
             onClick = { onOpenUrl("https://patreon.com/weishu") },
-            insideMargin = PaddingValues(18.dp)
         )
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/module/ModuleMaterial.kt
@@ -97,6 +97,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -170,11 +171,14 @@ fun ModulePagerMaterial(
     val searchListState = rememberLazyListState()
     val refreshTick = remember { mutableIntStateOf(0) }
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
+
+    // Track scroll direction to expand/collapse the FAB. State must live outside
+    // derivedStateOf so mutations are observable across recompositions.
+    var lastIndex by remember { mutableIntStateOf(0) }
+    var lastOffset by remember { mutableIntStateOf(0) }
+    var scrollDelta by remember { mutableFloatStateOf(0f) }
+    var expanded by remember { mutableStateOf(true) }
     val fabExpanded by remember {
-        var lastIndex = 0
-        var lastOffset = 0
-        var scrollDelta = 0f
-        var expanded = true
         derivedStateOf {
             val currentIndex = listState.firstVisibleItemIndex
             val currentOffset = listState.firstVisibleItemScrollOffset

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/sulog/SulogMaterial.kt
@@ -97,9 +97,9 @@ fun SulogScreenMaterial(
         localSearchText = state.searchText
     }
 
-    if (selectedEntry != null) {
+    selectedEntry?.let { entry ->
         SulogDetailDialog(
-            entry = selectedEntry!!,
+            entry = entry,
             onDismiss = { selectedEntry = null },
         )
     }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/template/TemplateMaterial.kt
@@ -46,6 +46,8 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -83,11 +85,14 @@ fun AppProfileTemplateScreenMaterial(
     val pullToRefreshState = rememberPullToRefreshState()
     val listState = rememberLazyListState()
     val threshold = with(LocalDensity.current) { 100.dp.toPx() }
+
+    // Track scroll direction to expand/collapse the FAB. State must live outside
+    // derivedStateOf so mutations are observable across recompositions.
+    var lastIndex by remember { mutableIntStateOf(0) }
+    var lastOffset by remember { mutableIntStateOf(0) }
+    var scrollDelta by remember { mutableFloatStateOf(0f) }
+    var expanded by remember { mutableStateOf(true) }
     val fabExpanded by remember {
-        var lastIndex = 0
-        var lastOffset = 0
-        var scrollDelta = 0f
-        var expanded = true
         derivedStateOf {
             val currentIndex = listState.firstVisibleItemIndex
             val currentOffset = listState.firstVisibleItemScrollOffset


### PR DESCRIPTION
## Summary

This PR fixes several UI bugs found during code review of the KernelSU manager interface.

## Details

- **HomeMiuix StatusCard**: Replace hardcoded green colors with theme-derived secondaryContainer/primary so the card follows the active color scheme in both dynamic and non-dynamic color modes.
- **HomeMiuix DonateCard**: Remove inconsistent insideMargin = PaddingValues(18.dp) so it matches LearnMoreCard (default 16dp).
- **HomeMaterial StatusTag**: Use secondaryContainer/onSecondaryContainer instead of errorContainer/onErrorContainer for SafeMode/LateLoadMode tags - these are operational states, not errors.
- **HomeMaterial InfoCard**: Fix asymmetric padding (start=16, end=16, top=14, bottom=12) to uniform 16.dp on all sides.
- **ModuleMaterial and TemplateMaterial**: Fix derivedStateOf anti-pattern where mutable variables were captured and mutated inside the derived block. State is now hoisted into mutableStateOf/mutableIntStateOf/mutableFloatStateOf so mutations are observable across recompositions.
- **SulogMaterial**: Replace selectedEntry!! force-unwrap with safe ?.let call inside the null-check block.

Signed-off-by: EasyGuo114514 <2025520491@qq.com>