### PR TITLE
feat(ksu): add KSU_IOCTL_DISABLE_KSU to drop KSU capability per process

### DIFF
--- a/kernel/hook/setuid_hook.c
+++ b/kernel/hook/setuid_hook.c
@@ -13,6 +13,7 @@
 #include <linux/uidgid.h>
 
 #include "policy/allowlist.h"
+#include "policy/app_profile.h"
 #include "hook/setuid_hook.h"
 #include "klog.h" // IWYU pragma: keep
 #include "manager/manager_identity.h"
@@ -24,6 +25,9 @@
 int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
 {
     // we rely on the fact that zygote always call setresuid(3) with same uids
+
+    if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+        return 0;
 
     pr_info("handle_setresuid from %d to %d\n", old_uid, new_uid);
 

--- a/kernel/manager/manager_identity.h
+++ b/kernel/manager/manager_identity.h
@@ -2,7 +2,10 @@
 #define __KSU_H_MANAGER_IDENTITY
 
 #include <linux/cred.h>
+#include <linux/thread_info.h>
 #include <linux/types.h>
+
+#include "policy/app_profile.h"
 
 #define KSU_INVALID_APPID -1
 #define KSU_PER_USER_RANGE 100000
@@ -15,6 +18,8 @@ static inline bool ksu_is_manager_appid_valid()
 
 static inline bool is_manager()
 {
+    if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+        return false;
     return current_uid().val == 0;
 }
 
@@ -46,6 +51,8 @@ static inline bool ksu_is_manager_appid_valid()
 
 static inline bool is_manager()
 {
+    if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+        return false;
     return unlikely(ksu_manager_appid == current_uid().val % KSU_PER_USER_RANGE);
 }
 

--- a/kernel/policy/allowlist.c
+++ b/kernel/policy/allowlist.c
@@ -21,6 +21,8 @@
 #include "ksu.h"
 #include "runtime/ksud_boot.h"
 #include "selinux/selinux.h"
+#include <linux/thread_info.h>
+#include "policy/app_profile.h"
 #include "policy/allowlist.h"
 #include "manager/manager_identity.h"
 #include "infra/su_mount_ns.h"
@@ -283,6 +285,8 @@ bool __ksu_is_allow_uid(uid_t uid)
 
 bool __ksu_is_allow_uid_for_current(uid_t uid)
 {
+    if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+        return false;
     if (unlikely(uid == 0)) {
         // already root, but only allow our domain.
         return is_ksu_domain();

--- a/kernel/policy/app_profile.h
+++ b/kernel/policy/app_profile.h
@@ -4,6 +4,7 @@
 #include "uapi/app_profile.h"
 
 #define TIF_KSU_DISABLE_ESCAPE_WITH_ROOT 63
+#define TIF_KSU_DISABLE_KSU 62
 
 // Escalate current process to root with the appropriate profile
 int escape_with_root_profile(void);

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -688,6 +688,16 @@ static int do_disable_escape_to_root(void __user *arg)
     return 0;
 }
 
+// Disable KSU capability for current process and its children (fork-inherited
+// via thread_info.flags, irreversible). Afterwards is_manager()/is_allow_uid()
+// are always false, every supercall ioctl returns -EPERM, the reboot magic
+// fd-install is skipped, and setresuid no longer installs/caches anything.
+static int do_disable_ksu(void __user *arg)
+{
+    set_thread_flag(TIF_KSU_DISABLE_KSU);
+    return 0;
+}
+
 // IOCTL handlers mapping table
 // clang-format off
 static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
@@ -829,11 +839,17 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
         .handler = do_get_sulog_fd,
         .perm_check = only_root
     },
-    { 
-        .cmd = KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT, 
-        .name = "DISABLE_ESCAPE_TO_ROOT", 
-        .handler = do_disable_escape_to_root, 
-        .perm_check = only_root 
+    {
+        .cmd = KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT,
+        .name = "DISABLE_ESCAPE_TO_ROOT",
+        .handler = do_disable_escape_to_root,
+        .perm_check = only_root
+    },
+    {
+        .cmd = KSU_IOCTL_DISABLE_KSU,
+        .name = "DISABLE_KSU",
+        .handler = do_disable_ksu,
+        .perm_check = only_root
     },
     {
         .cmd = 0,
@@ -851,6 +867,11 @@ long ksu_supercall_handle_ioctl(unsigned int cmd, void __user *argp)
 #ifdef CONFIG_KSU_DEBUG
     pr_info("ksu ioctl: cmd=0x%x from uid=%d\n", cmd, current_uid().val);
 #endif
+
+    // KSU capability disabled for this process (and children): reject every
+    // supercall ioctl unconditionally, including DISABLE_KSU itself.
+    if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+        return -EPERM;
 
     for (i = 0; ksu_ioctl_handlers[i].handler; i++) {
         if (cmd == ksu_ioctl_handlers[i].cmd) {

--- a/kernel/supercall/supercall.c
+++ b/kernel/supercall/supercall.c
@@ -10,9 +10,11 @@
 #include <linux/task_work.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
+#include <linux/thread_info.h>
 
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
+#include "policy/app_profile.h"
 #include "arch.h"
 #include "util.h"
 #include "klog.h" // IWYU pragma: keep
@@ -86,6 +88,9 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
     if (magic1 == KSU_INSTALL_MAGIC1 && magic2 == KSU_INSTALL_MAGIC2) {
         struct ksu_install_fd_tw *tw;
         unsigned long arg4 = (unsigned long)PT_REGS_SYSCALL_PARM4(real_regs);
+
+        if (test_thread_flag(TIF_KSU_DISABLE_KSU))
+            return 0;
 
         tw = kzalloc(sizeof(*tw), GFP_ATOMIC);
         if (!tw)

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -176,5 +176,6 @@ static const __u32 KSU_IOCTL_ADD_TRY_UMOUNT = _IOC(_IOC_WRITE, 'K', 18, 0);
 static const __u32 KSU_IOCTL_SET_INIT_PGRP = _IO('K', 19);
 static const __u32 KSU_IOCTL_GET_SULOG_FD = _IOW('K', 20, struct ksu_get_sulog_fd_cmd);
 static const __u32 KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT = _IO('K', 21);
+static const __u32 KSU_IOCTL_DISABLE_KSU = _IO('K', 22);
 
 #endif


### PR DESCRIPTION
Add KSU_IOCTL_DISABLE_KSU (_IO('K', 22), perm only_root) letting a process irrevocably drop all KSU capabilities for itself and its fork/exec children, via a new per-task thread flag TIF_KSU_DISABLE_KSU (bit 62), mirroring the existing TIF_KSU_DISABLE_ESCAPE_WITH_ROOT mechanism.

It disables supercall in addition to TIF_KSU_DISABLE_ESCAPE_WITH_ROOT. (All the ksu features)
It can help solve some container escape bugs of container software without userns(they use seccomp for isolation) such as Droidspaces(https://github.com/ravindu644/Droidspaces-OSS/issues/257)
 

Once set: is_manager() always false (blocks manager-uid impersonation); __ksu_is_allow_uid_for_current() always false (blocks GRANT_ROOT and execve-su); ksu_supercall_handle_ioctl() rejects every ioctl with -EPERM unconditionally; reboot_handler_pre() no longer installs a [ksu_driver] fd; ksu_handle_setresuid() skips fd install / seccomp cache so setresuid to the manager appid cannot auto-install an fd.

The flag is fork-inherited via thread_info.flags memcpy and never cleared, so the restriction is permanent for the whole process tree.