### PR TITLE
fix(kernel): Handle execveat for new bionic libc

### DIFF
--- a/.github/workflows/ksuinit.yml
+++ b/.github/workflows/ksuinit.yml
@@ -17,8 +17,13 @@ jobs:
     - name: Setup rustup
       run: |
         rustup update stable
-        rustup target add aarch64-unknown-linux-musl
-        rustup target add x86_64-unknown-linux-musl
+        rustup target add aarch64-linux-android
+        rustup target add x86_64-linux-android
+
+    - uses: nttld/setup-ndk@v1
+      id: setup-ndk
+      with:
+        ndk-version: r29
 
     - uses: Swatinem/rust-cache@v2
       with:
@@ -26,26 +31,33 @@ jobs:
         cache-targets: false
 
     - name: Build ksuinit
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
-        LLVM_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
-        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$LLVM_BIN/aarch64-linux-android26-clang"
-        export RUSTFLAGS="-C link-arg=-no-pie"
-        cargo build --package ksuinit --target=aarch64-unknown-linux-musl --release
+        source .github/scripts/setup-rust-build.sh aarch64-linux-android 26
+        BUILTINS="$($CLANG_PATH --print-resource-dir)/lib/linux/libclang_rt.builtins-aarch64-android.a"
+        test -f "$BUILTINS"
+        export RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wno-unused-command-line-argument -C link-arg=$BUILTINS"
+        cargo build --package ksuinit --target=aarch64-linux-android --release
 
     - name: Upload ksuinit artifact
       uses: actions/upload-artifact@v7
       with:
         name: ksuinit-aarch64
-        path: target/aarch64-unknown-linux-musl/release/ksuinit
+        path: target/aarch64-linux-android/release/ksuinit
 
     - name: Build ksuinit x64
+      env:
+        ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
-        LLVM_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
-        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$LLVM_BIN/x86_64-linux-android26-clang"
-        cargo build --package ksuinit --target=x86_64-unknown-linux-musl --release
+        source .github/scripts/setup-rust-build.sh x86_64-linux-android 26
+        BUILTINS="$($CLANG_PATH --print-resource-dir)/lib/linux/libclang_rt.builtins-x86_64-android.a"
+        test -f "$BUILTINS"
+        export RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wno-unused-command-line-argument -C link-arg=$BUILTINS"
+        cargo build --package ksuinit --target=x86_64-linux-android --release
 
     - name: Upload x64 ksuinit artifact
       uses: actions/upload-artifact@v7
       with:
         name: ksuinit-x86_64
-        path: target/x86_64-unknown-linux-musl/release/ksuinit
+        path: target/x86_64-linux-android/release/ksuinit

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -19,11 +19,10 @@
 
 DEFINE_STATIC_KEY_FALSE(ksu_adb_root);
 
-static long is_exec_adbd(struct pt_regs *regs)
+static long is_exec_adbd(const char __user *filename_user)
 {
     static const char kAdbd[] = "/adbd";
     static const size_t kAdbdLen = sizeof(kAdbd) - 1;
-    char __user *filename_user = (char __user *)PT_REGS_PARM1(regs);
     // should be bigger than `/apex/com.android.adbd/bin/adbd`
     char buf[40];
     char __user *fn;
@@ -65,7 +64,7 @@ static long is_libadbroot_ok()
     return ret;
 }
 
-static long setup_ld_preload(struct pt_regs *regs)
+static long setup_ld_preload(struct pt_regs *regs, unsigned long *envp_p)
 {
     static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
     static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
@@ -73,7 +72,6 @@ static long setup_ld_preload(struct pt_regs *regs)
     static const size_t kPtrSize = sizeof(unsigned long);
     unsigned long stackp = user_stack_pointer(regs);
     unsigned long envp, ld_preload_p, ld_library_path_p;
-    unsigned long *envp_p = (unsigned long *)&PT_REGS_PARM3(regs);
     unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
     size_t env_count = 0, total_size;
     long ret;
@@ -159,9 +157,9 @@ out_release_env_p:
     return ret;
 }
 
-static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
+static long do_ksu_adb_root_handle_execve(const char __user *filename_user, struct pt_regs *regs, unsigned long *envp_p)
 {
-    if (likely(is_exec_adbd(regs) != 1)) {
+    if (likely(is_exec_adbd(filename_user) != 1)) {
         return 0;
     }
 
@@ -169,7 +167,7 @@ static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
         return 0;
     }
 
-    long ret = setup_ld_preload(regs);
+    long ret = setup_ld_preload(regs, envp_p);
     if (ret) {
         return ret;
     }
@@ -182,7 +180,17 @@ static long do_ksu_adb_root_handle_execve(struct pt_regs *regs)
 long ksu_adb_root_handle_execve(struct pt_regs *regs)
 {
     if (static_branch_unlikely(&ksu_adb_root)) {
-        return do_ksu_adb_root_handle_execve(regs);
+        return do_ksu_adb_root_handle_execve((const char __user *)PT_REGS_PARM1(regs), regs,
+                                             (unsigned long *)&PT_REGS_PARM3(regs));
+    }
+    return 0;
+}
+
+long ksu_adb_root_handle_execveat(struct pt_regs *regs)
+{
+    if (static_branch_unlikely(&ksu_adb_root)) {
+        return do_ksu_adb_root_handle_execve((const char __user *)PT_REGS_PARM2(regs), regs,
+                                             (unsigned long *)&PT_REGS_SYSCALL_PARM4(regs));
     }
     return 0;
 }

--- a/kernel/feature/adb_root.h
+++ b/kernel/feature/adb_root.h
@@ -3,6 +3,7 @@
 #include <asm/ptrace.h>
 
 long ksu_adb_root_handle_execve(struct pt_regs *regs);
+long ksu_adb_root_handle_execveat(struct pt_regs *regs);
 
 void ksu_adb_root_init(void);
 

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -1,4 +1,5 @@
 #include "linux/file.h"
+#include "linux/fcntl.h"
 #include "linux/namei.h"
 #include <linux/compiler_types.h>
 #include <linux/preempt.h>
@@ -156,10 +157,11 @@ do_orig_stat:
     return ksu_syscall_table[orig_nr](regs);
 }
 
-long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs)
+static long ksu_handle_execve_sucompat_common(const char __user **filename_user,
+                                              const char __user *const __user *argv_user, unsigned long envp,
+                                              bool execveat, int orig_nr, struct pt_regs *regs)
 {
     const char __user *fn;
-    const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
     struct ksu_sulog_pending_event *pending_sucompat = NULL;
     char path[sizeof(su_path) + 1];
     long ret, orig_regs[5];
@@ -167,6 +169,9 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
     int tmp_fd;
     struct file *ksud_file;
     const struct cred *old_cred;
+
+    if (execveat && ((int)PT_REGS_PARM1(regs) != AT_FDCWD || (int)PT_REGS_PARM5(regs) != 0))
+        goto do_orig_execve;
 
     if (unlikely(!filename_user))
         goto do_orig_execve;
@@ -216,8 +221,8 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
     orig_regs[3] = regs->__PT_SYSCALL_PARM4_REG;
     orig_regs[4] = regs->__PT_PARM5_REG;
     regs->__PT_PARM5_REG = AT_EMPTY_PATH;
-    regs->__PT_SYSCALL_PARM4_REG = regs->__PT_PARM3_REG;
-    regs->__PT_PARM3_REG = regs->__PT_PARM2_REG;
+    regs->__PT_SYSCALL_PARM4_REG = envp;
+    regs->__PT_PARM3_REG = (unsigned long)argv_user;
     regs->__PT_PARM2_REG = empty_user_path();
     regs->__PT_PARM1_REG = tmp_fd;
 
@@ -240,6 +245,18 @@ long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, 
 
 do_orig_execve:
     return ksu_syscall_table[orig_nr](regs);
+}
+
+long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs)
+{
+    return ksu_handle_execve_sucompat_common(filename_user, (const char __user *const __user *)PT_REGS_PARM2(regs),
+                                             PT_REGS_PARM3(regs), false, orig_nr, regs);
+}
+
+long ksu_handle_execveat_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs)
+{
+    return ksu_handle_execve_sucompat_common(filename_user, (const char __user *const __user *)PT_REGS_PARM3(regs),
+                                             PT_REGS_SYSCALL_PARM4(regs), true, orig_nr, regs);
 }
 
 // sucompat: permitted process can execute 'su' to gain root access.

--- a/kernel/feature/sucompat.h
+++ b/kernel/feature/sucompat.h
@@ -12,5 +12,6 @@ void ksu_sucompat_exit(void);
 long ksu_handle_faccessat_sucompat(int orig_nr, struct pt_regs *regs);
 long ksu_handle_stat_sucompat(int orig_nr, struct pt_regs *regs);
 long ksu_handle_execve_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs);
+long ksu_handle_execveat_sucompat(const char __user **filename_user, int orig_nr, struct pt_regs *regs);
 
 #endif

--- a/kernel/hook/syscall_event_bridge.c
+++ b/kernel/hook/syscall_event_bridge.c
@@ -71,28 +71,37 @@ void ksu_stop_ksud_execve_hook()
     static_branch_disable(&ksud_execve_key);
 }
 
-long __nocfi ksu_hook_execve(int orig_nr, const struct pt_regs *regs)
+static long __nocfi ksu_hook_execve_common(int orig_nr, const struct pt_regs *regs, bool execveat)
 {
-    const char __user **filename_user = (const char __user **)&PT_REGS_PARM1(regs);
-    const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
+    const char __user **filename_user =
+        execveat ? (const char __user **)&PT_REGS_PARM2(regs) : (const char __user **)&PT_REGS_PARM1(regs);
+    const char __user *const __user *argv_user = execveat ? (const char __user *const __user *)PT_REGS_PARM3(regs) :
+                                                            (const char __user *const __user *)PT_REGS_PARM2(regs);
     bool current_is_init = is_init(current_cred());
     struct ksu_sulog_pending_event *pending_root_execve = NULL;
     long ret;
 
-    if (static_branch_unlikely(&ksud_execve_key))
-        ksu_execve_hook_ksud(regs);
+    if (static_branch_unlikely(&ksud_execve_key)) {
+        if (execveat) {
+            ksu_execveat_hook_ksud(regs);
+        } else {
+            ksu_execve_hook_ksud(regs);
+        }
+    }
 
     if (current_euid().val == 0)
         pending_root_execve = ksu_sulog_capture_root_execve(*filename_user, argv_user, GFP_KERNEL);
 
     if (current->pid != 1 && current_is_init) {
         ksu_handle_init_mark_tracker(filename_user);
-        ret = ksu_adb_root_handle_execve((struct pt_regs *)regs);
+        ret = execveat ? ksu_adb_root_handle_execveat((struct pt_regs *)regs) :
+                         ksu_adb_root_handle_execve((struct pt_regs *)regs);
         if (ret) {
             pr_err("adb root failed: %ld\n", ret);
         }
     } else if (ksu_su_compat_enabled) {
-        ret = ksu_handle_execve_sucompat(filename_user, orig_nr, (struct pt_regs *)regs);
+        ret = execveat ? ksu_handle_execveat_sucompat(filename_user, orig_nr, (struct pt_regs *)regs) :
+                         ksu_handle_execve_sucompat(filename_user, orig_nr, (struct pt_regs *)regs);
         ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
         return ret;
     }
@@ -100,6 +109,16 @@ long __nocfi ksu_hook_execve(int orig_nr, const struct pt_regs *regs)
     ret = ksu_syscall_table[orig_nr](regs);
     ksu_sulog_emit_pending(pending_root_execve, ret, GFP_KERNEL);
     return ret;
+}
+
+long __nocfi ksu_hook_execve(int orig_nr, const struct pt_regs *regs)
+{
+    return ksu_hook_execve_common(orig_nr, regs, false);
+}
+
+long __nocfi ksu_hook_execveat(int orig_nr, const struct pt_regs *regs)
+{
+    return ksu_hook_execve_common(orig_nr, regs, true);
 }
 
 long __nocfi ksu_hook_setresuid(int orig_nr, const struct pt_regs *regs)

--- a/kernel/hook/syscall_event_bridge.h
+++ b/kernel/hook/syscall_event_bridge.h
@@ -6,6 +6,7 @@
 long ksu_hook_newfstatat(int orig_nr, const struct pt_regs *regs);
 long ksu_hook_faccessat(int orig_nr, const struct pt_regs *regs);
 long ksu_hook_execve(int orig_nr, const struct pt_regs *regs);
+long ksu_hook_execveat(int orig_nr, const struct pt_regs *regs);
 long ksu_hook_setresuid(int orig_nr, const struct pt_regs *regs);
 
 void ksu_stop_ksud_execve_hook(void);

--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -134,6 +134,7 @@ void __init ksu_syscall_hook_manager_init(void)
     // Register syscall hooks via dispatcher
     ksu_register_syscall_hook(__NR_setresuid, ksu_hook_setresuid);
     ksu_register_syscall_hook(__NR_execve, ksu_hook_execve);
+    ksu_register_syscall_hook(__NR_execveat, ksu_hook_execveat);
     ksu_register_syscall_hook(__NR_newfstatat, ksu_hook_newfstatat);
     ksu_register_syscall_hook(__NR_faccessat, ksu_hook_faccessat);
 
@@ -169,6 +170,7 @@ void __exit ksu_syscall_hook_manager_exit(void)
 
     ksu_unregister_syscall_hook(__NR_setresuid);
     ksu_unregister_syscall_hook(__NR_execve);
+    ksu_unregister_syscall_hook(__NR_execveat);
     ksu_unregister_syscall_hook(__NR_newfstatat);
     ksu_unregister_syscall_hook(__NR_faccessat);
 

--- a/kernel/runtime/ksud.h
+++ b/kernel/runtime/ksud.h
@@ -9,6 +9,7 @@ void ksu_ksud_init();
 void ksu_ksud_exit();
 
 void ksu_execve_hook_ksud(const struct pt_regs *regs);
+void ksu_execveat_hook_ksud(const struct pt_regs *regs);
 void ksu_stop_input_hook_runtime(void);
 
 #endif

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -519,11 +519,9 @@ bool ksu_is_safe_mode()
     return false;
 }
 
-void ksu_execve_hook_ksud(const struct pt_regs *regs)
+static void ksu_execve_hook_ksud_common(const char __user *filename_user, const char __user *const __user *argv_user)
 {
-    const char __user **filename_user = (const char **)&PT_REGS_PARM1(regs);
-    const char __user *const __user *__argv = (const char __user *const __user *)PT_REGS_PARM2(regs);
-    struct user_arg_ptr argv = { .ptr.native = __argv };
+    struct user_arg_ptr argv = { .ptr.native = argv_user };
     char path[32];
     long ret;
     unsigned long addr;
@@ -532,7 +530,7 @@ void ksu_execve_hook_ksud(const struct pt_regs *regs)
     if (!filename_user)
         return;
 
-    addr = untagged_addr((unsigned long)*filename_user);
+    addr = untagged_addr((unsigned long)filename_user);
     fn = (const char __user *)addr;
 
     memset(path, 0, sizeof(path));
@@ -543,6 +541,22 @@ void ksu_execve_hook_ksud(const struct pt_regs *regs)
     }
 
     ksu_handle_execveat_ksud(path, &argv);
+}
+
+void ksu_execve_hook_ksud(const struct pt_regs *regs)
+{
+    const char __user *filename_user = (const char __user *)PT_REGS_PARM1(regs);
+    const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM2(regs);
+
+    ksu_execve_hook_ksud_common(filename_user, argv_user);
+}
+
+void ksu_execveat_hook_ksud(const struct pt_regs *regs)
+{
+    const char __user *filename_user = (const char __user *)PT_REGS_PARM2(regs);
+    const char __user *const __user *argv_user = (const char __user *const __user *)PT_REGS_PARM3(regs);
+
+    ksu_execve_hook_ksud_common(filename_user, argv_user);
 }
 
 static long (*orig_sys_read)(const struct pt_regs *regs);


### PR DESCRIPTION
New bionic in A17 QPR2 Beta3 maps all execve calls to execveat. So we have to handle it in four areas: ksud integration, tracepoint hook, sucompat, adb root.
```
execve @ 0xD4700
  signal(36, SIG_IGN)
  signal(38, SIG_IGN)
  jmp __execveat(AT_FDCWD, path, argv, envp, 0)

execv @ 0x8F5D0
  envp = environ
  signal(36, SIG_IGN)
  signal(38, SIG_IGN)
  jmp __execveat(AT_FDCWD, path, argv, envp, 0)

__execveat @ 0x5BCB0
  mov eax, 0x142       ; __NR_execveat = 322
  syscall
```