### PR TITLE
selinux hide: spoof status page and avd seqno

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -317,6 +317,7 @@ static int ksu_selinux_hide_enable()
         pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
         return -EAGAIN;
     }
+    backup_sepolicy->latest_granting = 1;
     selinux_write_op = find_kernel_symbol_exact("write_op");
     if (!selinux_write_op) {
         pr_err("selinux_hide: no write_op found!\n");

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -269,12 +269,13 @@ static void initialize_fake_status()
 
     struct selinux_kernel_status *new_status = page_address(new_page);
     memcpy(new_status, status, sizeof(*status));
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+    new_status->sequence = 4;
+#else
+    new_status->sequence = 0;
+#endif
     if (ksu_late_loaded && !new_status->enforcing) {
-        // In late_load mode, we may be loaded when selinux was set to permissive
-        // So we need to modify the sequence value
-        // We assume that setenforce 0 is just called once
         new_status->enforcing = 1;
-        new_status->sequence = new_status->policyload ? 4 : 0;
     }
 
     fake_status = new_page;

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -131,9 +131,6 @@ out:
     return length;
 }
 
-// stock reads 1; late load may follow a loader load_policy that bumped the backup
-static u32 fake_avd_seqno __read_mostly = 1;
-
 static ssize_t my_write_access(struct file *file, char *buf, size_t size)
 {
     // apply to all app uids
@@ -191,7 +188,8 @@ static ssize_t my_write_access(struct file *file, char *buf, size_t size)
     security_compute_av_user(&fake_state, ssid, tsid, tclass, &avd);
 #endif
 
-    avd.seqno = fake_avd_seqno;
+    // stock reads 1; a loader load_policy may have bumped the backup before we load
+    avd.seqno = 1;
     length = scnprintf(buf, SIMPLE_TRANSACTION_LIMIT, "%x %x %x %x %u %x", avd.allowed, 0xffffffff, avd.auditallow,
                        avd.auditdeny, avd.seqno, avd.flags);
 out:

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -269,15 +269,21 @@ static void initialize_fake_status()
 
     struct selinux_kernel_status *new_status = page_address(new_page);
     memcpy(new_status, status, sizeof(*status));
+    if (ksu_late_loaded) {
+        // In late_load mode the loader may have reloaded sepolicy before us,
+        // so the captured page is not stock. Serve what a stock boot ends
+        // with instead: creation sentinel below 6.10, one load plus one
+        // setenforce above.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
-    new_status->sequence = 4;
-    new_status->policyload = 1;
+        new_status->sequence = 4;
+        new_status->policyload = 1;
 #else
-    new_status->sequence = 0;
-    new_status->policyload = 0;
+        new_status->sequence = 0;
+        new_status->policyload = 0;
 #endif
-    if (ksu_late_loaded && !new_status->enforcing) {
-        new_status->enforcing = 1;
+        if (!new_status->enforcing) {
+            new_status->enforcing = 1;
+        }
     }
 
     fake_status = new_page;

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -131,6 +131,9 @@ out:
     return length;
 }
 
+// stock reads 1; late load may follow a loader load_policy that bumped the backup
+static u32 fake_avd_seqno __read_mostly = 1;
+
 static ssize_t my_write_access(struct file *file, char *buf, size_t size)
 {
     // apply to all app uids
@@ -188,6 +191,7 @@ static ssize_t my_write_access(struct file *file, char *buf, size_t size)
     security_compute_av_user(&fake_state, ssid, tsid, tclass, &avd);
 #endif
 
+    avd.seqno = fake_avd_seqno;
     length = scnprintf(buf, SIMPLE_TRANSACTION_LIMIT, "%x %x %x %x %u %x", avd.allowed, 0xffffffff, avd.auditallow,
                        avd.auditdeny, avd.seqno, avd.flags);
 out:
@@ -326,7 +330,6 @@ static int ksu_selinux_hide_enable()
         pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
         return -EAGAIN;
     }
-    backup_sepolicy->latest_granting = 1;
     selinux_write_op = find_kernel_symbol_exact("write_op");
     if (!selinux_write_op) {
         pr_err("selinux_hide: no write_op found!\n");

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -271,8 +271,10 @@ static void initialize_fake_status()
     memcpy(new_status, status, sizeof(*status));
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
     new_status->sequence = 4;
+    new_status->policyload = 1;
 #else
     new_status->sequence = 0;
+    new_status->policyload = 0;
 #endif
     if (ksu_late_loaded && !new_status->enforcing) {
         new_status->enforcing = 1;


### PR DESCRIPTION
sets both to the stock value for the kernel: sequence 0 and policyload 0 below 6.10, sequence 4 and policyload 1 on 6.10 and up.

on late load, the backup can be done after policy is modified (such as when we use exploit to turn selinux to permissive then do loadd_policy to reload policy after the exploit fucks it up. so restore avd seqno to 1