### PR TITLE
Fix ksud crash (error 134) when installing module with strict memory padding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,7 +996,6 @@ version = "0.1.0"
 dependencies = [
  "adb_client",
  "android-bootimg",
- "android-properties",
  "android_logger",
  "anyhow",
  "base16ct",

--- a/userspace/ksud/Cargo.toml
+++ b/userspace/ksud/Cargo.toml
@@ -29,7 +29,6 @@ android-bootimg = { git = "https://github.com/5ec1cff/android_bootimg", rev = "1
 rustix = { version = "1", features = [
     "all-apis",
 ] }
-android-properties = { version = "0.2", features = ["bionic-deprecated"] }
 android_logger = { version = "0.15", default-features = false }
 zip = { version = "8",  features = [
     "deflate",

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -143,7 +143,7 @@ pub fn getprop(name: &str) -> Option<String> {
         __system_property_read_callback(
             property_info,
             property_read_callback,
-            std::ptr::from_mut(&mut value).cast(),
+            std::ptr::addr_of_mut!(value).cast(),
         );
     }
     value

--- a/userspace/ksud/src/utils.rs
+++ b/userspace/ksud/src/utils.rs
@@ -3,6 +3,7 @@ use rustix::fs::{Mode, OFlags, open};
 use rustix::process::setpgid;
 use rustix::stdio::{dup2_stderr, dup2_stdin, dup2_stdout};
 use std::{
+    ffi::{CStr, CString, c_char, c_void},
     fs::{File, OpenOptions, create_dir_all, remove_file, write},
     io::{
         ErrorKind::{AlreadyExists, NotFound},
@@ -27,6 +28,17 @@ use rustix::{
     process,
     thread::{LinkNameSpaceType, move_into_link_name_space},
 };
+
+type PropertyReadCallback = unsafe extern "C" fn(*mut c_void, *const c_char, *const c_char, u32);
+
+unsafe extern "C" {
+    fn __system_property_find(name: *const c_char) -> *const c_void;
+    fn __system_property_read_callback(
+        property_info: *const c_void,
+        callback: PropertyReadCallback,
+        cookie: *mut c_void,
+    );
+}
 
 #[macro_export]
 macro_rules! debug_select {
@@ -104,8 +116,37 @@ pub fn ensure_binary<T: AsRef<Path>>(
     Ok(())
 }
 
-pub fn getprop(prop: &str) -> Option<String> {
-    android_properties::getprop(prop).value()
+unsafe extern "C" fn property_read_callback(
+    cookie: *mut c_void,
+    _name: *const c_char,
+    value: *const c_char,
+    _serial: u32,
+) {
+    if cookie.is_null() || value.is_null() {
+        return;
+    }
+
+    let result = unsafe { &mut *cookie.cast::<Option<String>>() };
+    let value = unsafe { CStr::from_ptr(value) };
+    *result = Some(value.to_string_lossy().into_owned());
+}
+
+pub fn getprop(name: &str) -> Option<String> {
+    let name = CString::new(name).ok()?;
+    let property_info = unsafe { __system_property_find(name.as_ptr()) };
+    if property_info.is_null() {
+        return None;
+    }
+
+    let mut value = None;
+    unsafe {
+        __system_property_read_callback(
+            property_info,
+            property_read_callback,
+            std::ptr::from_mut(&mut value).cast(),
+        );
+    }
+    value
 }
 
 pub fn is_safe_mode() -> bool {


### PR DESCRIPTION
When using [mimalloc](https://github.com/WeiguangTWK/android_external_mimalloc) with MI_SECURE>=3 enabled in AOSP, I noticed ksud got killed by mimalloc, meaning there's a known heap overflow in ksud

log:

> 1784897719.867  root 16691 16691 E DEBUG   : failed to read process info: failed to open /proc/16687: No such file or directory
> 1784897719.872  root 16691 16691 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
> 1784897719.872  root 16691 16691 F DEBUG   : LineageOS Version: '23.2-20260724-UNOFFICIAL-GMS-marble'
> 1784897719.872  root 16691 16691 F DEBUG   : Build fingerprint: 'POCO/marble_global/marble:15/AQ3A.250226.002/OS3.0.4.0.VMRMIXM:user/release-keys'
> 1784897719.872  root 16691 16691 F DEBUG   : Kernel Release: '5.10.256-gki-g47bc39aca331'
> 1784897719.872  root 16691 16691 F DEBUG   : Revision: '0'
> 1784897719.872  root 16691 16691 F DEBUG   : ABI: 'arm64'
> 1784897719.872  root 16691 16691 F DEBUG   : Timestamp: 2026-07-24 20:55:19.867048099+0800
> 1784897719.872  root 16691 16691 F DEBUG   : Process uptime: 0s
> 1784897719.872  root 16691 16691 F DEBUG   : Executable: /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so
> 1784897719.872  root 16691 16691 F DEBUG   : Cmdline: /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so module install /data/user/0/me.weishu.kernelsu/cache/module.zip
> 1784897719.872  root 16691 16691 F DEBUG   : pid: 16687, tid: 16687, name: libksud.so  >>> /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so <<<
> 1784897719.872  root 16691 16691 F DEBUG   : uid: 0
> 1784897719.872  root 16691 16691 F DEBUG   : tagged_addr_ctrl: 0000000000000001 (PR_TAGGED_ADDR_ENABLE)
> 1784897719.872  root 16691 16691 F DEBUG   : pac_enabled_keys: 000000000000000f (PR_PAC_APIAKEY, PR_PAC_APIBKEY, PR_PAC_APDAKEY, PR_PAC_APDBKEY)
> 1784897719.872  root 16691 16691 F DEBUG   : esr: 0000000092000006 (Data Abort Exception 0x24)
> 1784897719.872  root 16691 16691 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
> 1784897719.872  root 16691 16691 F DEBUG   :     x0  0000000000000000  x1  000000000000412f  x2  0000000000000006  x3  0000007ff1c030f0
> 1784897719.872  root 16691 16691 F DEBUG   :     x4  2e5d160100000000  x5  2e5d160100000000  x6  2e5d160100000000  x7  b400007a8e020b41
> 1784897719.872  root 16691 16691 F DEBUG   :     x8  00000000000000f0  x9  000001ff00000020  x10 000000ff00000020  x11 0000000000000001
> 1784897719.872  root 16691 16691 F DEBUG   :     x12 0000000000000007  x13 0000000000000000  x14 0000000002000000  x15 ae4066445c000000
> 1784897719.872  root 16691 16691 F DEBUG   :     x16 0000007ca1d711f0  x17 0000007ca1d57140  x18 0000007ca54bc000  x19 000000000000412f
> 1784897719.872  root 16691 16691 F DEBUG   :     x20 000000000000412f  x21 00000000ffffffff  x22 00000059d5791fc8  x23 00000059d5807c88
> 1784897719.872  root 16691 16691 F DEBUG   :     x24 00000059d549611f  x25 00000059d58ca000  x26 0000007ff1c03540  x27 00000059d5495ca6
> 1784897719.872  root 16691 16691 F DEBUG   :     x28 00000059d5496640  x29 0000007ff1c03170
> 1784897719.872  root 16691 16691 F DEBUG   :     lr  0000007ca1cf9058  sp  0000007ff1c030f0  pc  0000007ca1cf907c  pst 0000000000001000
> 1784897719.872  root 16691 16691 F DEBUG   :     esr 0000000092000006
> 1784897719.872  root 16691 16691 F DEBUG   : 8 total frames
> 1784897719.872  root 16691 16691 F DEBUG   : backtrace:
> 1784897719.872  root 16691 16691 F DEBUG   :       #00 pc 000000000008a07c  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160) (BuildId: 2cbf676773dfe3634abc9b45f44a3c58)
> 1784897719.872  root 16691 16691 F DEBUG   :       #01 pc 0000000000065ba8  /apex/com.android.runtime/lib64/bionic/libc.so (_mi_error_message+392) (BuildId: 2cbf676773dfe3634abc9b45f44a3c58)
> 1784897719.872  root 16691 16691 F DEBUG   :       #02 pc 0000000000066504  /apex/com.android.runtime/lib64/bionic/libc.so (mi_free_block_local(mi_page_s*, mi_block_s*, bool, bool, bool) (.__uniq.303579168390213215875901568090150437607)+484) (BuildId: 2cbf676773dfe3634abc9b45f44a3c58)
> 1784897719.872  root 16691 16691 F DEBUG   :       #03 pc 000000000005d1c4  /apex/com.android.runtime/lib64/bionic/libc.so (mimalloc_free(void*) (.__uniq.40980702978230381423013916994429309340)+52) (BuildId: 2cbf676773dfe3634abc9b45f44a3c58)
> 1784897719.872  root 16691 16691 F DEBUG   :       #04 pc 00000000002edd34  /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so
> 1784897719.872  root 16691 16691 F DEBUG   :       #05 pc 00000000002dc684  /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so
> 1784897719.872  root 16691 16691 F DEBUG   :       #06 pc 000000000031b4ac  /data/app/~~rfT2ZzIAJhnVDsF4OtRUFw==/me.weishu.kernelsu-Y2yRd5UUxvpC94EUkU7hQg==/lib/arm64/libksud.so
> 1784897719.872  root 16691 16691 F DEBUG   :       #07 pc 000000000007e06c  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+124) (BuildId: 2cbf676773dfe3634abc9b45f44a3c58)

To fix the issue, I dropped [android-properties](https://github.com/miklelappo/android-properties) dependency