### PR TITLE
manager: defer module repo WebViews until pager settles

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMaterial.kt
@@ -443,6 +443,7 @@ fun ModuleRepoDetailScreenMaterial(
                 )
                 when (page) {
                     0 -> ReadmePage(
+                        contentReadyForWebView = pagerState.settledPage == page,
                         readmeHtml = state.readmeHtml,
                         readmeLoaded = state.readmeLoaded,
                         innerPadding = paddedInnerPadding,
@@ -450,6 +451,7 @@ fun ModuleRepoDetailScreenMaterial(
                     )
 
                     1 -> ReleasesPage(
+                        contentReadyForWebView = pagerState.settledPage == page,
                         detailReleases = state.detailReleases,
                         innerPadding = paddedInnerPadding,
                         scrollBehavior = scrollBehavior,
@@ -489,6 +491,7 @@ fun ModuleRepoDetailScreenMaterial(
 
 @Composable
 private fun ReadmePage(
+    contentReadyForWebView: Boolean,
     readmeHtml: String?,
     readmeLoaded: Boolean,
     innerPadding: PaddingValues,
@@ -517,7 +520,7 @@ private fun ReadmePage(
                     label = "ReadmeAlpha",
                 )
                 Box {
-                    if (isReady) {
+                    if (isReady && contentReadyForWebView) {
                         Box(modifier = Modifier.graphicsLayer { this.alpha = alpha }) {
                             GithubMarkdown(
                                 content = readmeHtml,
@@ -554,6 +557,7 @@ private fun ReadmePage(
 @SuppressLint("DefaultLocale")
 @Composable
 fun ReleasesPage(
+    contentReadyForWebView: Boolean,
     detailReleases: List<ReleaseArg>,
     innerPadding: PaddingValues,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -621,7 +625,7 @@ fun ReleasesPage(
                                             .padding(horizontal = 16.dp, vertical = 12.dp)
                                             .animateContentSize(animationSpec = tween(durationMillis = 300)),
                                     ) {
-                                        if (descReady) {
+                                        if (descReady && contentReadyForWebView) {
                                             Box(modifier = Modifier.graphicsLayer { this.alpha = descAlpha }) {
                                                 GithubMarkdown(
                                                     content = rel.descriptionHTML,

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/modulerepo/ModuleRepoMiuix.kt
@@ -544,6 +544,7 @@ fun ModuleRepoScreenMiuix(
 
 @Composable
 private fun ReadmePage(
+    contentReadyForWebView: Boolean,
     readmeHtml: String?,
     readmeLoaded: Boolean,
     innerPadding: PaddingValues, scrollBehavior: ScrollBehavior, backdrop: LayerBackdrop?
@@ -579,7 +580,7 @@ private fun ReadmePage(
                         label = "MiuixReadmePlaceholderAlpha",
                     )
                     Box {
-                        if (isReady) {
+                        if (isReady && contentReadyForWebView) {
                             Box(modifier = Modifier.graphicsLayer { this.alpha = alpha }) {
                                 Column {
                                     GithubMarkdown(
@@ -617,6 +618,7 @@ private fun ReadmePage(
 @SuppressLint("DefaultLocale")
 @Composable
 fun ReleasesPage(
+    contentReadyForWebView: Boolean,
     detailReleases: List<ReleaseArg>,
     innerPadding: PaddingValues,
     scrollBehavior: ScrollBehavior,
@@ -721,7 +723,7 @@ fun ReleasesPage(
                                                     .fillMaxWidth()
                                                     .animateContentSize(animationSpec = tween(durationMillis = 300)),
                                             ) {
-                                                if (descReady) {
+                                                if (descReady && contentReadyForWebView) {
                                                     Box(modifier = Modifier.graphicsLayer { this.alpha = descAlpha }) {
                                                         GithubMarkdown(
                                                             content = rel.descriptionHTML,
@@ -1123,6 +1125,7 @@ fun ModuleRepoDetailScreenMiuix(
 
             when (page) {
                 0 -> ReadmePage(
+                    contentReadyForWebView = pagerState.settledPage == page,
                     readmeHtml = state.readmeHtml,
                     readmeLoaded = state.readmeLoaded,
                     innerPadding = innerPadding,
@@ -1131,6 +1134,7 @@ fun ModuleRepoDetailScreenMiuix(
                 )
 
                 1 -> ReleasesPage(
+                    contentReadyForWebView = pagerState.settledPage == page,
                     detailReleases = state.detailReleases,
                     innerPadding = innerPadding,
                     scrollBehavior = scrollBehavior,


### PR DESCRIPTION
## Summary

Mitigates a crash reported when navigating from the module README page to
the Releases page for modules with large release descriptions.

The README and release descriptions are rendered using WebViews. During an
animated pager transition, both the previous page and the target page may be
composed at the same time. This can cause the README WebView and multiple
release-description WebViews to coexist temporarily, significantly increasing
memory pressure.

This change defers creation of the heavy Markdown/WebView content until the
pager has settled on the corresponding page.

The same lifecycle handling is applied to both the Material and Miuix module
repository detail implementations.

## Changes

- only compose README Markdown after the pager settles on the README page
- only compose release Markdown after the pager settles on the Releases page
- keep lightweight page structure available during pager animation
- apply the same behavior to Material and Miuix UIs

## Testing

- built KernelSU Manager with:
  `clean assembleRelease -PIS_PR_BUILD=true`
- verified both Manager UI implementations compile successfully

Addresses #3636.

The reported navigation pattern is consistent with overlapping heavy WebView
composition and increased memory pressure. The issue currently has no usable
crash log, so this PR intentionally does not claim that the root cause has been
conclusively proven.