### PR TITLE
manager: stop and clean cancelled downloads

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/DownloadManager.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/DownloadManager.kt
@@ -67,27 +67,51 @@ object DownloadManager {
     internal fun updateProgress(id: Int, progress: Int) {
         _downloads.update { map ->
             val state = map[id] ?: return@update map
+            if (state.status == Status.COMPLETED || state.status == Status.FAILED) {
+                return@update map
+            }
             map + (id to state.copy(progress = progress, status = Status.DOWNLOADING))
         }
     }
 
-    internal fun markCompleted(id: Int, uri: Uri) {
-        _downloads.update { map ->
-            val state = map[id] ?: return@update map
-            map + (id to state.copy(status = Status.COMPLETED, progress = 100, resultUri = uri))
+    internal fun tryMarkCompleted(id: Int, uri: Uri): Boolean {
+        if (!tryTransitionToTerminal(id) { state ->
+                state.copy(status = Status.COMPLETED, progress = 100, resultUri = uri)
+            }) {
+            return false
         }
 
         val callback = completionCallbacks.remove(id)
         if (callback != null) {
             mainHandler.post { callback(uri) }
         }
+        return true
     }
 
-    internal fun markFailed(id: Int, error: String) {
-        _downloads.update { map ->
-            val state = map[id] ?: return@update map
-            map + (id to state.copy(status = Status.FAILED, error = error))
+    internal fun tryMarkFailed(id: Int, error: String): Boolean {
+        if (!tryTransitionToTerminal(id) { state ->
+                state.copy(status = Status.FAILED, error = error)
+            }) {
+            return false
         }
         completionCallbacks.remove(id)
+        return true
+    }
+
+    private inline fun tryTransitionToTerminal(
+        id: Int,
+        transform: (DownloadState) -> DownloadState,
+    ): Boolean {
+        while (true) {
+            val current = _downloads.value
+            val state = current[id] ?: return false
+            if (state.status == Status.COMPLETED || state.status == Status.FAILED) {
+                return false
+            }
+            val updated = current + (id to transform(state))
+            if (_downloads.compareAndSet(current, updated)) {
+                return true
+            }
+        }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/DownloadService.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/DownloadService.kt
@@ -17,11 +17,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import me.weishu.kernelsu.R
 import me.weishu.kernelsu.data.repository.SettingsRepositoryImpl
 import me.weishu.kernelsu.ksuApp
 import me.weishu.kernelsu.ui.MainActivity
+import okhttp3.Call
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
@@ -47,6 +49,7 @@ class DownloadService : Service() {
     }
 
     private val activeJobs = ConcurrentHashMap<Int, Job>()
+    private val activeCalls = ConcurrentHashMap<Int, Call>()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private lateinit var notificationManager: NotificationManager
 
@@ -83,9 +86,10 @@ class DownloadService : Service() {
                 val downloadId = intent.getIntExtra(EXTRA_DOWNLOAD_ID, -1)
                 if (downloadId != -1) {
                     activeJobs[downloadId]?.cancel()
+                    activeCalls.remove(downloadId)?.cancel()
                     activeJobs.remove(downloadId)
                     notificationManager.cancel(downloadId)
-                    DownloadManager.markFailed(downloadId, "Cancelled")
+                    DownloadManager.tryMarkFailed(downloadId, "Cancelled")
                     stopForegroundIfIdle()
                 }
             }
@@ -106,66 +110,87 @@ class DownloadService : Service() {
 
     private fun startDownload(id: Int, url: String, fileName: String) {
         val job = serviceScope.launch {
-            val target = resolveAvailableTarget(
-                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-                fileName
-            )
+            var target: File? = null
             try {
-                ksuApp.okhttpClient.newCall(Request.Builder().url(url).build()).execute()
-                    .use { resp ->
-                        if (!resp.isSuccessful) throw IOException("HTTP ${resp.code}")
-                        val body = resp.body
-                        val total = body.contentLength()
+                val targetFile = reserveAvailableTarget(
+                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                    fileName
+                )
+                target = targetFile
+                ensureActive()
+                val call = ksuApp.okhttpClient.newCall(Request.Builder().url(url).build())
+                activeCalls[id] = call
+                ensureActive()
+                call.execute().use { resp ->
+                    if (!resp.isSuccessful) throw IOException("HTTP ${resp.code}")
+                    val body = resp.body
+                    val total = body.contentLength()
 
-                        FileOutputStream(target).use { fos ->
-                            val buf = ByteArray(8 * 1024)
-                            var soFar = 0L
-                            var lastNotifiedProgress = -1
-                            val source = body.byteStream()
+                    FileOutputStream(targetFile).use { fos ->
+                        val buf = ByteArray(8 * 1024)
+                        var soFar = 0L
+                        var lastNotifiedProgress = -1
+                        val source = body.byteStream()
 
-                            while (true) {
-                                val read = source.read(buf)
-                                if (read == -1) break
-                                fos.write(buf, 0, read)
-                                soFar += read
+                        while (true) {
+                            ensureActive()
+                            val read = source.read(buf)
+                            ensureActive()
+                            if (read == -1) break
+                            fos.write(buf, 0, read)
+                            soFar += read
 
-                                if (total > 0) {
-                                    val percent =
-                                        ((soFar * 100L) / total).toInt().coerceIn(0, 100)
-                                    DownloadManager.updateProgress(id, percent)
+                            if (total > 0) {
+                                val percent =
+                                    ((soFar * 100L) / total).toInt().coerceIn(0, 100)
+                                DownloadManager.updateProgress(id, percent)
 
-                                    if (percent - lastNotifiedProgress >= 2 || percent == 100) {
-                                        notificationManager.notify(
-                                            id,
-                                            buildProgressNotification(id, target.name, percent)
-                                        )
-                                        lastNotifiedProgress = percent
-                                    }
+                                if (percent - lastNotifiedProgress >= 2 || percent == 100) {
+                                    notificationManager.notify(
+                                        id,
+                                        buildProgressNotification(id, targetFile.name, percent)
+                                    )
+                                    lastNotifiedProgress = percent
                                 }
                             }
-                            fos.flush()
                         }
+                        fos.flush()
                     }
+                }
 
-                val uri = Uri.fromFile(target)
-                DownloadManager.markCompleted(id, uri)
+                ensureActive()
+                val uri = Uri.fromFile(targetFile)
+                if (!DownloadManager.tryMarkCompleted(id, uri)) {
+                    targetFile.delete()
+                    return@launch
+                }
+                target = null
 
-                notificationManager.cancel(id)
-                notificationManager.notify(
-                    COMPLETION_NOTIFICATION_ID_BASE + id,
-                    buildCompletionNotification(id, target.name, uri)
-                )
+                try {
+                    notificationManager.cancel(id)
+                    notificationManager.notify(
+                        COMPLETION_NOTIFICATION_ID_BASE + id,
+                        buildCompletionNotification(id, targetFile.name, uri)
+                    )
+                } catch (_: Exception) {
+                    // The download is already complete. Notification failures must not delete it
+                    // or rewrite its terminal state.
+                }
             } catch (e: CancellationException) {
+                target?.delete()
                 throw e
             } catch (e: Exception) {
-                DownloadManager.markFailed(id, e.message ?: "Unknown error")
-
-                notificationManager.cancel(id)
-                notificationManager.notify(
-                    COMPLETION_NOTIFICATION_ID_BASE + id,
-                    buildFailureNotification(target.name)
-                )
+                target?.delete()
+                ensureActive()
+                if (DownloadManager.tryMarkFailed(id, e.message ?: "Unknown error")) {
+                    notificationManager.cancel(id)
+                    notificationManager.notify(
+                        COMPLETION_NOTIFICATION_ID_BASE + id,
+                        buildFailureNotification(target?.name ?: fileName)
+                    )
+                }
             } finally {
+                activeCalls.remove(id)
                 activeJobs.remove(id)
                 stopForegroundIfIdle()
             }
@@ -173,10 +198,14 @@ class DownloadService : Service() {
         activeJobs[id] = job
     }
 
-    private fun resolveAvailableTarget(
+    private fun reserveAvailableTarget(
         directory: File,
         fileName: String
     ): File {
+        if (!directory.isDirectory && !directory.mkdirs() && !directory.isDirectory) {
+            throw IOException("Unable to create download directory: $directory")
+        }
+
         val dotIndex = fileName.lastIndexOf('.')
         val baseName = if (dotIndex > 0) fileName.substring(0, dotIndex) else fileName
         val extension = if (dotIndex > 0) fileName.substring(dotIndex) else ""
@@ -189,7 +218,7 @@ class DownloadService : Service() {
                 "$baseName ($index)$extension"
             }
             val candidate = File(directory, candidateName)
-            if (!candidate.exists()) {
+            if (candidate.createNewFile()) {
                 return candidate
             }
             index++


### PR DESCRIPTION
## Summary

Improve the Manager download lifecycle so cancelled or failed downloads do not
continue writing data or leave partial files in the Downloads directory.

Previously, cancelling a download cancelled the coroutine Job, but the blocking
response read loop did not explicitly observe coroutine cancellation. A task
could therefore continue processing data and potentially reach the completion
path after cancellation.

Failed or cancelled transfers could also leave partially downloaded files
behind. Subsequent downloads with the same filename would then be renamed,
accumulating stale partial files.

## Changes

- check coroutine cancellation while streaming response data
- prevent a cancelled download from reaching markCompleted()
- remove partially written files after cancellation
- remove partially written files after download failures
- reserve the destination filename atomically with createNewFile()
- avoid races between simultaneous downloads choosing the same target name
- handle target-directory and target-file reservation failures through the
  normal failure/cleanup lifecycle
- cancel the active OkHttp `Call` together with the coroutine `Job`, so cancellation can interrupt a blocking network read
- preserve the `Cancelled` state when OkHttp surfaces call cancellation as an `IOException`

## Testing

- `clean assembleRelease -PIS_PR_BUILD=true` passed before the final rebase
- rebased onto current `main` (`af62466b70c0ebf8f9340e3a9bf0a487d804ca66`)
- post-rebase diff contains one clean commit touching only `DownloadManager.kt` and `DownloadService.kt`
- fresh upstream Build Manager CI is awaiting upstream approval