### PR TITLE
Harden runtime paths and module isolation

### DIFF
--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -189,7 +189,9 @@ int __init kernelsu_init(void)
 
 void __exit kernelsu_exit(void)
 {
-    // Phase 1: Stop all hooks first to prevent new callbacks
+    // Phase 1: stop every KernelSU entry point before releasing state.
+    // The hook manager fail-stops if a persistent module-text target cannot
+    // be detached because module_exit() cannot cancel an unload in progress.
     ksu_syscall_hook_manager_exit();
 
     ksu_supercalls_exit();

--- a/kernel/feature/adb_root.c
+++ b/kernel/feature/adb_root.c
@@ -67,11 +67,10 @@ static long is_libadbroot_ok()
 static long setup_ld_preload(struct pt_regs *regs, unsigned long *envp_p)
 {
     static const char kLdPreload[] = "LD_PRELOAD=/data/adb/ksu/lib/libadbroot.so";
-    static const char kLdLibraryPath[] = "LD_LIBRARY_PATH=/data/adb/ksu/lib";
     static const size_t kReadEnvBatch = 16;
     static const size_t kPtrSize = sizeof(unsigned long);
-    unsigned long stackp = user_stack_pointer(regs);
-    unsigned long envp, ld_preload_p, ld_library_path_p;
+    unsigned long stackp = ksu_user_stack_scratch_top(user_stack_pointer(regs));
+    unsigned long envp, ld_preload_p;
     unsigned long *tmp_env_p = NULL, *tmp_env_p2 = NULL;
     size_t env_count = 0, total_size;
     long ret;
@@ -82,13 +81,6 @@ static long setup_ld_preload(struct pt_regs *regs, unsigned long *envp_p)
     ret = copy_to_user(ld_preload_p, kLdPreload, sizeof(kLdPreload));
     if (ret != 0) {
         pr_warn("write ld_preload when adb_root_handle_execve failed: %ld\n", ret);
-        return -EFAULT;
-    }
-
-    ld_library_path_p = stackp = ALIGN_DOWN(stackp - sizeof(kLdLibraryPath), 8);
-    ret = copy_to_user(ld_library_path_p, kLdLibraryPath, sizeof(kLdLibraryPath));
-    if (ret != 0) {
-        pr_warn("write ld_library_path when adb_root_handle_execve failed: %ld\n", ret);
         return -EFAULT;
     }
 
@@ -134,7 +126,6 @@ static long setup_ld_preload(struct pt_regs *regs, unsigned long *envp_p)
     // We should have allocated enough memory
     // TODO: handle existing LD_PRELOAD
     tmp_env_p[env_count++] = ld_preload_p;
-    tmp_env_p[env_count++] = ld_library_path_p;
     tmp_env_p[env_count++] = 0;
     total_size = env_count * kPtrSize;
 
@@ -172,7 +163,7 @@ static long do_ksu_adb_root_handle_execve(const char __user *filename_user, stru
         return ret;
     }
 
-    pr_info("escape to root for adb\n");
+    pr_debug("escape to root for adb\n");
     escape_to_root_for_adb_root();
     return 0;
 }

--- a/kernel/feature/kernel_umount.c
+++ b/kernel/feature/kernel_umount.c
@@ -9,6 +9,7 @@
 #include <linux/nsproxy.h>
 #include <linux/path.h>
 #include <linux/printk.h>
+#include <linux/string.h>
 #include <linux/types.h>
 
 #include "feature/kernel_umount.h"
@@ -24,14 +25,14 @@ bool ksu_webview_zygote_umount_enabled = false;
 
 static int kernel_umount_feature_get(u64 *value)
 {
-    *value = ksu_kernel_umount_enabled ? 1 : 0;
+    *value = READ_ONCE(ksu_kernel_umount_enabled) ? 1 : 0;
     return 0;
 }
 
 static int kernel_umount_feature_set(u64 value)
 {
     bool enable = value != 0;
-    ksu_kernel_umount_enabled = enable;
+    WRITE_ONCE(ksu_kernel_umount_enabled, enable);
     pr_info("kernel_umount: set to %d\n", enable);
     return 0;
 }
@@ -45,14 +46,14 @@ static const struct ksu_feature_handler kernel_umount_handler = {
 
 static int webview_zygote_umount_feature_get(u64 *value)
 {
-    *value = ksu_webview_zygote_umount_enabled ? 1 : 0;
+    *value = READ_ONCE(ksu_webview_zygote_umount_enabled) ? 1 : 0;
     return 0;
 }
 
 static int webview_zygote_umount_feature_set(u64 value)
 {
     bool enable = value != 0;
-    ksu_webview_zygote_umount_enabled = enable;
+    WRITE_ONCE(ksu_webview_zygote_umount_enabled, enable);
     pr_info("webview_zygote_umount: set to %d\n", enable);
     return 0;
 }
@@ -70,7 +71,7 @@ static void ksu_umount_mnt(const char *mnt, struct path *path, int flags)
 {
     int err = path_umount(path, flags);
     if (err) {
-        pr_info("umount %s failed: %d\n", mnt, err);
+        pr_debug("umount %s failed: %d\n", mnt, err);
     }
 }
 
@@ -98,11 +99,11 @@ struct umount_tw {
 int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
 {
     // if there isn't any module mounted, just ignore it!
-    if (!ksu_module_mounted) {
+    if (!READ_ONCE(ksu_module_mounted)) {
         return 0;
     }
 
-    if (!ksu_kernel_umount_enabled) {
+    if (!READ_ONCE(ksu_kernel_umount_enabled)) {
         return 0;
     }
 
@@ -117,6 +118,12 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
         return 0;
     }
 
+    // WebView zygote is handled explicitly because it is not part of the
+    // normal app allowlist path; its child processes inherit this isolation.
+    if (new_uid == WEBVIEW_ZYGOTE_UID && !READ_ONCE(ksu_webview_zygote_umount_enabled)) {
+        return 0;
+    }
+
     if (!ksu_uid_should_umount(new_uid) && !is_isolated_process(new_uid)) {
         return 0;
     }
@@ -127,19 +134,51 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid)
     // also handle case 4 and 5
     bool is_zygote_child = is_zygote(current_cred());
     if (!is_zygote_child) {
-        pr_info("handle umount ignore non zygote child: %d\n", current->pid);
+        pr_debug("handle umount ignore non zygote child: %d\n", current->pid);
         return 0;
     }
     // umount the target mnt
-    pr_info("handle umount for uid: %d, pid: %d\n", new_uid, current->pid);
+    pr_debug("handle umount for uid: %d, pid: %d\n", new_uid, current->pid);
 
     const struct cred *saved = override_creds(ksu_cred);
 
     struct mount_entry *entry;
     down_read(&mount_list_lock);
     list_for_each_entry (entry, &mount_list, list) {
-        pr_info("%s: unmounting: %s flags: 0x%x\n", __func__, entry->umountable, entry->flags);
-        try_umount(entry->umountable, entry->flags);
+        struct mount_entry *other;
+        unsigned int flags = 0;
+        unsigned int layers = 0;
+        unsigned int layer;
+        bool seen = false;
+
+        /*
+         * A path can have both an unmanaged/manual entry and an auto-managed
+         * entry. Treat them as one isolation target: summing layer counts
+         * could unmount through the KernelSU stack into the real system mount,
+         * while processing only one entry could leave a lower KSU layer visible.
+         */
+        list_for_each_entry (other, &mount_list, list) {
+            if (other == entry)
+                break;
+            if (!strcmp(other->umountable, entry->umountable)) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen)
+            continue;
+
+        list_for_each_entry (other, &mount_list, list) {
+            if (strcmp(other->umountable, entry->umountable))
+                continue;
+            flags |= other->flags;
+            if (other->layers > layers)
+                layers = other->layers;
+        }
+
+        pr_debug("%s: unmounting: %s flags: 0x%x layers: %u\n", __func__, entry->umountable, flags, layers);
+        for (layer = 0; layer < layers; layer++)
+            try_umount(entry->umountable, flags);
     }
     up_read(&mount_list_lock);
 
@@ -158,7 +197,7 @@ void __init ksu_kernel_umount_init(void)
     }
 }
 
-void __exit ksu_kernel_umount_exit(void)
+void ksu_kernel_umount_exit(void)
 {
     ksu_unregister_feature_handler(KSU_FEATURE_WEBVIEW_ZYGOTE_UMOUNT);
     ksu_unregister_feature_handler(KSU_FEATURE_KERNEL_UMOUNT);

--- a/kernel/feature/kernel_umount.h
+++ b/kernel/feature/kernel_umount.h
@@ -16,6 +16,10 @@ int ksu_handle_umount(uid_t old_uid, uid_t new_uid);
 struct mount_entry {
     char *umountable;
     unsigned int flags;
+    unsigned int layers;
+    unsigned int managed_layers;
+    bool managed;
+    bool unmanaged;
     struct list_head list;
 };
 extern struct list_head mount_list;

--- a/kernel/feature/selinux_hide.h
+++ b/kernel/feature/selinux_hide.h
@@ -6,5 +6,7 @@ void ksu_selinux_hide_exit();
 void ksu_selinux_hide_drop_backup_if_unused();
 void ksu_selinux_hide_handle_second_stage();
 void ksu_selinux_hide_handle_post_fs_data();
+int ksu_selinux_hide_prepare_unload(void);
+int ksu_selinux_hide_abort_unload(void);
 
 #endif

--- a/kernel/feature/sucompat.c
+++ b/kernel/feature/sucompat.c
@@ -57,7 +57,7 @@ static void __user *userspace_stack_buffer(const void *d, size_t len)
 {
     // To avoid having to mmap a page in userspace, just write below the stack
     // pointer.
-    char __user *p = (void __user *)current_user_stack_pointer() - len;
+    char __user *p = (void __user *)ksu_user_stack_scratch_top(current_user_stack_pointer()) - len;
 
     return copy_to_user(p, d, len) ? NULL : p;
 }
@@ -267,7 +267,7 @@ void __init ksu_sucompat_init()
     }
 }
 
-void __exit ksu_sucompat_exit()
+void ksu_sucompat_exit()
 {
     ksu_unregister_feature_handler(KSU_FEATURE_SU_COMPAT);
 }

--- a/kernel/hook/arm64/syscall_hook.c
+++ b/kernel/hook/arm64/syscall_hook.c
@@ -13,20 +13,19 @@
 syscall_fn_t *ksu_syscall_table = NULL;
 int ksu_dispatcher_nr = -1;
 
-// Hook registration table — read with READ_ONCE from tracepoint/dispatcher
-// context, written with WRITE_ONCE from init/exit context.
 static ksu_syscall_hook_fn syscall_hooks[__NR_syscalls];
 
-// Track all hooked syscall entries for restoration.
-// Protected by hooked_entries_lock.
 struct syscall_hook_entry {
     int nr;
     syscall_fn_t orig;
+    syscall_fn_t hook;
+    bool restore_on_abort;
 };
 
 static DEFINE_MUTEX(hooked_entries_lock);
 static struct syscall_hook_entry hooked_entries[16];
-static int hooked_count = 0;
+static int hooked_count;
+static bool direct_hooks_prepared;
 
 static int patch_syscall_table(int nr, syscall_fn_t fn)
 {
@@ -46,72 +45,117 @@ static int patch_syscall_table(int nr, syscall_fn_t fn)
     return 0;
 }
 
-// Direct syscall table patching: overwrite syscall_table[nr] with fn,
-// save original to *old, and record for restoration at module exit.
-void ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old)
+int ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old)
 {
+    bool added = false;
+    int entry_idx = -1;
+    syscall_fn_t current_fn;
+    int i;
+    int ret;
+
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls) {
         pr_info("invalid nr: %d\n", nr);
-        return;
+        return -EINVAL;
     }
 
     mutex_lock(&hooked_entries_lock);
+    if (direct_hooks_prepared) {
+        ret = -ESHUTDOWN;
+        goto out_unlock;
+    }
 
-    syscall_fn_t orig = READ_ONCE(ksu_syscall_table[nr]);
+    current_fn = READ_ONCE(ksu_syscall_table[nr]);
     if (old)
-        *old = orig;
+        *old = current_fn;
 
-    // Record for later restoration
-    int i;
-    bool found = false;
     for (i = 0; i < hooked_count; i++) {
         if (hooked_entries[i].nr == nr) {
-            found = true;
+            entry_idx = i;
             break;
         }
     }
-    if (!found) {
-        if (hooked_count < ARRAY_SIZE(hooked_entries)) {
-            hooked_entries[hooked_count].nr = nr;
-            hooked_entries[hooked_count].orig = orig;
-            hooked_count++;
-        } else {
-            pr_warn("hooked_entries full, cannot track syscall %d for restoration\n", nr);
+
+    if (entry_idx < 0) {
+        if (hooked_count >= ARRAY_SIZE(hooked_entries)) {
+            pr_err("hooked_entries full, refusing to patch syscall %d\n", nr);
+            ret = -ENOSPC;
+            goto out_unlock;
         }
+        entry_idx = hooked_count++;
+        hooked_entries[entry_idx].nr = nr;
+        hooked_entries[entry_idx].orig = current_fn;
+        hooked_entries[entry_idx].restore_on_abort = false;
+        added = true;
+    } else if (current_fn != hooked_entries[entry_idx].hook && current_fn != hooked_entries[entry_idx].orig) {
+        pr_err("syscall %d ownership lost: current=0x%lx hook=0x%lx orig=0x%lx\n", nr, (unsigned long)current_fn,
+               (unsigned long)hooked_entries[entry_idx].hook, (unsigned long)hooked_entries[entry_idx].orig);
+        ret = -EBUSY;
+        goto out_unlock;
     }
 
-    patch_syscall_table(nr, fn);
+    ret = patch_syscall_table(nr, fn);
+    if (ret) {
+        if (added)
+            --hooked_count;
+    } else {
+        hooked_entries[entry_idx].hook = fn;
+        hooked_entries[entry_idx].restore_on_abort = false;
+        ksu_syscall_hook_hold_unload_guard();
+    }
 
+out_unlock:
     mutex_unlock(&hooked_entries_lock);
+    return ret;
 }
 
-// Restore syscall_table[nr] to its original value and remove from tracking list.
-void ksu_syscall_table_unhook(int nr)
+int ksu_syscall_table_unhook(int nr)
 {
     int i;
+    int ret = -ENOENT;
 
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls)
-        return;
+        return -EINVAL;
 
     mutex_lock(&hooked_entries_lock);
-
-    for (i = 0; i < hooked_count; i++) {
-        if (hooked_entries[i].nr == nr) {
-            patch_syscall_table(nr, hooked_entries[i].orig);
-            // Remove entry by swapping with last
-            hooked_entries[i] = hooked_entries[--hooked_count];
-            mutex_unlock(&hooked_entries_lock);
-            pr_info("unhooked syscall %d\n", nr);
-            return;
-        }
+    if (direct_hooks_prepared) {
+        ret = -ESHUTDOWN;
+        goto out_unlock;
     }
 
+    for (i = 0; i < hooked_count; i++) {
+        syscall_fn_t current_fn;
+
+        if (hooked_entries[i].nr != nr)
+            continue;
+
+        current_fn = READ_ONCE(ksu_syscall_table[nr]);
+        if (current_fn == hooked_entries[i].hook) {
+            ret = patch_syscall_table(nr, hooked_entries[i].orig);
+            if (ret) {
+                pr_err("failed to unhook syscall %d: %d\n", nr, ret);
+                break;
+            }
+        } else if (current_fn == hooked_entries[i].orig) {
+            ret = 0;
+        } else {
+            pr_err("refusing to unhook syscall %d after ownership loss: current=0x%lx\n", nr,
+                   (unsigned long)current_fn);
+            ret = -EBUSY;
+            break;
+        }
+
+        hooked_entries[i] = hooked_entries[--hooked_count];
+        pr_info("unhooked syscall %d\n", nr);
+        break;
+    }
+
+out_unlock:
     mutex_unlock(&hooked_entries_lock);
-    pr_warn("syscall %d not found in hooked entries\n", nr);
+    return ret;
 }
 
 static int __init ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
@@ -139,9 +183,6 @@ static int __init ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
     return count;
 }
 
-// Unified dispatcher: reads original NR from x8, dispatches to handler.
-// Validates that syscallno matches our dispatcher slot (i.e. we redirected it),
-// otherwise it's a spurious call — return -ENOSYS.
 static long __nocfi ksu_syscall_dispatcher(const struct pt_regs *regs)
 {
     if (regs->syscallno != ksu_dispatcher_nr)
@@ -152,7 +193,6 @@ static long __nocfi ksu_syscall_dispatcher(const struct pt_regs *regs)
     if (regs->syscallno == orig_nr)
         return -ENOSYS;
 
-    // Restore registers to original state before dispatching
     ((struct pt_regs *)regs)->syscallno = orig_nr;
     PT_REGS_ORIG_SYSCALL((struct pt_regs *)regs) = orig_nr;
 
@@ -165,8 +205,6 @@ static long __nocfi ksu_syscall_dispatcher(const struct pt_regs *regs)
     return -ENOSYS;
 }
 
-// Register a handler into the dispatcher's routing table.
-// Does not modify the syscall table — the dispatcher slot is shared by all hooks.
 int ksu_register_syscall_hook(int nr, ksu_syscall_hook_fn fn)
 {
     if (nr < 0 || nr >= __NR_syscalls)
@@ -180,8 +218,6 @@ int ksu_register_syscall_hook(int nr, ksu_syscall_hook_fn fn)
     return 0;
 }
 
-// Remove a handler from the dispatcher's routing table.
-// The syscall table is not touched — only the dispatcher stops routing this nr.
 void ksu_unregister_syscall_hook(int nr)
 {
     if (nr < 0 || nr >= __NR_syscalls)
@@ -200,8 +236,10 @@ bool ksu_has_syscall_hook(int nr)
 void __init ksu_syscall_hook_init(void)
 {
     int ni_slot;
+    int ret;
 
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
+    direct_hooks_prepared = false;
 
     ksu_syscall_table = (syscall_fn_t *)ksu_resolve_symbol_for_functable_hook("sys_call_table");
     pr_info("sys_call_table=0x%lx", (unsigned long)ksu_syscall_table);
@@ -209,48 +247,199 @@ void __init ksu_syscall_hook_init(void)
     if (!ksu_syscall_table)
         return;
 
-    // Find one ni_syscall slot for the dispatcher
     if (ksu_find_ni_syscall_slots(&ni_slot, 1) < 1) {
         pr_err("failed to find ni_syscall slot for dispatcher\n");
         return;
     }
 
     ksu_dispatcher_nr = ni_slot;
-    ksu_syscall_table_hook(ksu_dispatcher_nr, (syscall_fn_t)ksu_syscall_dispatcher, NULL);
+    ret = ksu_syscall_table_hook(ksu_dispatcher_nr, (syscall_fn_t)ksu_syscall_dispatcher, NULL);
+    if (ret) {
+        pr_err("failed to install dispatcher at slot %d: %d\n", ksu_dispatcher_nr, ret);
+        ksu_dispatcher_nr = -1;
+        return;
+    }
     pr_info("dispatcher installed at slot %d\n", ksu_dispatcher_nr);
 }
 
-void __exit ksu_syscall_hook_exit(void)
+static int validate_hook_ownership_locked(void)
 {
     int i;
 
-    if (!ksu_syscall_table)
-        goto clear_state;
-
-    // First, restore all patched syscall table entries while the dispatcher
-    // and hook table are still intact, so in-flight syscalls see valid state.
-    mutex_lock(&hooked_entries_lock);
     for (i = 0; i < hooked_count; i++) {
-        int nr = hooked_entries[i].nr;
-        syscall_fn_t orig = hooked_entries[i].orig;
+        syscall_fn_t current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
 
-        pr_info("restore syscall %d to 0x%lx\n", nr, (unsigned long)orig);
-        if (ksu_patch_text(&ksu_syscall_table[nr], &orig, sizeof(orig), KSU_PATCH_TEXT_FLUSH_DCACHE)) {
-            pr_err("restore syscall %d failed\n", nr);
+        if (current_fn == hooked_entries[i].hook || current_fn == hooked_entries[i].orig)
+            continue;
+
+        pr_err("syscall %d ownership lost: current=0x%lx hook=0x%lx orig=0x%lx\n", hooked_entries[i].nr,
+               (unsigned long)current_fn, (unsigned long)hooked_entries[i].hook, (unsigned long)hooked_entries[i].orig);
+        return -EBUSY;
+    }
+
+    return 0;
+}
+
+static int rollback_prepared_hooks_locked(void)
+{
+    int rollback_ret = 0;
+    int i;
+
+    for (i = hooked_count - 1; i >= 0; i--) {
+        syscall_fn_t current_fn;
+        int ret;
+
+        if (!hooked_entries[i].restore_on_abort)
+            continue;
+
+        current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+        if (current_fn == hooked_entries[i].hook) {
+            hooked_entries[i].restore_on_abort = false;
+            continue;
+        }
+        if (current_fn != hooked_entries[i].orig) {
+            pr_err("cannot rollback syscall %d after ownership loss\n", hooked_entries[i].nr);
+            rollback_ret = -EUCLEAN;
+            continue;
+        }
+
+        ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].hook);
+        if (ret) {
+            rollback_ret = ret;
+            pr_err("rollback syscall %d to hook failed: %d\n", hooked_entries[i].nr, ret);
+            continue;
+        }
+        hooked_entries[i].restore_on_abort = false;
+    }
+
+    return rollback_ret;
+}
+
+int ksu_syscall_hook_exit(void)
+{
+    int rollback_ret;
+    int ret;
+    int i;
+
+    mutex_lock(&hooked_entries_lock);
+    if (direct_hooks_prepared) {
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
+
+    if (!ksu_syscall_table) {
+        direct_hooks_prepared = true;
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
+
+    ret = validate_hook_ownership_locked();
+    if (ret) {
+        mutex_unlock(&hooked_entries_lock);
+        return ret;
+    }
+
+    for (i = 0; i < hooked_count; i++) {
+        syscall_fn_t current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+
+        hooked_entries[i].restore_on_abort = false;
+        if (current_fn == hooked_entries[i].orig)
+            continue;
+
+        pr_info("restore syscall %d to 0x%lx\n", hooked_entries[i].nr, (unsigned long)hooked_entries[i].orig);
+        ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].orig);
+        if (ret) {
+            pr_err("restore syscall %d failed: %d\n", hooked_entries[i].nr, ret);
+            rollback_ret = rollback_prepared_hooks_locked();
+            mutex_unlock(&hooked_entries_lock);
+            return rollback_ret ? -EUCLEAN : ret;
+        }
+        hooked_entries[i].restore_on_abort = true;
+    }
+
+    direct_hooks_prepared = true;
+    mutex_unlock(&hooked_entries_lock);
+    pr_info("all direct syscall hooks prepared for unload\n");
+    return 0;
+}
+
+int ksu_syscall_hook_abort_exit(void)
+{
+    bool applied[ARRAY_SIZE(hooked_entries)] = { false };
+    int rollback_ret = 0;
+    int ret;
+    int i;
+
+    mutex_lock(&hooked_entries_lock);
+    if (!direct_hooks_prepared) {
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
+
+    if (!ksu_syscall_table) {
+        direct_hooks_prepared = false;
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
+
+    for (i = 0; i < hooked_count; i++) {
+        syscall_fn_t current_fn;
+
+        if (!hooked_entries[i].restore_on_abort)
+            continue;
+        current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+        if (current_fn != hooked_entries[i].orig && current_fn != hooked_entries[i].hook) {
+            pr_err("cannot re-arm syscall %d after ownership loss\n", hooked_entries[i].nr);
+            mutex_unlock(&hooked_entries_lock);
+            return -EBUSY;
         }
     }
+
+    for (i = 0; i < hooked_count; i++) {
+        syscall_fn_t current_fn;
+
+        if (!hooked_entries[i].restore_on_abort)
+            continue;
+
+        current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+        if (current_fn == hooked_entries[i].hook)
+            continue;
+
+        ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].hook);
+        if (ret) {
+            int j;
+
+            pr_err("re-arm syscall %d failed: %d\n", hooked_entries[i].nr, ret);
+            for (j = i - 1; j >= 0; j--) {
+                if (applied[j]) {
+                    int rollback = patch_syscall_table(hooked_entries[j].nr, hooked_entries[j].orig);
+                    if (rollback)
+                        rollback_ret = rollback;
+                }
+            }
+            mutex_unlock(&hooked_entries_lock);
+            return rollback_ret ? -EUCLEAN : ret;
+        }
+        applied[i] = true;
+    }
+
+    for (i = 0; i < hooked_count; i++)
+        hooked_entries[i].restore_on_abort = false;
+    direct_hooks_prepared = false;
+    mutex_unlock(&hooked_entries_lock);
+    pr_info("all direct syscall hooks re-armed\n");
+    return 0;
+}
+
+void ksu_syscall_hook_finish_exit(void)
+{
+    mutex_lock(&hooked_entries_lock);
     hooked_count = 0;
+    direct_hooks_prepared = false;
     mutex_unlock(&hooked_entries_lock);
 
-clear_state:
-    // Now that the syscall table is restored, clear internal state.
-    // At this point the tracepoint is already unregistered and synchronized
-    // (done by ksu_syscall_hook_manager_exit before calling us), so no new
-    // dispatches will occur.
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
     ksu_dispatcher_nr = -1;
-
-    pr_info("all syscall hooks restored\n");
 }
 
 #endif /* __aarch64__ */

--- a/kernel/hook/lsm_hook.c
+++ b/kernel/hook/lsm_hook.c
@@ -125,6 +125,19 @@ int ksu_lsm_hook(struct ksu_lsm_hook *hook)
         goto out_unlock;
     }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
+    /*
+     * security_hook_heads no longer exists here. The static-call table is a
+     * randomized struct whose per-hook arrays are MAX_LSM_COUNT wide, so the
+     * legacy numeric head offset cannot be mapped safely at runtime.
+     */
+    if (hook->offset) {
+        pr_err("lsm_hook: nonzero hook offsets are unsupported with LSM static calls\n");
+        ret = -EOPNOTSUPP;
+        goto out_unlock;
+    }
+#endif
+
     target = hook->original;
     if (!target)
         target = ksu_resolve_symbol_for_functable_hook(target_name);
@@ -395,41 +408,62 @@ out_unlock:
 
 void ksu_lsm_unhook(struct ksu_lsm_hook *hook)
 {
+    void *slot_value;
+    void *expected;
     void **slot;
+
+    if (!hook)
+        return;
+
     mutex_lock(&ksu_lsm_hook_lock);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
-    if (!hook->entry || !hook->scall) {
+    if (!hook->entry || !hook->scall)
 #else
-    if (!hook->entry) {
+    if (!hook->entry)
 #endif
-        mutex_unlock(&ksu_lsm_hook_lock);
-        return;
-    }
+        goto out_unlock;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     slot = (void **)((char *)hook->entry + hook->hook_offset);
+    expected = hook->replacement;
 #else
     if (hook->entry == &hook->list) {
         slot = (void **)&hook->list.head->first;
+        expected = &hook->list;
         pr_info("unhook patch head->first\n");
     } else {
         slot = (void **)((char *)hook->entry + hook->hook_offset);
+        expected = hook->replacement;
         pr_info("unhook patch slot\n");
     }
 #endif
-    if (ksu_lsm_hook_patch_slot(slot, hook->original)) {
+
+    slot_value = READ_ONCE(*slot);
+    if (slot_value != expected && slot_value != hook->original) {
+        pr_err("lsm_hook: refusing to restore %s after ownership loss: current=%px expected=%px orig=%px\n",
+               hook->head_name ?: "unknown", slot_value, expected, hook->original);
+        goto out_unlock;
+    }
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+    if (slot_value == expected && hook->entry == &hook->list && READ_ONCE(hook->list.list.next)) {
+        pr_err("lsm_hook: refusing to unlink %s after another hook chained behind KernelSU\n",
+               hook->head_name ?: "unknown");
+        goto out_unlock;
+    }
+#endif
+
+    if (slot_value == expected && ksu_lsm_hook_patch_slot(slot, hook->original)) {
         pr_err("lsm_hook: failed to restore %s\n", hook->head_name ?: "unknown");
-        mutex_unlock(&ksu_lsm_hook_lock);
-        return;
+        goto out_unlock;
     }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     if (ksu_lsm_hook_update_scall(hook->scall, hook->original)) {
-        if (ksu_lsm_hook_patch_slot(slot, hook->replacement))
+        if (slot_value == expected && ksu_lsm_hook_patch_slot(slot, hook->replacement))
             pr_err("lsm_hook: failed to reapply %s after static call restore failure\n", hook->head_name ?: "unknown");
-        mutex_unlock(&ksu_lsm_hook_lock);
-        return;
+        goto out_unlock;
     }
 #endif
 
@@ -440,6 +474,8 @@ void ksu_lsm_unhook(struct ksu_lsm_hook *hook)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
     hook->scall = NULL;
 #endif
+
+out_unlock:
     mutex_unlock(&ksu_lsm_hook_lock);
 }
 
@@ -470,6 +506,11 @@ void __exit ksu_lsm_hook_exit(void)
         hooks[i] = ksu_lsm_hook_entries[i].hook;
     mutex_unlock(&ksu_lsm_hook_lock);
 
-    for (i = count - 1; i >= 0; i--)
+    for (i = count - 1; i >= 0; i--) {
         ksu_lsm_unhook(hooks[i]);
+        if (hooks[i]->entry) {
+            pr_emerg("lsm_hook: final restore failed for %s\n", hooks[i]->head_name ?: "unknown");
+            panic("KernelSU: refusing unsafe module unload with live LSM hooks");
+        }
+    }
 }

--- a/kernel/hook/setuid_hook.c
+++ b/kernel/hook/setuid_hook.c
@@ -25,7 +25,7 @@ int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
 {
     // we rely on the fact that zygote always call setresuid(3) with same uids
 
-    pr_info("handle_setresuid from %d to %d\n", old_uid, new_uid);
+    pr_debug("handle_setresuid from %d to %d\n", old_uid, new_uid);
 
     if (unlikely(is_uid_manager(new_uid))) {
         spin_lock_irq(&current->sighand->siglock);
@@ -46,6 +46,12 @@ int ksu_handle_setresuid(uid_t old_uid, uid_t new_uid)
         }
         ksu_set_task_tracepoint_flag(current);
     } else {
+        /*
+         * Zygote children inherit the syscall tracepoint flag. Drop that
+         * inherited cost for ordinary apps only while KernelSU is known to be
+         * the sole sys_enter consumer; otherwise the flag belongs to shared
+         * perf/ftrace/eBPF tracing state and must stay set.
+         */
         ksu_clear_task_tracepoint_flag_if_needed(current);
     }
 
@@ -60,7 +66,7 @@ void __init ksu_setuid_hook_init(void)
     ksu_kernel_umount_init();
 }
 
-void __exit ksu_setuid_hook_exit(void)
+void ksu_setuid_hook_exit(void)
 {
     pr_info("ksu_core_exit\n");
     ksu_kernel_umount_exit();

--- a/kernel/hook/syscall_event_bridge.c
+++ b/kernel/hook/syscall_event_bridge.c
@@ -9,7 +9,6 @@
 
 #include "arch.h"
 #include "klog.h" // IWYU pragma: keep
-#include "hook/tp_marker.h"
 #include "feature/sucompat.h"
 #include "hook/setuid_hook.h"
 #include "policy/app_profile.h"
@@ -39,10 +38,6 @@ static int ksu_handle_init_mark_tracker(const char __user **filename_user)
     if (unlikely(strcmp(path, KSUD_PATH) == 0)) {
         pr_info("hook_manager: escape to root for init executing ksud: %d\n", current->pid);
         escape_to_root_for_init();
-    } else if (likely(strstr(path, "/app_process") == NULL && strstr(path, "/adbd") == NULL &&
-                      strstr(path, "/stub_zygote") == NULL)) {
-        pr_info("hook_manager: unmark %d exec %s\n", current->pid, path);
-        ksu_clear_task_tracepoint_flag_if_needed(current);
     }
 
     return 0;

--- a/kernel/hook/syscall_hook.h
+++ b/kernel/hook/syscall_hook.h
@@ -37,15 +37,24 @@ bool ksu_has_syscall_hook(int nr);
 // Saves the original handler to *@old (if non-NULL) and records the entry
 // for restoration at module exit. Use this for boot-time hooks that replace
 // a real syscall entry (e.g. ksud hooking __NR_execve/__NR_read/__NR_fstat).
-void ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old);
+int ksu_syscall_table_hook(int nr, syscall_fn_t fn, syscall_fn_t *old);
 
 // Restore syscall_table[@nr] to its original value recorded by
 // ksu_syscall_table_hook(), and remove the entry from the tracking list.
 // Use this to cleanly undo a direct hook when it is no longer needed
 // (e.g. ksud unhooking __NR_read after init.rc injection is done).
-void ksu_syscall_table_unhook(int nr);
+int ksu_syscall_table_unhook(int nr);
+
+// Persistent direct patches point into KernelSU module text. Keep the module
+// pinned until every such patch is restored by the controlled unload path.
+void ksu_syscall_hook_hold_unload_guard(void);
 
 void ksu_syscall_hook_init(void);
-void ksu_syscall_hook_exit(void);
+// Restore direct patches but retain enough state to re-arm them if unload aborts.
+int ksu_syscall_hook_exit(void);
+// Re-arm a successfully prepared direct-hook set. Transactional on failure.
+int ksu_syscall_hook_abort_exit(void);
+// Finalize bookkeeping only after module removal has actually begun.
+void ksu_syscall_hook_finish_exit(void);
 
 #endif

--- a/kernel/hook/syscall_hook_manager.c
+++ b/kernel/hook/syscall_hook_manager.c
@@ -1,10 +1,12 @@
 #include "linux/printk.h"
-#include <linux/spinlock.h>
-#include <linux/kprobes.h>
+#include <linux/cred.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/rcupdate.h>
 #include <linux/tracepoint.h>
+#include <linux/kprobes.h>
 #include <asm/syscall.h>
 #include <linux/ptrace.h>
-#include <linux/slab.h>
 #include <trace/events/syscalls.h>
 
 #include <linux/version.h>
@@ -18,83 +20,207 @@
 #include "hook/syscall_hook_manager.h"
 #include "hook/tp_marker.h"
 #include "feature/sucompat.h"
+#include "feature/selinux_hide.h"
 #include "hook/setuid_hook.h"
 #include "hook/syscall_hook.h"
 #include "hook/syscall_event_bridge.h"
+#include "selinux/selinux.h"
 
-#ifdef CONFIG_KRETPROBES
-
-static struct kretprobe *init_kretprobe(const char *name, kretprobe_handler_t handler)
-{
-    struct kretprobe *rp = kzalloc(sizeof(struct kretprobe), GFP_KERNEL);
-    if (!rp)
-        return NULL;
-    rp->kp.symbol_name = name;
-    rp->handler = handler;
-    rp->data_size = 0;
-    rp->maxactive = 0;
-
-    int ret = register_kretprobe(rp);
-    pr_info("hook_manager: register_%s kretprobe: %d\n", name, ret);
-    if (ret) {
-        kfree(rp);
-        return NULL;
-    }
-
-    return rp;
-}
-
-static void destroy_kretprobe(struct kretprobe **rp_ptr)
-{
-    struct kretprobe *rp = *rp_ptr;
-    if (!rp)
-        return;
-    unregister_kretprobe(rp);
-    synchronize_rcu();
-    kfree(rp);
-    *rp_ptr = NULL;
-}
-
-static int syscall_regfunc_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
-{
-    unsigned long flags;
-    ksu_tp_marker_lock(&flags);
-    if (ksu_tp_marker_reg_count() < 1) {
-        // while install our tracepoint, mark our processes
-        ksu_mark_running_process_locked();
-    } else if (ksu_tp_marker_reg_count() == 1) {
-        // while other tracepoint first added, mark all processes
-        ksu_mark_all_process();
-    }
-    ksu_tp_marker_inc_reg_count();
-    ksu_tp_marker_unlock(&flags);
-    return 0;
-}
-
-static int syscall_unregfunc_handler(struct kretprobe_instance *ri, struct pt_regs *regs)
-{
-    unsigned long flags;
-    ksu_tp_marker_lock(&flags);
-    ksu_tp_marker_dec_reg_count();
-    if (ksu_tp_marker_reg_count() <= 0) {
-        // while no tracepoint left, unmark all processes
-        ksu_unmark_all_process();
-    } else if (ksu_tp_marker_reg_count() == 1) {
-        // while just our tracepoint left, unmark disallowed processes
-        ksu_mark_running_process_locked();
-    }
-    ksu_tp_marker_unlock(&flags);
-    return 0;
-}
-
-static struct kretprobe *syscall_regfunc_rp = NULL;
-static struct kretprobe *syscall_unregfunc_rp = NULL;
-#endif
+static bool manager_cleanup_done;
+static bool sys_enter_registered;
 
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
-// sys_enter handler: redirect hooked syscalls to the dispatcher
+/* Conservative until the mutation observer proves KernelSU is the sole owner. */
+static bool syscall_tracepoint_shared = true;
+#endif
+
+enum ksu_unload_state {
+    KSU_UNLOAD_RUNNING,
+    KSU_UNLOAD_PREPARING,
+    KSU_UNLOAD_PREPARED,
+    KSU_UNLOAD_COMMITTED,
+    KSU_UNLOAD_FAILED,
+};
+
+static enum ksu_unload_state unload_state;
+static unsigned int active_runtime_calls;
+static DEFINE_MUTEX(unload_state_lock);
+
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+static DEFINE_MUTEX(unload_guard_lock);
+static bool unload_guard_held;
+static bool prepared_guard_needed;
+#endif
+
+bool ksu_module_unload_in_progress(void)
+{
+    return READ_ONCE(unload_state) != KSU_UNLOAD_RUNNING;
+}
+
+bool ksu_module_unload_recovery_allowed(void)
+{
+    enum ksu_unload_state state = READ_ONCE(unload_state);
+
+    return state == KSU_UNLOAD_PREPARED || state == KSU_UNLOAD_COMMITTED;
+}
+
+bool ksu_syscall_tracepoint_allows_selective_marks(void)
+{
+#ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+    return READ_ONCE(sys_enter_registered) && !READ_ONCE(syscall_tracepoint_shared);
+#else
+    return false;
+#endif
+}
+
+bool ksu_module_unload_try_enter(void)
+{
+    bool entered = false;
+
+    mutex_lock(&unload_state_lock);
+    if (unload_state == KSU_UNLOAD_RUNNING) {
+        active_runtime_calls++;
+        entered = true;
+    }
+    mutex_unlock(&unload_state_lock);
+    return entered;
+}
+
+bool ksu_module_control_try_enter(void)
+{
+    bool entered = false;
+
+    mutex_lock(&unload_state_lock);
+    if (unload_state == KSU_UNLOAD_RUNNING || unload_state == KSU_UNLOAD_PREPARED ||
+        unload_state == KSU_UNLOAD_COMMITTED) {
+        active_runtime_calls++;
+        entered = true;
+    }
+    mutex_unlock(&unload_state_lock);
+    return entered;
+}
+
+void ksu_module_unload_leave(void)
+{
+    mutex_lock(&unload_state_lock);
+    if (active_runtime_calls > 0)
+        active_runtime_calls--;
+    mutex_unlock(&unload_state_lock);
+}
+
+void ksu_syscall_hook_hold_unload_guard(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    mutex_lock(&unload_guard_lock);
+    if (!unload_guard_held) {
+        __module_get(THIS_MODULE);
+        unload_guard_held = true;
+        pr_debug("hook_manager: module unload guard acquired\n");
+    }
+    mutex_unlock(&unload_guard_lock);
+#endif
+}
+
+static void release_unload_guard(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    mutex_lock(&unload_guard_lock);
+    if (unload_guard_held) {
+        unload_guard_held = false;
+        module_put(THIS_MODULE);
+        pr_debug("hook_manager: module unload guard released\n");
+    }
+    mutex_unlock(&unload_guard_lock);
+#endif
+}
+
+static bool unload_guard_is_held(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    bool held;
+
+    mutex_lock(&unload_guard_lock);
+    held = unload_guard_held;
+    mutex_unlock(&unload_guard_lock);
+    return held;
+#else
+    return false;
+#endif
+}
+
+static int preflight_unload_refs(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    int expected_refs = 1;
+    int refs;
+
+    if (active_runtime_calls != 0) {
+        pr_debug("hook_manager: unload blocked by %u active runtime calls\n", active_runtime_calls);
+        return -EBUSY;
+    }
+
+    if (unload_guard_is_held())
+        expected_refs++;
+
+    refs = module_refcount(THIS_MODULE);
+    if (refs != expected_refs) {
+        pr_warn("hook_manager: unload blocked by module refs: have=%d expected=%d\n", refs, expected_refs);
+        return -EBUSY;
+    }
+
+    return 0;
+#else
+    return -EOPNOTSUPP;
+#endif
+}
+
+#ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+static __always_inline bool ksu_syscall_id_maybe_hooked(long id)
+{
+    switch (id) {
+    case __NR_setresuid:
+    case __NR_execve:
+    case __NR_execveat:
+    case __NR_newfstatat:
+    case __NR_faccessat:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static __always_inline bool ksu_current_task_needs_hook_for_syscall(long id)
+{
+    if (ksu_current_task_needs_syscall_hook())
+        return true;
+
+    /*
+     * init forks children before execing adbd, app_process/stub_zygote, and
+     * other boot helpers. Those children are no longer PID 1 but still run in
+     * the init SELinux domain, and the exec hook intentionally handles them.
+     * Keep this exception scoped to exec so unrelated init-domain syscalls do
+     * not pay the dispatcher cost.
+     */
+    return (id == __NR_execve || id == __NR_execveat) && is_init(current_cred());
+}
+
 static void ksu_sys_enter_handler(void *data, struct pt_regs *regs, long id)
 {
+    struct pt_regs *current_regs;
+
+    if (likely(!ksu_syscall_id_maybe_hooked(id)))
+        return;
+
+    if (unlikely(ksu_module_unload_in_progress()))
+        return;
+
+    /* Never rewrite a syscall unless the dispatcher slot is installed. */
+    if (unlikely(READ_ONCE(ksu_dispatcher_nr) < 0))
+        return;
+
+    if (!ksu_has_syscall_hook(id))
+        return;
+
 #if defined(__x86_64__)
     if (unlikely(in_compat_syscall()))
 #elif defined(__aarch64__)
@@ -102,36 +228,192 @@ static void ksu_sys_enter_handler(void *data, struct pt_regs *regs, long id)
 #endif
         return;
 
-    if (ksu_dispatcher_nr < 0)
+    if (unlikely(!ksu_current_task_needs_hook_for_syscall(id)))
         return;
 
-    if (ksu_has_syscall_hook(id)) {
-        struct pt_regs *current_regs = task_pt_regs(current);
+    current_regs = task_pt_regs(current);
 
 #if defined(__x86_64__)
-        // Stash the original syscall number in ax.
-        // We use ax because it currently just holds -ENOSYS and is safe to overwrite.
-        current_regs->ax = id;
-        current_regs->orig_ax = ksu_dispatcher_nr;
+    current_regs->ax = id;
+    current_regs->orig_ax = ksu_dispatcher_nr;
 #elif defined(__aarch64__)
-        PT_REGS_ORIG_SYSCALL(current_regs) = id;
-        current_regs->syscallno = ksu_dispatcher_nr;
+    PT_REGS_ORIG_SYSCALL(current_regs) = id;
+    current_regs->syscallno = ksu_dispatcher_nr;
 #endif
-    }
 }
+
+static bool ksu_sys_enter_has_external_consumer(void)
+{
+    struct tracepoint_func *funcs;
+    bool external = false;
+    int i;
+
+    rcu_read_lock();
+    funcs = rcu_dereference(__tracepoint_sys_enter.funcs);
+    if (funcs) {
+        for (i = 0; READ_ONCE(funcs[i].func); i++) {
+            if (READ_ONCE(funcs[i].func) != (void *)ksu_sys_enter_handler) {
+                external = true;
+                break;
+            }
+        }
+    }
+    rcu_read_unlock();
+    return external;
+}
+
+static void ksu_refresh_sys_enter_marks(void)
+{
+    bool shared = ksu_sys_enter_has_external_consumer();
+
+    WRITE_ONCE(syscall_tracepoint_shared, shared);
+    if (shared)
+        ksu_mark_all_process();
+    else
+        ksu_mark_running_process_selective();
+}
+
+#ifdef CONFIG_KRETPROBES
+struct ksu_tracepoint_mutation_ctx {
+    bool target;
+    bool add;
+};
+
+static bool ksu_tracepoint_mutation_is_external(struct pt_regs *regs)
+{
+    struct tracepoint *tp = (struct tracepoint *)PT_REGS_PARM1(regs);
+    struct tracepoint_func *func = (struct tracepoint_func *)PT_REGS_PARM2(regs);
+
+    if (tp != &__tracepoint_sys_enter)
+        return false;
+
+    return !func || READ_ONCE(func->func) != (void *)ksu_sys_enter_handler;
+}
+
+static int ksu_tracepoint_add_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    struct ksu_tracepoint_mutation_ctx *ctx = (struct ksu_tracepoint_mutation_ctx *)ri->data;
+
+    ctx->target = ksu_tracepoint_mutation_is_external(regs);
+    ctx->add = true;
+    if (ctx->target) {
+        /*
+         * tracepoint_add_func() has not activated the new callback yet. Mark
+         * every task now so no external perf/ftrace/eBPF consumer can miss a
+         * syscall in the 1->2 transition window.
+         */
+        WRITE_ONCE(syscall_tracepoint_shared, true);
+        ksu_mark_all_process();
+    }
+    return 0;
+}
+
+static int ksu_tracepoint_remove_entry(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    struct ksu_tracepoint_mutation_ctx *ctx = (struct ksu_tracepoint_mutation_ctx *)ri->data;
+
+    ctx->target = ksu_tracepoint_mutation_is_external(regs);
+    ctx->add = false;
+    return 0;
+}
+
+static int ksu_tracepoint_mutation_ret(struct kretprobe_instance *ri, struct pt_regs *regs)
+{
+    struct ksu_tracepoint_mutation_ctx *ctx = (struct ksu_tracepoint_mutation_ctx *)ri->data;
+    long ret = (long)PT_REGS_RC(regs);
+
+    if (!ctx->target)
+        return 0;
+
+    /*
+     * Failed additions need their speculative global marks undone. Successful
+     * removals may have left KernelSU as the sole consumer. Re-read the actual
+     * callback array instead of inferring consumer count from regfunc calls.
+     */
+    if (ret || !ctx->add)
+        ksu_refresh_sys_enter_marks();
+    return 0;
+}
+
+static struct kretprobe tracepoint_add_rp = {
+    .kp.symbol_name = "tracepoint_add_func",
+    .handler = ksu_tracepoint_mutation_ret,
+    .entry_handler = ksu_tracepoint_add_entry,
+    .data_size = sizeof(struct ksu_tracepoint_mutation_ctx),
+    .maxactive = 32,
+};
+
+static struct kretprobe tracepoint_remove_rp = {
+    .kp.symbol_name = "tracepoint_remove_func",
+    .handler = ksu_tracepoint_mutation_ret,
+    .entry_handler = ksu_tracepoint_remove_entry,
+    .data_size = sizeof(struct ksu_tracepoint_mutation_ctx),
+    .maxactive = 32,
+};
+
+static bool tracepoint_observer_registered;
+
+static bool ksu_tracepoint_observer_init(void)
+{
+    int ret;
+
+    ret = register_kretprobe(&tracepoint_add_rp);
+    if (ret) {
+        pr_warn("hook_manager: tracepoint_add_func observer unavailable: %d\n", ret);
+        return false;
+    }
+
+    ret = register_kretprobe(&tracepoint_remove_rp);
+    if (ret) {
+        pr_warn("hook_manager: tracepoint_remove_func observer unavailable: %d\n", ret);
+        unregister_kretprobe(&tracepoint_add_rp);
+        return false;
+    }
+
+    tracepoint_observer_registered = true;
+    return true;
+}
+
+static void ksu_tracepoint_observer_exit(void)
+{
+    if (!tracepoint_observer_registered)
+        return;
+
+    unregister_kretprobe(&tracepoint_remove_rp);
+    unregister_kretprobe(&tracepoint_add_rp);
+    tracepoint_observer_registered = false;
+}
+#else
+static bool ksu_tracepoint_observer_init(void)
+{
+    return false;
+}
+
+static void ksu_tracepoint_observer_exit(void)
+{
+}
+#endif
 #endif
 
 void __init ksu_syscall_hook_manager_init(void)
 {
+#ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+    bool observer_ready;
     int ret;
-    pr_info("hook_manager: ksu_hook_manager_init called\n");
-
-#ifdef CONFIG_KRETPROBES
-    syscall_regfunc_rp = init_kretprobe("syscall_regfunc", syscall_regfunc_handler);
-    syscall_unregfunc_rp = init_kretprobe("syscall_unregfunc", syscall_unregfunc_handler);
 #endif
 
-    // Register syscall hooks via dispatcher
+    manager_cleanup_done = false;
+    sys_enter_registered = false;
+    active_runtime_calls = 0;
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    prepared_guard_needed = false;
+#endif
+#ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
+    WRITE_ONCE(syscall_tracepoint_shared, true);
+#endif
+    WRITE_ONCE(unload_state, KSU_UNLOAD_RUNNING);
+    pr_info("hook_manager: ksu_hook_manager_init called\n");
+
     ksu_register_syscall_hook(__NR_setresuid, ksu_hook_setresuid);
     ksu_register_syscall_hook(__NR_execve, ksu_hook_execve);
     ksu_register_syscall_hook(__NR_execveat, ksu_hook_execveat);
@@ -139,14 +421,26 @@ void __init ksu_syscall_hook_manager_init(void)
     ksu_register_syscall_hook(__NR_faccessat, ksu_hook_faccessat);
 
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
-    ret = register_trace_prio_sys_enter(ksu_sys_enter_handler, NULL, INT_MIN);
-#ifndef CONFIG_KRETPROBES
-    ksu_mark_running_process_locked();
-#endif
-    if (ret) {
-        pr_err("hook_manager: failed to register sys_enter tracepoint: %d\n", ret);
+    if (READ_ONCE(ksu_dispatcher_nr) < 0) {
+        pr_warn("hook_manager: dispatcher unavailable; skipping sys_enter tracepoint\n");
     } else {
-        pr_info("hook_manager: sys_enter tracepoint registered\n");
+        observer_ready = ksu_tracepoint_observer_init();
+        ret = register_trace_prio_sys_enter(ksu_sys_enter_handler, NULL, INT_MIN);
+        if (ret) {
+            pr_err("hook_manager: failed to register sys_enter tracepoint: %d\n", ret);
+            ksu_tracepoint_observer_exit();
+        } else {
+            sys_enter_registered = true;
+            if (observer_ready) {
+                ksu_refresh_sys_enter_marks();
+                pr_info("hook_manager: sys_enter tracepoint registered with coexistence observer\n");
+            } else {
+                /* Cannot observe later 1->2 transitions, so preserve correctness. */
+                WRITE_ONCE(syscall_tracepoint_shared, true);
+                ksu_mark_all_process();
+                pr_warn("hook_manager: sys_enter observer unavailable; using global tracepoint marks\n");
+            }
+        }
     }
 #endif
 
@@ -154,28 +448,203 @@ void __init ksu_syscall_hook_manager_init(void)
     ksu_sucompat_init();
 }
 
-void __exit ksu_syscall_hook_manager_exit(void)
+static void finish_hook_cleanup(void)
 {
-    pr_info("hook_manager: ksu_hook_manager_exit called\n");
 #ifdef CONFIG_HAVE_SYSCALL_TRACEPOINTS
-    unregister_trace_sys_enter(ksu_sys_enter_handler, NULL);
-    tracepoint_synchronize_unregister();
-    pr_info("hook_manager: sys_enter tracepoint unregistered\n");
+    if (sys_enter_registered) {
+        unregister_trace_sys_enter(ksu_sys_enter_handler, NULL);
+        tracepoint_synchronize_unregister();
+        sys_enter_registered = false;
+        pr_info("hook_manager: sys_enter tracepoint unregistered\n");
+    }
+    ksu_tracepoint_observer_exit();
+    WRITE_ONCE(syscall_tracepoint_shared, true);
 #endif
 
-#ifdef CONFIG_KRETPROBES
-    destroy_kretprobe(&syscall_regfunc_rp);
-    destroy_kretprobe(&syscall_unregfunc_rp);
-#endif
-
-    ksu_unregister_syscall_hook(__NR_setresuid);
-    ksu_unregister_syscall_hook(__NR_execve);
-    ksu_unregister_syscall_hook(__NR_execveat);
-    ksu_unregister_syscall_hook(__NR_newfstatat);
-    ksu_unregister_syscall_hook(__NR_faccessat);
-
-    ksu_syscall_hook_exit();
-
+    synchronize_rcu_tasks();
+    ksu_syscall_hook_finish_exit();
     ksu_sucompat_exit();
     ksu_setuid_hook_exit();
+    manager_cleanup_done = true;
+}
+
+int ksu_prepare_module_unload(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    int rollback_ret;
+    int ret;
+
+    mutex_lock(&unload_state_lock);
+
+    if (unload_state == KSU_UNLOAD_PREPARED) {
+        mutex_unlock(&unload_state_lock);
+        return 0;
+    }
+    if (manager_cleanup_done || unload_state != KSU_UNLOAD_RUNNING) {
+        mutex_unlock(&unload_state_lock);
+        return -EBUSY;
+    }
+
+    WRITE_ONCE(unload_state, KSU_UNLOAD_PREPARING);
+
+    ret = preflight_unload_refs();
+    if (ret) {
+        WRITE_ONCE(unload_state, KSU_UNLOAD_RUNNING);
+        mutex_unlock(&unload_state_lock);
+        return ret;
+    }
+
+    /*
+     * A sys_enter callback can have rewritten pt_regs just before PREPARING
+     * became visible, then be preempted before the syscall table dispatch.
+     * Drain those tasks before restoring the dispatcher slot.
+     */
+    synchronize_rcu_tasks();
+
+    ret = ksu_syscall_hook_exit();
+    if (ret) {
+        WRITE_ONCE(unload_state, ret == -EUCLEAN ? KSU_UNLOAD_FAILED : KSU_UNLOAD_RUNNING);
+        pr_err("hook_manager: syscall patch restore failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        return ret;
+    }
+
+    ret = ksu_selinux_hide_prepare_unload();
+    if (ret) {
+        rollback_ret = ksu_syscall_hook_abort_exit();
+        if (rollback_ret)
+            pr_err("hook_manager: syscall rollback after SELinux prepare failure failed: %d\n", rollback_ret);
+        WRITE_ONCE(unload_state, rollback_ret || ret == -EUCLEAN ? KSU_UNLOAD_FAILED : KSU_UNLOAD_RUNNING);
+        pr_err("hook_manager: SELinux patch restore failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        return rollback_ret ? -EUCLEAN : ret;
+    }
+
+    /* Drain module-text callbacks after all persistent entry points are gone. */
+    synchronize_rcu_tasks();
+    prepared_guard_needed = unload_guard_is_held();
+    WRITE_ONCE(unload_state, KSU_UNLOAD_PREPARED);
+    mutex_unlock(&unload_state_lock);
+    return 0;
+#else
+    return -EOPNOTSUPP;
+#endif
+}
+
+int ksu_commit_module_unload(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    int ret;
+
+    mutex_lock(&unload_state_lock);
+    if (unload_state != KSU_UNLOAD_PREPARED) {
+        mutex_unlock(&unload_state_lock);
+        return -EINVAL;
+    }
+
+    ret = preflight_unload_refs();
+    if (ret) {
+        mutex_unlock(&unload_state_lock);
+        return ret;
+    }
+
+    WRITE_ONCE(unload_state, KSU_UNLOAD_COMMITTED);
+    release_unload_guard();
+    mutex_unlock(&unload_state_lock);
+    return 0;
+#else
+    return -EOPNOTSUPP;
+#endif
+}
+
+int ksu_abort_module_unload(void)
+{
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    int rollback_ret;
+    int ret;
+
+    mutex_lock(&unload_state_lock);
+    if (unload_state == KSU_UNLOAD_RUNNING) {
+        mutex_unlock(&unload_state_lock);
+        return 0;
+    }
+    if (unload_state != KSU_UNLOAD_PREPARED && unload_state != KSU_UNLOAD_COMMITTED) {
+        mutex_unlock(&unload_state_lock);
+        return -EINVAL;
+    }
+
+    if (unload_state == KSU_UNLOAD_COMMITTED && prepared_guard_needed)
+        ksu_syscall_hook_hold_unload_guard();
+
+    ret = ksu_selinux_hide_abort_unload();
+    if (ret) {
+        WRITE_ONCE(unload_state, ret == -EUCLEAN ? KSU_UNLOAD_FAILED : KSU_UNLOAD_PREPARED);
+        pr_err("hook_manager: SELinux patch re-arm failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        return ret;
+    }
+
+    ret = ksu_syscall_hook_abort_exit();
+    if (ret) {
+        rollback_ret = ksu_selinux_hide_prepare_unload();
+        if (rollback_ret)
+            pr_err("hook_manager: SELinux rollback after syscall re-arm failure failed: %d\n", rollback_ret);
+        WRITE_ONCE(unload_state, rollback_ret || ret == -EUCLEAN ? KSU_UNLOAD_FAILED : KSU_UNLOAD_PREPARED);
+        pr_err("hook_manager: syscall patch re-arm failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        return rollback_ret ? -EUCLEAN : ret;
+    }
+
+    prepared_guard_needed = false;
+    WRITE_ONCE(unload_state, KSU_UNLOAD_RUNNING);
+    mutex_unlock(&unload_state_lock);
+    return 0;
+#else
+    return -EOPNOTSUPP;
+#endif
+}
+
+int ksu_syscall_hook_manager_exit(void)
+{
+    int ret;
+
+    mutex_lock(&unload_state_lock);
+    if (manager_cleanup_done) {
+        mutex_unlock(&unload_state_lock);
+        return 0;
+    }
+
+    WRITE_ONCE(unload_state, KSU_UNLOAD_PREPARING);
+
+    /*
+     * module_exit() cannot reject an unload once it is running. The normal
+     * PREPARE/COMMIT path prevents us from reaching this point with live
+     * persistent patches. If a forced or unexpected unload violates that
+     * invariant, continuing after a failed restore would free module text
+     * while a syscall/text entry point can still target it. Fail-stop instead.
+     */
+    ret = ksu_syscall_hook_exit();
+    if (ret) {
+        WRITE_ONCE(unload_state, KSU_UNLOAD_FAILED);
+        pr_emerg("hook_manager: final syscall patch restore failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        panic("KernelSU: refusing unsafe module unload with live syscall hooks");
+    }
+
+    ret = ksu_selinux_hide_prepare_unload();
+    if (ret) {
+        WRITE_ONCE(unload_state, KSU_UNLOAD_FAILED);
+        pr_emerg("hook_manager: final SELinux patch restore failed: %d\n", ret);
+        mutex_unlock(&unload_state_lock);
+        panic("KernelSU: refusing unsafe module unload with live SELinux hooks");
+    }
+
+    finish_hook_cleanup();
+    WRITE_ONCE(unload_state, KSU_UNLOAD_PREPARED);
+#if defined(MODULE) && defined(CONFIG_MODULE_UNLOAD)
+    prepared_guard_needed = false;
+#endif
+    release_unload_guard();
+    mutex_unlock(&unload_state_lock);
+    return 0;
 }

--- a/kernel/hook/syscall_hook_manager.h
+++ b/kernel/hook/syscall_hook_manager.h
@@ -3,8 +3,16 @@
 
 #include <asm/ptrace.h>
 
-// Hook manager initialization and cleanup
 void ksu_syscall_hook_manager_init(void);
-void ksu_syscall_hook_manager_exit(void);
+int ksu_syscall_hook_manager_exit(void);
+int ksu_prepare_module_unload(void);
+int ksu_commit_module_unload(void);
+int ksu_abort_module_unload(void);
+bool ksu_module_unload_in_progress(void);
+bool ksu_module_unload_recovery_allowed(void);
+bool ksu_module_unload_try_enter(void);
+bool ksu_module_control_try_enter(void);
+bool ksu_syscall_tracepoint_allows_selective_marks(void);
+void ksu_module_unload_leave(void);
 
 #endif

--- a/kernel/hook/tp_marker.c
+++ b/kernel/hook/tp_marker.c
@@ -1,7 +1,6 @@
 #include "hook/tp_marker.h"
 
 #include "linux/cred.h"
-#include <linux/spinlock.h>
 #include <linux/version.h>
 #include <linux/sched/signal.h>
 #include <linux/sched/task.h>
@@ -9,116 +8,104 @@
 #include "policy/allowlist.h"
 #include "klog.h" // IWYU pragma: keep
 #include "selinux/selinux.h"
+#include "hook/syscall_hook_manager.h"
 
-// Tracepoint registration count management
-// == 1: just us
-// >  1: someone else is also using syscall tracepoint e.g. ftrace
-static int tracepoint_reg_count = 0;
-static DEFINE_SPINLOCK(tracepoint_reg_lock);
-
-int ksu_tp_marker_reg_count(void)
+static bool ksu_task_needs_syscall_hook(struct task_struct *task, const struct cred *cred, uid_t uid)
 {
-    return tracepoint_reg_count;
+    return task->pid == 1 || uid == 2000 || is_zygote(cred) || (uid == 0 && is_task_ksu_domain(cred)) ||
+           ksu_is_allow_uid(uid);
 }
 
-void ksu_tp_marker_lock(unsigned long *flags)
+bool ksu_current_task_needs_syscall_hook(void)
 {
-    spin_lock_irqsave(&tracepoint_reg_lock, *flags);
+    /*
+     * The syscall tracepoint mark is also exposed through KSU_MARK_MARK.
+     * Treat it as authoritative here so explicit marks are not rejected by
+     * the automatic policy predicate used when refreshing selective marks.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+    return test_task_syscall_work(current, SYSCALL_TRACEPOINT);
+#else
+    return test_tsk_thread_flag(current, TIF_SYSCALL_TRACEPOINT);
+#endif
 }
 
-void ksu_tp_marker_unlock(unsigned long *flags)
-{
-    spin_unlock_irqrestore(&tracepoint_reg_lock, *flags);
-}
-
-void ksu_tp_marker_inc_reg_count(void)
-{
-    tracepoint_reg_count++;
-}
-
-void ksu_tp_marker_dec_reg_count(void)
-{
-    tracepoint_reg_count--;
-}
-
-void ksu_clear_task_tracepoint_flag_if_needed(struct task_struct *t)
-{
-    unsigned long flags;
-    spin_lock_irqsave(&tracepoint_reg_lock, flags);
-    if (tracepoint_reg_count <= 1) {
-        ksu_clear_task_tracepoint_flag(t);
-    }
-    spin_unlock_irqrestore(&tracepoint_reg_lock, flags);
-}
-
-// Process marking management
-static void handle_process_mark(bool mark)
+static void handle_process_mark(bool mark_all, bool clear_unneeded)
 {
     struct task_struct *p, *t;
+
     read_lock(&tasklist_lock);
     for_each_process_thread (p, t) {
-        if (mark)
+        const struct cred *cred;
+        bool needs_hook = false;
+        uid_t uid;
+
+        if (mark_all) {
             ksu_set_task_tracepoint_flag(t);
-        else
+            continue;
+        }
+
+        if (t->pid == 1 || t->mm) {
+            uid = task_uid(t).val;
+            cred = get_task_cred(t);
+            needs_hook = ksu_task_needs_syscall_hook(t, cred, uid);
+            put_cred(cred);
+        }
+
+        if (needs_hook)
+            ksu_set_task_tracepoint_flag(t);
+        else if (clear_unneeded)
             ksu_clear_task_tracepoint_flag(t);
     }
+    read_unlock(&tasklist_lock);
+}
+
+static void handle_process_unmark_all(void)
+{
+    struct task_struct *p, *t;
+
+    read_lock(&tasklist_lock);
+    for_each_process_thread (p, t)
+        ksu_clear_task_tracepoint_flag(t);
     read_unlock(&tasklist_lock);
 }
 
 void ksu_mark_all_process(void)
 {
-    handle_process_mark(true);
-    pr_info("tp_marker: mark all user process done!\n");
+    handle_process_mark(true, false);
 }
 
 void ksu_unmark_all_process(void)
 {
-    handle_process_mark(false);
-    pr_info("tp_marker: unmark all user process done!\n");
+    if (!ksu_syscall_tracepoint_allows_selective_marks()) {
+        pr_warn("tp_marker: refusing to clear shared syscall tracepoint marks\n");
+        return;
+    }
+
+    handle_process_unmark_all();
 }
 
-void ksu_mark_running_process_locked(void)
+void ksu_mark_running_process_selective(void)
 {
-    struct task_struct *p, *t;
-    read_lock(&tasklist_lock);
-    for_each_process_thread (p, t) {
-        if (t->pid != 1 && !t->mm) {
-            // skip kernel threads, but always allow pid 1
-            continue;
-        }
-        int uid = task_uid(t).val;
-        const struct cred *cred = get_task_cred(t);
-        bool ksu_root_process = uid == 0 && is_task_ksu_domain(cred);
-        bool is_zygote_process = is_zygote(cred);
-        bool is_shell = uid == 2000;
-        // before boot completed, we shall mark init for marking zygote
-        bool is_init = t->pid == 1;
-        if (ksu_root_process || is_zygote_process || is_shell || is_init || ksu_is_allow_uid(uid)) {
-            ksu_set_task_tracepoint_flag(t);
-            pr_info("tp_marker: mark process: pid:%d, uid: %d, comm:%s\n", t->pid, uid, t->comm);
-        } else {
-            ksu_clear_task_tracepoint_flag(t);
-            pr_info("tp_marker: unmark process: pid:%d, uid: %d, comm:%s\n", t->pid, uid, t->comm);
-        }
-        put_cred(cred);
-    }
-    read_unlock(&tasklist_lock);
+    handle_process_mark(false, true);
 }
 
 void ksu_mark_running_process(void)
 {
-    unsigned long flags;
-    spin_lock_irqsave(&tracepoint_reg_lock, flags);
-    if (tracepoint_reg_count <= 1) {
-        ksu_mark_running_process_locked();
-    } else {
-        pr_info("tp_marker: not mark running process since syscall tracepoint is in use\n");
-    }
-    spin_unlock_irqrestore(&tracepoint_reg_lock, flags);
+    /*
+     * Policy refreshes may run while perf/ftrace/eBPF also owns sys_enter.
+     * Only clear stale marks when the hook manager has proved KernelSU is the
+     * sole consumer; otherwise add marks for newly relevant tasks only.
+     */
+    handle_process_mark(false, ksu_syscall_tracepoint_allows_selective_marks());
 }
 
-// Get task mark status
-// Returns: 1 if marked, 0 if not marked, -ESRCH if task not found
+void ksu_clear_task_tracepoint_flag_if_needed(struct task_struct *t)
+{
+    if (ksu_syscall_tracepoint_allows_selective_marks())
+        ksu_clear_task_tracepoint_flag(t);
+}
+
 int ksu_get_task_mark(pid_t pid)
 {
     struct task_struct *task;
@@ -142,25 +129,23 @@ int ksu_get_task_mark(pid_t pid)
     return marked;
 }
 
-// Set task mark status
-// Returns: 0 on success, -ESRCH if task not found
 int ksu_set_task_mark(pid_t pid, bool mark)
 {
     struct task_struct *task;
     int ret = -ESRCH;
+
+    if (!mark && !ksu_syscall_tracepoint_allows_selective_marks())
+        return -EBUSY;
 
     rcu_read_lock();
     task = find_task_by_vpid(pid);
     if (task) {
         get_task_struct(task);
         rcu_read_unlock();
-        if (mark) {
+        if (mark)
             ksu_set_task_tracepoint_flag(task);
-            pr_info("tp_marker: marked task pid=%d comm=%s\n", pid, task->comm);
-        } else {
+        else
             ksu_clear_task_tracepoint_flag(task);
-            pr_info("tp_marker: unmarked task pid=%d comm=%s\n", pid, task->comm);
-        }
         put_task_struct(task);
         ret = 0;
     } else {

--- a/kernel/hook/tp_marker.h
+++ b/kernel/hook/tp_marker.h
@@ -5,12 +5,12 @@
 #include <linux/sched.h>
 #include <linux/thread_info.h>
 
-// Process marking for tracepoint
 void ksu_mark_all_process(void);
 void ksu_unmark_all_process(void);
 void ksu_mark_running_process(void);
+void ksu_mark_running_process_selective(void);
+void ksu_clear_task_tracepoint_flag_if_needed(struct task_struct *t);
 
-// Per-task mark operations
 int ksu_get_task_mark(pid_t pid);
 int ksu_set_task_mark(pid_t pid, bool mark);
 
@@ -32,16 +32,6 @@ static inline void ksu_clear_task_tracepoint_flag(struct task_struct *t)
 #endif
 }
 
-void ksu_clear_task_tracepoint_flag_if_needed(struct task_struct *t);
-
-// Used by syscall_hook_manager kretprobe handlers
-void ksu_mark_running_process_locked(void);
-
-// Tracepoint registration count management (for kretprobe handlers)
-int ksu_tp_marker_reg_count(void);
-void ksu_tp_marker_lock(unsigned long *flags);
-void ksu_tp_marker_unlock(unsigned long *flags);
-void ksu_tp_marker_inc_reg_count(void);
-void ksu_tp_marker_dec_reg_count(void);
+bool ksu_current_task_needs_syscall_hook(void);
 
 #endif

--- a/kernel/hook/x86_64/patch_memory.c
+++ b/kernel/hook/x86_64/patch_memory.c
@@ -9,6 +9,7 @@
 #include "../patch_memory.h"
 #include "klog.h" // IWYU pragma: keep
 #include <linux/cpumask.h>
+#include <linux/err.h>
 #include <linux/gfp.h> // IWYU pragma: keep
 #include <linux/uaccess.h>
 #include <linux/stop_machine.h>
@@ -18,6 +19,10 @@
 #include <asm/pgtable.h>
 #include <asm/page.h>
 #include <asm/fixmap.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+#include <asm/insn.h>
+#include "infra/symbol_resolver.h"
+#endif
 
 // --- Architecture-specific Page Table to Physical Address translation ---
 #define KSU_P4D_TO_PHYS(p4d) ((unsigned long)p4d_pfn(p4d) << PAGE_SHIFT)
@@ -193,10 +198,49 @@ int ksu_patch_text(void *dst, void *src, size_t len, int flags)
     return stop_machine(ksu_patch_text_cb, &info, cpu_online_mask);
 }
 
-// TODO:
 void *scan_call_to(void *start, size_t size, void *target)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    typedef int (*insn_decode_fn_t)(struct insn *, const void *, int, enum insn_mode);
+    static insn_decode_fn_t decode;
+    const u8 *code = start;
+    size_t offset = 0;
+
+    if (!start || !target)
+        return ERR_PTR(-EINVAL);
+    if (size < 5)
+        return NULL;
+
+    if (!decode)
+        decode = (insn_decode_fn_t)find_kernel_symbol_exact("insn_decode");
+    if (!decode)
+        return ERR_PTR(-EOPNOTSUPP);
+
+    while (offset < size) {
+        struct insn insn;
+        size_t remaining = size - offset;
+        int decode_len = remaining > MAX_INSN_SIZE ? MAX_INSN_SIZE : (int)remaining;
+        int ret;
+
+        ret = decode(&insn, &code[offset], decode_len, INSN_MODE_KERN);
+        if (ret || !insn.length || insn.length > remaining)
+            return ERR_PTR(ret ? ret : -EINVAL);
+
+        if (insn.opcode.nbytes == 1 && insn.opcode.bytes[0] == 0xe8 && insn.immediate.nbytes == sizeof(s32)) {
+            s32 disp = (s32)insn.immediate.value;
+            void *branch_target = (void *)((unsigned long)&code[offset + insn.length] + (long)disp);
+
+            if (branch_target == target)
+                return (void *)&code[offset];
+        }
+
+        offset += insn.length;
+    }
+
     return NULL;
+#else
+    return ERR_PTR(-EOPNOTSUPP);
+#endif
 }
 
 #endif /* __x86_64__ */

--- a/kernel/hook/x86_64/syscall_hook.c
+++ b/kernel/hook/x86_64/syscall_hook.c
@@ -18,20 +18,19 @@ int ksu_dispatcher_nr = -1;
 #define __NR_syscalls (__NR_syscall_max + 1)
 #endif
 
-// Hook registration table — read with READ_ONCE from tracepoint/dispatcher
-// context, written with WRITE_ONCE from init/exit context.
 static ksu_syscall_hook_fn syscall_hooks[__NR_syscalls];
 
-// Track all hooked syscall entries for restoration.
-// Protected by hooked_entries_lock.
 struct syscall_hook_entry {
     int nr;
     sys_call_ptr_t orig;
+    sys_call_ptr_t hook;
+    bool restore_on_abort;
 };
 
 static DEFINE_MUTEX(hooked_entries_lock);
 static struct syscall_hook_entry hooked_entries[16];
-static int hooked_count = 0;
+static int hooked_count;
+static bool direct_hooks_prepared;
 
 static int patch_syscall_table(int nr, sys_call_ptr_t fn)
 {
@@ -51,72 +50,117 @@ static int patch_syscall_table(int nr, sys_call_ptr_t fn)
     return 0;
 }
 
-// Direct syscall table patching: overwrite syscall_table[nr] with fn,
-// save original to *old, and record for restoration at module exit.
-void ksu_syscall_table_hook(int nr, sys_call_ptr_t fn, sys_call_ptr_t *old)
+int ksu_syscall_table_hook(int nr, sys_call_ptr_t fn, sys_call_ptr_t *old)
 {
+    bool added = false;
+    int entry_idx = -1;
+    sys_call_ptr_t current_fn;
+    int i;
+    int ret;
+
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls) {
         pr_info("invalid nr: %d\n", nr);
-        return;
+        return -EINVAL;
     }
 
     mutex_lock(&hooked_entries_lock);
+    if (direct_hooks_prepared) {
+        ret = -ESHUTDOWN;
+        goto out_unlock;
+    }
 
-    sys_call_ptr_t orig = READ_ONCE(ksu_syscall_table[nr]);
+    current_fn = READ_ONCE(ksu_syscall_table[nr]);
     if (old)
-        *old = orig;
+        *old = current_fn;
 
-    // Record for later restoration
-    int i;
-    bool found = false;
     for (i = 0; i < hooked_count; i++) {
         if (hooked_entries[i].nr == nr) {
-            found = true;
+            entry_idx = i;
             break;
         }
     }
-    if (!found) {
-        if (hooked_count < ARRAY_SIZE(hooked_entries)) {
-            hooked_entries[hooked_count].nr = nr;
-            hooked_entries[hooked_count].orig = orig;
-            hooked_count++;
-        } else {
-            pr_warn("hooked_entries full, cannot track syscall %d for restoration\n", nr);
+
+    if (entry_idx < 0) {
+        if (hooked_count >= ARRAY_SIZE(hooked_entries)) {
+            pr_err("hooked_entries full, refusing to patch syscall %d\n", nr);
+            ret = -ENOSPC;
+            goto out_unlock;
         }
+        entry_idx = hooked_count++;
+        hooked_entries[entry_idx].nr = nr;
+        hooked_entries[entry_idx].orig = current_fn;
+        hooked_entries[entry_idx].restore_on_abort = false;
+        added = true;
+    } else if (current_fn != hooked_entries[entry_idx].hook && current_fn != hooked_entries[entry_idx].orig) {
+        pr_err("syscall %d ownership lost: current=0x%lx hook=0x%lx orig=0x%lx\n", nr, (unsigned long)current_fn,
+               (unsigned long)hooked_entries[entry_idx].hook, (unsigned long)hooked_entries[entry_idx].orig);
+        ret = -EBUSY;
+        goto out_unlock;
     }
 
-    patch_syscall_table(nr, fn);
+    ret = patch_syscall_table(nr, fn);
+    if (ret) {
+        if (added)
+            --hooked_count;
+    } else {
+        hooked_entries[entry_idx].hook = fn;
+        hooked_entries[entry_idx].restore_on_abort = false;
+        ksu_syscall_hook_hold_unload_guard();
+    }
 
+out_unlock:
     mutex_unlock(&hooked_entries_lock);
+    return ret;
 }
 
-// Restore syscall_table[nr] to its original value and remove from tracking list.
-void ksu_syscall_table_unhook(int nr)
+int ksu_syscall_table_unhook(int nr)
 {
     int i;
+    int ret = -ENOENT;
 
     if (ksu_syscall_table == NULL)
-        return;
+        return -ENOENT;
     if (nr < 0 || nr >= __NR_syscalls)
-        return;
+        return -EINVAL;
 
     mutex_lock(&hooked_entries_lock);
-
-    for (i = 0; i < hooked_count; i++) {
-        if (hooked_entries[i].nr == nr) {
-            patch_syscall_table(nr, hooked_entries[i].orig);
-            // Remove entry by swapping with last
-            hooked_entries[i] = hooked_entries[--hooked_count];
-            mutex_unlock(&hooked_entries_lock);
-            pr_info("unhooked syscall %d\n", nr);
-            return;
-        }
+    if (direct_hooks_prepared) {
+        ret = -ESHUTDOWN;
+        goto out_unlock;
     }
 
+    for (i = 0; i < hooked_count; i++) {
+        sys_call_ptr_t current_fn;
+
+        if (hooked_entries[i].nr != nr)
+            continue;
+
+        current_fn = READ_ONCE(ksu_syscall_table[nr]);
+        if (current_fn == hooked_entries[i].hook) {
+            ret = patch_syscall_table(nr, hooked_entries[i].orig);
+            if (ret) {
+                pr_err("failed to unhook syscall %d: %d\n", nr, ret);
+                break;
+            }
+        } else if (current_fn == hooked_entries[i].orig) {
+            ret = 0;
+        } else {
+            pr_err("refusing to unhook syscall %d after ownership loss: current=0x%lx\n", nr,
+                   (unsigned long)current_fn);
+            ret = -EBUSY;
+            break;
+        }
+
+        hooked_entries[i] = hooked_entries[--hooked_count];
+        pr_info("unhooked syscall %d\n", nr);
+        break;
+    }
+
+out_unlock:
     mutex_unlock(&hooked_entries_lock);
-    pr_warn("syscall %d not found in hooked entries\n", nr);
+    return ret;
 }
 
 static int ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
@@ -144,22 +188,16 @@ static int ksu_find_ni_syscall_slots(int *out_slots, int max_slots)
     return count;
 }
 
-// Unified dispatcher: reads original NR from orig_ax, dispatches to handler.
-// Validates that orig_ax matches our dispatcher slot (i.e. we redirected it),
-// otherwise it's a spurious call — return -ENOSYS.
 static long __nocfi ksu_syscall_dispatcher(const struct pt_regs *regs)
 {
     if (regs->orig_ax != ksu_dispatcher_nr)
         return -ENOSYS;
 
-    // On x86_64, orig_ax was overwritten by our tracepoint to route here.
-    // The original syscall number passed by userspace is still sitting untouched in ax.
     int orig_nr = (int)regs->ax;
 
     if (regs->orig_ax == orig_nr)
         return -ENOSYS;
 
-    // Restore registers to original state before dispatching
     ((struct pt_regs *)regs)->orig_ax = orig_nr;
 
     if (likely(orig_nr >= 0 && orig_nr < __NR_syscalls)) {
@@ -171,8 +209,6 @@ static long __nocfi ksu_syscall_dispatcher(const struct pt_regs *regs)
     return -ENOSYS;
 }
 
-// Register a handler into the dispatcher's routing table.
-// Does not modify the syscall table — the dispatcher slot is shared by all hooks.
 int ksu_register_syscall_hook(int nr, ksu_syscall_hook_fn fn)
 {
     if (nr < 0 || nr >= __NR_syscalls)
@@ -186,8 +222,6 @@ int ksu_register_syscall_hook(int nr, ksu_syscall_hook_fn fn)
     return 0;
 }
 
-// Remove a handler from the dispatcher's routing table.
-// The syscall table is not touched — only the dispatcher stops routing this nr.
 void ksu_unregister_syscall_hook(int nr)
 {
     if (nr < 0 || nr >= __NR_syscalls)
@@ -203,34 +237,28 @@ bool ksu_has_syscall_hook(int nr)
     return READ_ONCE(syscall_hooks[nr]) != NULL;
 }
 
-// https://github.com/torvalds/linux/commit/1e3ad78334a69b36e107232e337f9d693dcc9df2
-// harden syscall table was introduced in 6.9, but it was backported to almost
-// all of GKI kernel except 5.10
 #ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
 static void *x64_sys_call_patch_addr;
 static char x64_sys_call_patch_orig_insn[14];
+static char x64_sys_call_patch_insn[14];
+static bool x64_restore_on_abort;
 
 static long my_x64_sys_call(const struct pt_regs *regs, unsigned int nr)
 {
     return ksu_syscall_table[nr](regs);
 }
 
-// avd 13-5.15 missing this commit:
-// https://github.com/torvalds/linux/commit/fb13b11d53875e28e7fbf0c26b288e4ea676aa9f
-// we need to patch the whole do_syscall_64
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 static void *do_syscall_64_patch_addr;
 static char do_syscall_64_orig_insn[14];
+static char do_syscall_64_patch_insn[14];
+static bool do_syscall_restore_on_abort;
 
 static long (*syscall_enter_from_user_mode_fn)(struct pt_regs *regs, long syscall);
 static void (*syscall_exit_to_user_mode_fn)(struct pt_regs *regs);
 
 static __always_inline bool my_do_syscall_x64(struct pt_regs *regs, int nr)
 {
-    /*
-	 * Convert negative numbers to very high and thus out of range
-	 * numbers for comparisons.
-	 */
     unsigned int unr = nr;
 
     if (likely(unr < NR_syscalls)) {
@@ -246,57 +274,63 @@ static void __nocfi my_do_syscall_64(struct pt_regs *regs, int nr)
     nr = syscall_enter_from_user_mode_fn(regs, nr);
     nr = syscall_get_nr(current, regs);
 
-    // AVD doesn't have x32 support after A13, we can ignore do_syscall_x32
-
-    if (!my_do_syscall_x64(regs, nr) && nr != -1) {
-        /* Invalid system call, but still a system call. */
+    if (!my_do_syscall_x64(regs, nr) && nr != -1)
         regs->ax = -ENOSYS;
-    }
 
     syscall_exit_to_user_mode_fn(regs);
 }
 #endif
 #endif
 
-static void patch_abs_jump(const char *sym, void **patch_addr, void *target, char backup[14])
+static void patch_abs_jump(const char *sym, void **patch_addr, void *target, char backup[14], char patch[14])
 {
+    static const char endbr64_insn[] = {
+        // clang-format off
+        0xf3, 0x0f, 0x1e, 0xfa
+        // clang-format on
+    };
+    char buf[] = {
+        // clang-format off
+        0xff, 0x25, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // clang-format on
+    };
+    int ret;
+
     *patch_addr = (void *)find_kernel_symbol_exact(sym);
     pr_info("%s=0x%lx\n", sym, (unsigned long)*patch_addr);
-    if (*patch_addr) {
-        pr_info("patching %s\n", sym);
-        // skip endbr64
-        static const char endbr64_insn[] = {
-            // clang-format off
-            0xf3, 0x0f, 0x1e, 0xfa
-            // clang-format on
-        };
-        if (memcmp((void *)*patch_addr, endbr64_insn, sizeof(endbr64_insn)) == 0) {
-            pr_info("%s: skip endbr64\n", sym);
-            *patch_addr = (void *)((char *)(*patch_addr) + 4);
-        }
-        // clang-format off
-        char buf[] = {
-            // jmp *(%rip) = addr
-            0xff, 0x25, 0x00, 0x00, 0x00, 0x00,
-            // addr: .quad 0
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        };
-        // clang-format on
-        *((void **)(buf + 6)) = target;
-        memcpy(backup, *patch_addr, sizeof(buf));
-        int ret = ksu_patch_text(*patch_addr, buf, sizeof(buf), KSU_PATCH_TEXT_FLUSH_ICACHE);
-        if (ret) {
-            pr_err("patch %s err: %d\n", sym, ret);
-            *patch_addr = NULL;
-        }
+    if (!*patch_addr)
+        return;
+
+    if (memcmp(*patch_addr, endbr64_insn, sizeof(endbr64_insn)) == 0)
+        *patch_addr = (void *)((char *)(*patch_addr) + 4);
+
+    *((void **)(buf + 6)) = target;
+    memcpy(backup, *patch_addr, sizeof(buf));
+    memcpy(patch, buf, sizeof(buf));
+    ret = ksu_patch_text(*patch_addr, buf, sizeof(buf), KSU_PATCH_TEXT_FLUSH_ICACHE);
+    if (ret) {
+        pr_err("patch %s err: %d\n", sym, ret);
+        *patch_addr = NULL;
+        return;
     }
+
+    ksu_syscall_hook_hold_unload_guard();
 }
 
 void __init __nocfi ksu_syscall_hook_init(void)
 {
     int ni_slot;
+    int ret;
 
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
+    direct_hooks_prepared = false;
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    x64_restore_on_abort = false;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    do_syscall_restore_on_abort = false;
+#endif
+#endif
 
     ksu_syscall_table = (sys_call_ptr_t *)ksu_resolve_symbol_for_functable_hook("sys_call_table");
     pr_info("sys_call_table=0x%lx\n", (unsigned long)ksu_syscall_table);
@@ -305,81 +339,362 @@ void __init __nocfi ksu_syscall_hook_init(void)
         return;
 
 #ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
-    patch_abs_jump("x64_sys_call", &x64_sys_call_patch_addr, my_x64_sys_call, x64_sys_call_patch_orig_insn);
+    patch_abs_jump("x64_sys_call", &x64_sys_call_patch_addr, my_x64_sys_call, x64_sys_call_patch_orig_insn,
+                   x64_sys_call_patch_insn);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
     syscall_enter_from_user_mode_fn = find_kernel_symbol_exact("syscall_enter_from_user_mode");
     syscall_exit_to_user_mode_fn = find_kernel_symbol_exact("syscall_exit_to_user_mode");
     pr_info("syscall_enter_from_user_mode: 0x%lx, syscall_exit_to_user_mode: 0x%lx\n",
             (unsigned long)syscall_enter_from_user_mode_fn, (unsigned long)syscall_exit_to_user_mode_fn);
     if (syscall_enter_from_user_mode_fn && syscall_exit_to_user_mode_fn) {
-        patch_abs_jump("do_syscall_64", &do_syscall_64_patch_addr, my_do_syscall_64, do_syscall_64_orig_insn);
+        patch_abs_jump("do_syscall_64", &do_syscall_64_patch_addr, my_do_syscall_64, do_syscall_64_orig_insn,
+                       do_syscall_64_patch_insn);
     }
 #endif
 #endif
 
-    // Find one ni_syscall slot for the dispatcher
     if (ksu_find_ni_syscall_slots(&ni_slot, 1) < 1) {
         pr_err("failed to find ni_syscall slot for dispatcher\n");
         return;
     }
 
     ksu_dispatcher_nr = ni_slot;
-    ksu_syscall_table_hook(ksu_dispatcher_nr, (sys_call_ptr_t)ksu_syscall_dispatcher, NULL);
+    ret = ksu_syscall_table_hook(ksu_dispatcher_nr, (sys_call_ptr_t)ksu_syscall_dispatcher, NULL);
+    if (ret) {
+        pr_err("failed to install dispatcher at slot %d: %d\n", ksu_dispatcher_nr, ret);
+        ksu_dispatcher_nr = -1;
+        return;
+    }
     pr_info("dispatcher installed at slot %d\n", ksu_dispatcher_nr);
 }
 
-void __exit ksu_syscall_hook_exit(void)
+static int validate_table_ownership_locked(void)
 {
     int i;
 
+    for (i = 0; i < hooked_count; i++) {
+        sys_call_ptr_t current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+
+        if (current_fn == hooked_entries[i].hook || current_fn == hooked_entries[i].orig)
+            continue;
+
+        pr_err("syscall %d ownership lost: current=0x%lx hook=0x%lx orig=0x%lx\n", hooked_entries[i].nr,
+               (unsigned long)current_fn, (unsigned long)hooked_entries[i].hook, (unsigned long)hooked_entries[i].orig);
+        return -EBUSY;
+    }
+
+    return 0;
+}
+
+static int rollback_prepared_table_locked(void)
+{
+    int rollback_ret = 0;
+    int i;
+
+    for (i = hooked_count - 1; i >= 0; i--) {
+        sys_call_ptr_t current_fn;
+        int ret;
+
+        if (!hooked_entries[i].restore_on_abort)
+            continue;
+
+        current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+        if (current_fn == hooked_entries[i].hook) {
+            hooked_entries[i].restore_on_abort = false;
+            continue;
+        }
+        if (current_fn != hooked_entries[i].orig) {
+            pr_err("cannot rollback syscall %d after ownership loss\n", hooked_entries[i].nr);
+            rollback_ret = -EUCLEAN;
+            continue;
+        }
+
+        ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].hook);
+        if (ret) {
+            rollback_ret = ret;
+            continue;
+        }
+        hooked_entries[i].restore_on_abort = false;
+    }
+
+    return rollback_ret;
+}
+
 #ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+static int inspect_text_patch(void *addr, const char *patch, const char *orig, size_t len, const char *name,
+                              bool *owned)
+{
+    if (!addr) {
+        *owned = false;
+        return 0;
+    }
+    if (!memcmp(addr, patch, len)) {
+        *owned = true;
+        return 0;
+    }
+    if (!memcmp(addr, orig, len)) {
+        *owned = false;
+        return 0;
+    }
+
+    pr_err("%s ownership lost; refusing to overwrite foreign text\n", name);
+    return -EBUSY;
+}
+#endif
+
+int ksu_syscall_hook_exit(void)
+{
+    int rollback_ret;
     int ret;
-    if (x64_sys_call_patch_addr) {
-        ret = ksu_patch_text((void *)x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn,
+    int i;
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    bool owned;
+#endif
+
+    mutex_lock(&hooked_entries_lock);
+    if (direct_hooks_prepared) {
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
+
+    if (ksu_syscall_table) {
+        ret = validate_table_ownership_locked();
+        if (ret)
+            goto out_fail;
+    }
+
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    ret = inspect_text_patch(x64_sys_call_patch_addr, x64_sys_call_patch_insn, x64_sys_call_patch_orig_insn,
+                             sizeof(x64_sys_call_patch_insn), "x64_sys_call", &owned);
+    if (ret)
+        goto out_fail;
+    x64_restore_on_abort = owned;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    ret = inspect_text_patch(do_syscall_64_patch_addr, do_syscall_64_patch_insn, do_syscall_64_orig_insn,
+                             sizeof(do_syscall_64_patch_insn), "do_syscall_64", &owned);
+    if (ret)
+        goto out_fail;
+    do_syscall_restore_on_abort = owned;
+#endif
+#endif
+
+    if (ksu_syscall_table) {
+        for (i = 0; i < hooked_count; i++) {
+            sys_call_ptr_t current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+
+            hooked_entries[i].restore_on_abort = false;
+            if (current_fn == hooked_entries[i].orig)
+                continue;
+
+            ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].orig);
+            if (ret) {
+                rollback_ret = rollback_prepared_table_locked();
+                if (rollback_ret)
+                    ret = -EUCLEAN;
+                goto out_fail;
+            }
+            hooked_entries[i].restore_on_abort = true;
+        }
+    }
+
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    if (x64_restore_on_abort) {
+        ret = ksu_patch_text(x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn,
                              sizeof(x64_sys_call_patch_orig_insn), KSU_PATCH_TEXT_FLUSH_ICACHE);
         if (ret) {
-            pr_err("restore x64_sys_call err: %d\n", ret);
+            rollback_ret = rollback_prepared_table_locked();
+            if (rollback_ret)
+                ret = -EUCLEAN;
+            goto out_fail;
         }
     }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
-    if (do_syscall_64_patch_addr) {
-        ret = ksu_patch_text((void *)do_syscall_64_patch_addr, do_syscall_64_orig_insn, sizeof(do_syscall_64_orig_insn),
+    if (do_syscall_restore_on_abort) {
+        ret = ksu_patch_text(do_syscall_64_patch_addr, do_syscall_64_orig_insn, sizeof(do_syscall_64_orig_insn),
                              KSU_PATCH_TEXT_FLUSH_ICACHE);
         if (ret) {
-            pr_err("restore x64_sys_call err: %d\n", ret);
+            int rollback = 0;
+
+            if (x64_restore_on_abort &&
+                !memcmp(x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn, sizeof(x64_sys_call_patch_orig_insn)))
+                rollback = ksu_patch_text(x64_sys_call_patch_addr, x64_sys_call_patch_insn,
+                                          sizeof(x64_sys_call_patch_insn), KSU_PATCH_TEXT_FLUSH_ICACHE);
+            rollback_ret = rollback_prepared_table_locked();
+            if (rollback || rollback_ret)
+                ret = -EUCLEAN;
+            goto out_fail;
         }
     }
 #endif
 #endif
 
-    if (!ksu_syscall_table)
-        goto clear_state;
+    direct_hooks_prepared = true;
+    mutex_unlock(&hooked_entries_lock);
+    pr_info("all direct syscall hooks prepared for unload\n");
+    return 0;
 
-    // First, restore all patched syscall table entries while the dispatcher
-    // and hook table are still intact, so in-flight syscalls see valid state.
+out_fail:
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    x64_restore_on_abort = false;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    do_syscall_restore_on_abort = false;
+#endif
+#endif
+    mutex_unlock(&hooked_entries_lock);
+    return ret;
+}
+
+int ksu_syscall_hook_abort_exit(void)
+{
+    bool table_applied[ARRAY_SIZE(hooked_entries)] = { false };
+    int rollback_ret = 0;
+    int ret = 0;
+    int i;
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    bool x64_applied = false;
+#endif
+
     mutex_lock(&hooked_entries_lock);
-    for (i = 0; i < hooked_count; i++) {
-        int nr = hooked_entries[i].nr;
-        sys_call_ptr_t orig = hooked_entries[i].orig;
+    if (!direct_hooks_prepared) {
+        mutex_unlock(&hooked_entries_lock);
+        return 0;
+    }
 
-        pr_info("restore syscall %d to 0x%lx\n", nr, (unsigned long)orig);
-        if (ksu_patch_text(&ksu_syscall_table[nr], &orig, sizeof(orig), KSU_PATCH_TEXT_FLUSH_DCACHE)) {
-            pr_err("restore syscall %d failed\n", nr);
+    if (ksu_syscall_table) {
+        for (i = 0; i < hooked_count; i++) {
+            sys_call_ptr_t current_fn;
+
+            if (!hooked_entries[i].restore_on_abort)
+                continue;
+            current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+            if (current_fn != hooked_entries[i].orig && current_fn != hooked_entries[i].hook) {
+                pr_err("cannot re-arm syscall %d after ownership loss\n", hooked_entries[i].nr);
+                ret = -EBUSY;
+                goto out_fail;
+            }
         }
     }
+
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    if (x64_restore_on_abort &&
+        memcmp(x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn, sizeof(x64_sys_call_patch_orig_insn)) &&
+        memcmp(x64_sys_call_patch_addr, x64_sys_call_patch_insn, sizeof(x64_sys_call_patch_insn))) {
+        pr_err("x64_sys_call ownership lost during unload abort\n");
+        ret = -EBUSY;
+        goto out_fail;
+    }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    if (do_syscall_restore_on_abort &&
+        memcmp(do_syscall_64_patch_addr, do_syscall_64_orig_insn, sizeof(do_syscall_64_orig_insn)) &&
+        memcmp(do_syscall_64_patch_addr, do_syscall_64_patch_insn, sizeof(do_syscall_64_patch_insn))) {
+        pr_err("do_syscall_64 ownership lost during unload abort\n");
+        ret = -EBUSY;
+        goto out_fail;
+    }
+#endif
+#endif
+
+    if (ksu_syscall_table) {
+        for (i = 0; i < hooked_count; i++) {
+            sys_call_ptr_t current_fn;
+
+            if (!hooked_entries[i].restore_on_abort)
+                continue;
+            current_fn = READ_ONCE(ksu_syscall_table[hooked_entries[i].nr]);
+            if (current_fn == hooked_entries[i].hook)
+                continue;
+            ret = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].hook);
+            if (ret)
+                goto rollback;
+            table_applied[i] = true;
+        }
+    }
+
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    if (x64_restore_on_abort &&
+        !memcmp(x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn, sizeof(x64_sys_call_patch_orig_insn))) {
+        ret = ksu_patch_text(x64_sys_call_patch_addr, x64_sys_call_patch_insn, sizeof(x64_sys_call_patch_insn),
+                             KSU_PATCH_TEXT_FLUSH_ICACHE);
+        if (ret)
+            goto rollback;
+        x64_applied = true;
+    }
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    if (do_syscall_restore_on_abort &&
+        !memcmp(do_syscall_64_patch_addr, do_syscall_64_orig_insn, sizeof(do_syscall_64_orig_insn))) {
+        ret = ksu_patch_text(do_syscall_64_patch_addr, do_syscall_64_patch_insn, sizeof(do_syscall_64_patch_insn),
+                             KSU_PATCH_TEXT_FLUSH_ICACHE);
+        if (ret)
+            goto rollback;
+    }
+#endif
+#endif
+
+    for (i = 0; i < hooked_count; i++)
+        hooked_entries[i].restore_on_abort = false;
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    x64_restore_on_abort = false;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    do_syscall_restore_on_abort = false;
+#endif
+#endif
+    direct_hooks_prepared = false;
+    mutex_unlock(&hooked_entries_lock);
+    pr_info("all direct syscall hooks re-armed\n");
+    return 0;
+
+rollback:
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    if (do_syscall_restore_on_abort &&
+        !memcmp(do_syscall_64_patch_addr, do_syscall_64_patch_insn, sizeof(do_syscall_64_patch_insn))) {
+        int rollback = ksu_patch_text(do_syscall_64_patch_addr, do_syscall_64_orig_insn,
+                                      sizeof(do_syscall_64_orig_insn), KSU_PATCH_TEXT_FLUSH_ICACHE);
+        if (rollback)
+            rollback_ret = rollback;
+    }
+#endif
+    if (x64_applied) {
+        int rollback = ksu_patch_text(x64_sys_call_patch_addr, x64_sys_call_patch_orig_insn,
+                                      sizeof(x64_sys_call_patch_orig_insn), KSU_PATCH_TEXT_FLUSH_ICACHE);
+        if (rollback)
+            rollback_ret = rollback;
+    }
+#endif
+    for (i = hooked_count - 1; i >= 0; i--) {
+        if (table_applied[i]) {
+            int rollback = patch_syscall_table(hooked_entries[i].nr, hooked_entries[i].orig);
+            if (rollback)
+                rollback_ret = rollback;
+        }
+    }
+    if (rollback_ret)
+        ret = -EUCLEAN;
+
+out_fail:
+    mutex_unlock(&hooked_entries_lock);
+    return ret;
+}
+
+void ksu_syscall_hook_finish_exit(void)
+{
+    mutex_lock(&hooked_entries_lock);
     hooked_count = 0;
+    direct_hooks_prepared = false;
+#ifdef CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER
+    x64_restore_on_abort = false;
+    x64_sys_call_patch_addr = NULL;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
+    do_syscall_restore_on_abort = false;
+    do_syscall_64_patch_addr = NULL;
+#endif
+#endif
     mutex_unlock(&hooked_entries_lock);
 
-clear_state:
-    // Now that the syscall table is restored, clear internal state.
-    // At this point the tracepoint is already unregistered and synchronized
-    // (done by ksu_syscall_hook_manager_exit before calling us), so no new
-    // dispatches will occur.
     memset(syscall_hooks, 0, sizeof(syscall_hooks));
     ksu_dispatcher_nr = -1;
-
-    pr_info("all syscall hooks restored\n");
 }
 
 #endif /* __x86_64__ */

--- a/kernel/include/arch.h
+++ b/kernel/include/arch.h
@@ -25,6 +25,7 @@
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscalltbl.sh;l=57;drc=9142be9e6443fd641ca37f820efe00d9cd890eb1
 // https://cs.android.com/android/kernel/superproject/+/common-android-mainline:common/scripts/syscall.tbl;l=104;drc=b36d4b6aa88ef039647228b98c59a875e92f8c8e
 #define SYS_FSTAT_SYMBOL "__arm64_sys_newfstat"
+#define KSU_USER_STACK_SCRATCH_GAP 0UL
 
 #elif defined(__x86_64__)
 
@@ -46,6 +47,7 @@
 #define SYS_READ_SYMBOL "__x64_sys_read"
 #define SYS_EXECVE_SYMBOL "__x64_sys_execve"
 #define SYS_FSTAT_SYMBOL "__x64_sys_newfstat"
+#define KSU_USER_STACK_SCRATCH_GAP 128UL
 
 #else
 #error "Unsupported arch"
@@ -71,5 +73,10 @@
 #define PT_REGS_ORIG_SYSCALL(x) (__PT_REGS_CAST(x)->__PT_ORIG_SYSCALL_REG)
 
 #define PT_REAL_REGS(regs) ((struct pt_regs *)PT_REGS_PARM1(regs))
+
+static inline unsigned long ksu_user_stack_scratch_top(unsigned long sp)
+{
+    return sp - KSU_USER_STACK_SCRATCH_GAP;
+}
 
 #endif

--- a/kernel/infra/event_queue.c
+++ b/kernel/infra/event_queue.c
@@ -1,3 +1,4 @@
+#include <linux/err.h>
 #include <linux/ktime.h>
 #include <linux/list.h>
 #include <linux/mutex.h>
@@ -11,9 +12,10 @@
 
 #include "infra/event_queue.h"
 
-struct ksu_event_queue_node {
+struct ksu_event_queue_entry {
     struct list_head list;
     struct ksu_event_record_hdr hdr;
+    __u32 capacity;
     __u8 payload[];
 };
 
@@ -68,7 +70,7 @@ void ksu_event_queue_init(struct ksu_event_queue *queue, __u32 max_queued, __u32
 
 void ksu_event_queue_destroy(struct ksu_event_queue *queue)
 {
-    struct ksu_event_queue_node *node, *tmp;
+    struct ksu_event_queue_entry *entry, *tmp;
     unsigned long irq_flags;
 
     ksu_event_queue_mark_closed(queue);
@@ -76,9 +78,9 @@ void ksu_event_queue_destroy(struct ksu_event_queue *queue)
 
     mutex_lock(&queue->read_lock);
     spin_lock_irqsave(&queue->lock, irq_flags);
-    list_for_each_entry_safe (node, tmp, &queue->pending, list) {
-        list_del(&node->list);
-        kfree(node);
+    list_for_each_entry_safe (entry, tmp, &queue->pending, list) {
+        list_del(&entry->list);
+        kfree(entry);
     }
     queue->queued = 0;
     queue->dropped_pending = 0;
@@ -93,36 +95,56 @@ void ksu_event_queue_destroy(struct ksu_event_queue *queue)
     wake_up_interruptible_poll(&queue->read_wait, EPOLLHUP | POLLHUP);
 }
 
-int ksu_event_queue_push(struct ksu_event_queue *queue, __u16 type, __u16 flags, const void *payload, __u32 len,
-                         gfp_t gfp)
+struct ksu_event_queue_entry *ksu_event_queue_entry_alloc(struct ksu_event_queue *queue, __u16 type, __u16 flags,
+                                                          __u32 capacity, gfp_t gfp)
 {
-    struct ksu_event_queue_node *node = NULL;
+    struct ksu_event_queue_entry *entry;
+
+    if (capacity > queue->max_payload_len) {
+        return ERR_PTR(-EMSGSIZE);
+    }
+
+    entry = kmalloc(struct_size(entry, payload, capacity), gfp);
+    if (!entry) {
+        return ERR_PTR(-ENOMEM);
+    }
+
+    INIT_LIST_HEAD(&entry->list);
+    entry->hdr.type = type;
+    entry->hdr.flags = flags;
+    entry->hdr.len = capacity;
+    entry->hdr.ts_ns = 0;
+    entry->hdr.seq = 0;
+    entry->capacity = capacity;
+    return entry;
+}
+
+void *ksu_event_queue_entry_payload(struct ksu_event_queue_entry *entry)
+{
+    return entry ? entry->payload : NULL;
+}
+
+int ksu_event_queue_entry_set_len(struct ksu_event_queue_entry *entry, __u32 len)
+{
+    if (!entry || len > entry->capacity) {
+        return -EINVAL;
+    }
+    entry->hdr.len = len;
+    return 0;
+}
+
+int ksu_event_queue_entry_push(struct ksu_event_queue *queue, struct ksu_event_queue_entry *entry)
+{
     unsigned long irq_flags;
     __u64 seq;
     bool wake = false;
     int ret = 0;
 
-    if (len > queue->max_payload_len) {
-        return -EMSGSIZE;
-    }
-
-    if (len && !payload) {
+    if (!entry) {
         return -EINVAL;
     }
-
-    node = kmalloc(struct_size(node, payload, len), gfp);
-
-    if (node) {
-        INIT_LIST_HEAD(&node->list);
-        node->hdr.type = type;
-        node->hdr.flags = flags;
-        node->hdr.len = len;
-        node->hdr.ts_ns = 0;
-        node->hdr.seq = 0;
-
-        if (len) {
-            memcpy(node->payload, payload, len);
-        }
+    if (entry->hdr.len > entry->capacity || entry->hdr.len > queue->max_payload_len) {
+        return -EMSGSIZE;
     }
 
     spin_lock_irqsave(&queue->lock, irq_flags);
@@ -132,30 +154,61 @@ int ksu_event_queue_push(struct ksu_event_queue *queue, __u16 type, __u16 flags,
     }
 
     seq = queue->next_seq++;
-    if (!node || (queue->max_queued && queue->queued >= queue->max_queued)) {
+    if (queue->max_queued && queue->queued >= queue->max_queued) {
         ksu_event_queue_note_drop_locked(queue, seq);
         wake = true;
-        ret = node ? -ENOSPC : -ENOMEM;
+        ret = -ENOSPC;
         goto out_unlock;
     }
 
-    node->hdr.seq = seq;
-    node->hdr.ts_ns = ktime_get_ns();
-    list_add_tail(&node->list, &queue->pending);
+    entry->hdr.seq = seq;
+    entry->hdr.ts_ns = ktime_get_ns();
+    list_add_tail(&entry->list, &queue->pending);
     queue->queued++;
     wake = true;
 
 out_unlock:
     spin_unlock_irqrestore(&queue->lock, irq_flags);
 
-    if (ret && node) {
-        kfree(node);
-    }
-
     if (wake) {
         wake_up_interruptible_poll(&queue->read_wait, EPOLLIN | EPOLLRDNORM);
     }
 
+    return ret;
+}
+
+void ksu_event_queue_entry_free(struct ksu_event_queue_entry *entry)
+{
+    kfree(entry);
+}
+
+int ksu_event_queue_push(struct ksu_event_queue *queue, __u16 type, __u16 flags, const void *payload, __u32 len,
+                         gfp_t gfp)
+{
+    struct ksu_event_queue_entry *entry;
+    int ret;
+
+    if (len && !payload) {
+        return -EINVAL;
+    }
+
+    entry = ksu_event_queue_entry_alloc(queue, type, flags, len, gfp);
+    if (IS_ERR(entry)) {
+        ret = PTR_ERR(entry);
+        if (ret == -ENOMEM) {
+            ksu_event_queue_drop(queue);
+        }
+        return ret;
+    }
+
+    if (len) {
+        memcpy(entry->payload, payload, len);
+    }
+
+    ret = ksu_event_queue_entry_push(queue, entry);
+    if (ret) {
+        ksu_event_queue_entry_free(entry);
+    }
     return ret;
 }
 
@@ -270,9 +323,9 @@ out_restore:
     return -EFAULT;
 }
 
-static ssize_t ksu_event_queue_read_node(struct ksu_event_queue *queue, char __user *buf, size_t count)
+static ssize_t ksu_event_queue_read_entry(struct ksu_event_queue *queue, char __user *buf, size_t count)
 {
-    struct ksu_event_queue_node *node;
+    struct ksu_event_queue_entry *entry;
     struct list_head *first;
     size_t record_size;
     unsigned long irq_flags;
@@ -284,19 +337,19 @@ static ssize_t ksu_event_queue_read_node(struct ksu_event_queue *queue, char __u
     }
 
     first = queue->pending.next;
-    node = list_entry(first, struct ksu_event_queue_node, list);
-    record_size = ksu_event_queue_record_size(node->hdr.len);
+    entry = list_entry(first, struct ksu_event_queue_entry, list);
+    record_size = ksu_event_queue_record_size(entry->hdr.len);
     if (count < record_size) {
         spin_unlock_irqrestore(&queue->lock, irq_flags);
         return -EMSGSIZE;
     }
     spin_unlock_irqrestore(&queue->lock, irq_flags);
 
-    if (copy_to_user(buf, &node->hdr, sizeof(node->hdr))) {
+    if (copy_to_user(buf, &entry->hdr, sizeof(entry->hdr))) {
         return -EFAULT;
     }
 
-    if (node->hdr.len && copy_to_user(buf + sizeof(node->hdr), node->payload, node->hdr.len)) {
+    if (entry->hdr.len && copy_to_user(buf + sizeof(entry->hdr), entry->payload, entry->hdr.len)) {
         return -EFAULT;
     }
 
@@ -305,7 +358,7 @@ static ssize_t ksu_event_queue_read_node(struct ksu_event_queue *queue, char __u
     queue->queued--;
     spin_unlock_irqrestore(&queue->lock, irq_flags);
 
-    kfree(node);
+    kfree(entry);
     return record_size;
 }
 
@@ -344,7 +397,7 @@ ssize_t ksu_event_queue_read(struct ksu_event_queue *queue, char __user *buf, si
             continue;
         }
 
-        ret = ksu_event_queue_read_node(queue, buf, count);
+        ret = ksu_event_queue_read_entry(queue, buf, count);
         if (ret < 0) {
             if (!copied) {
                 copied = ret;

--- a/kernel/infra/event_queue.h
+++ b/kernel/infra/event_queue.h
@@ -47,8 +47,17 @@ struct ksu_event_queue {
     bool closed;
 };
 
+struct ksu_event_queue_entry;
+
 void ksu_event_queue_init(struct ksu_event_queue *queue, __u32 max_queued, __u32 max_payload_len);
 void ksu_event_queue_destroy(struct ksu_event_queue *queue);
+
+struct ksu_event_queue_entry *ksu_event_queue_entry_alloc(struct ksu_event_queue *queue, __u16 type, __u16 flags,
+                                                          __u32 capacity, gfp_t gfp);
+void *ksu_event_queue_entry_payload(struct ksu_event_queue_entry *entry);
+int ksu_event_queue_entry_set_len(struct ksu_event_queue_entry *entry, __u32 len);
+int ksu_event_queue_entry_push(struct ksu_event_queue *queue, struct ksu_event_queue_entry *entry);
+void ksu_event_queue_entry_free(struct ksu_event_queue_entry *entry);
 
 int ksu_event_queue_push(struct ksu_event_queue *queue, __u16 type, __u16 flags, const void *payload, __u32 len,
                          gfp_t gfp);

--- a/kernel/infra/file_wrapper.c
+++ b/kernel/infra/file_wrapper.c
@@ -12,12 +12,13 @@
 #include <linux/uaccess.h>
 #include <linux/version.h>
 #include <linux/mount.h>
-
-#include "objsec.h"
+#include <linux/module.h>
+#include <linux/security.h>
 
 #include "klog.h" // IWYU pragma: keep
-#include "selinux/selinux.h"
 
+#include "hook/syscall_hook.h"
+#include "hook/syscall_hook_manager.h"
 #include "infra/file_wrapper.h"
 
 struct ksu_file_wrapper {
@@ -418,6 +419,7 @@ static void ksu_wrapper_d_release(struct dentry *dentry)
     struct path *orig_path = dentry->d_fsdata;
     path_put(orig_path);
     kfree(orig_path);
+    ksu_module_unload_leave();
 }
 
 static const struct dentry_operations ksu_file_wrapper_d_ops = { .d_dname = ksu_wrapper_d_dname,
@@ -521,14 +523,16 @@ int ksu_install_file_wrapper(int fd)
     // It should be safe to modify them since the file hasn't been published.
 
     struct inode *wrapper_inode = file_inode(wrapper_file);
+    /*
+     * The wrapper needs a unique inode because libc uses fstat() to identify
+     * TTYs. It is not pathname-addressable, so restore the S_PRIVATE flag
+     * that secure anonymous-inode creation clears. SELinux intentionally
+     * skips inode permission checks for private inodes; descriptor handoff is
+     * still controlled by the file's creator SID and the existing fd/use rule.
+     */
+    wrapper_inode->i_flags |= S_PRIVATE;
     // libc's stdio relies on the fstat() result of the fd to determine its buffer type.
     wrapper_inode->i_mode = file_inode(orig_file)->i_mode;
-    struct inode_security_struct *wrapper_sec = selinux_inode(wrapper_inode);
-    // Use ksu_file_sid to bypass SELinux check.
-    // When we call `su` from terminal app, this is useful.
-    if (wrapper_sec) {
-        wrapper_sec->sid = ksu_file_sid;
-    }
     // Install open file operation for inode.
     wrapper_inode->i_fop = &ksu_file_wrapper_inode_fops;
 
@@ -539,6 +543,21 @@ int ksu_install_file_wrapper(int fd)
     }
     *orig_path = orig_file->f_path;
     path_get(orig_path);
+
+    /*
+     * dentry_operations has no owner field, so the custom d_dname/d_release
+     * callbacks cannot pin module text by themselves. Keep one logical runtime
+     * reference for the dentry lifetime and a persistent module guard until the
+     * controlled unload path has observed that every wrapper dentry is gone.
+     */
+    if (!ksu_module_unload_try_enter()) {
+        path_put(orig_path);
+        kfree(orig_path);
+        ret = -ESHUTDOWN;
+        goto out_put_wrapper_file;
+    }
+    ksu_syscall_hook_hold_unload_guard();
+
     // Some applications (such as screen) won't work if the tty's path is weird,
     // Therefore, we use d_dname to spoof it to return the path to the original file.
     wrapper_file->f_path.dentry->d_fsdata = orig_path;

--- a/kernel/manager/manager_identity.h
+++ b/kernel/manager/manager_identity.h
@@ -1,6 +1,7 @@
 #ifndef __KSU_H_MANAGER_IDENTITY
 #define __KSU_H_MANAGER_IDENTITY
 
+#include <linux/compiler.h>
 #include <linux/cred.h>
 #include <linux/types.h>
 
@@ -41,32 +42,32 @@ extern uid_t ksu_manager_appid; // DO NOT DIRECT USE
 
 static inline bool ksu_is_manager_appid_valid()
 {
-    return ksu_manager_appid != KSU_INVALID_APPID;
+    return READ_ONCE(ksu_manager_appid) != KSU_INVALID_APPID;
 }
 
 static inline bool is_manager()
 {
-    return unlikely(ksu_manager_appid == current_uid().val % KSU_PER_USER_RANGE);
+    return unlikely(READ_ONCE(ksu_manager_appid) == current_uid().val % KSU_PER_USER_RANGE);
 }
 
 static inline bool is_uid_manager(uid_t uid)
 {
-    return unlikely(ksu_manager_appid == uid % KSU_PER_USER_RANGE);
+    return unlikely(READ_ONCE(ksu_manager_appid) == uid % KSU_PER_USER_RANGE);
 }
 
 static inline uid_t ksu_get_manager_appid()
 {
-    return ksu_manager_appid;
+    return READ_ONCE(ksu_manager_appid);
 }
 
 static inline void ksu_set_manager_appid(uid_t appid)
 {
-    ksu_manager_appid = appid;
+    WRITE_ONCE(ksu_manager_appid, appid);
 }
 
 static inline void ksu_invalidate_manager_uid()
 {
-    ksu_manager_appid = KSU_INVALID_APPID;
+    WRITE_ONCE(ksu_manager_appid, KSU_INVALID_APPID);
 }
 #endif
 

--- a/kernel/manager/pkg_observer.c
+++ b/kernel/manager/pkg_observer.c
@@ -3,9 +3,11 @@
 #include <linux/fs.h>
 #include <linux/namei.h>
 #include <linux/fsnotify_backend.h>
+#include <linux/mutex.h>
 #include <linux/slab.h>
 #include <linux/rculist.h>
 #include <linux/version.h>
+#include <linux/workqueue.h>
 #include "klog.h" // IWYU pragma: keep
 #include "manager/throne_tracker.h"
 
@@ -20,6 +22,16 @@ struct watch_dir {
 };
 
 static struct fsnotify_group *g;
+static DEFINE_MUTEX(observer_lock);
+static bool observer_initialized;
+
+static void ksu_track_throne_work(struct work_struct *work)
+{
+    if (READ_ONCE(observer_initialized))
+        track_throne(false);
+}
+
+static DECLARE_WORK(track_throne_work, ksu_track_throne_work);
 
 static int ksu_handle_inode_event(struct fsnotify_mark *mark, u32 mask, struct inode *inode, struct inode *dir,
                                   const struct qstr *file_name, u32 cookie)
@@ -30,13 +42,20 @@ static int ksu_handle_inode_event(struct fsnotify_mark *mark, u32 mask, struct i
         return 0;
     if (file_name->len == 13 && !memcmp(file_name->name, "packages.list", 13)) {
         pr_info("packages.list detected: %d\n", mask);
-        track_throne(false);
+        if (READ_ONCE(observer_initialized))
+            schedule_work(&track_throne_work);
     }
     return 0;
 }
 
+static void ksu_free_mark(struct fsnotify_mark *mark)
+{
+    kfree(mark);
+}
+
 static const struct fsnotify_ops ksu_ops = {
     .handle_inode_event = ksu_handle_inode_event,
+    .free_mark = ksu_free_mark,
 };
 
 static int add_mark_on_inode(struct inode *inode, u32 mask, struct fsnotify_mark **out)
@@ -72,6 +91,7 @@ static int watch_one_dir(struct watch_dir *wd)
     if (ret) {
         pr_err("Add mark failed for %s (%d)\n", wd->path, ret);
         path_put(&wd->kpath);
+        memset(&wd->kpath, 0, sizeof(wd->kpath));
         iput(wd->inode);
         wd->inode = NULL;
         return ret;
@@ -101,24 +121,67 @@ static struct watch_dir g_watch = { .path = "/data/system", .mask = MASK_SYSTEM 
 
 int ksu_observer_init(void)
 {
-    int ret = 0;
+    int ret;
+
+    mutex_lock(&observer_lock);
+    if (READ_ONCE(observer_initialized)) {
+        mutex_unlock(&observer_lock);
+        return 0;
+    }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
     g = fsnotify_alloc_group(&ksu_ops, 0);
 #else
     g = fsnotify_alloc_group(&ksu_ops);
 #endif
-    if (IS_ERR(g))
-        return PTR_ERR(g);
+    if (IS_ERR(g)) {
+        ret = PTR_ERR(g);
+        g = NULL;
+        mutex_unlock(&observer_lock);
+        return ret;
+    }
 
     ret = watch_one_dir(&g_watch);
+    if (ret) {
+        /*
+         * A failed mark attachment can still queue the mark for deferred
+         * SRCU destruction. Drain it before dropping the final group ref so
+         * no delayed fsnotify callback can retain ksu_ops module text.
+         */
+        fsnotify_wait_marks_destroyed();
+        fsnotify_put_group(g);
+        g = NULL;
+        mutex_unlock(&observer_lock);
+        return ret;
+    }
+
+    WRITE_ONCE(observer_initialized, true);
+    mutex_unlock(&observer_lock);
     pr_info("observer init done\n");
     return 0;
 }
 
 void __exit ksu_observer_exit(void)
 {
+    mutex_lock(&observer_lock);
+    if (!READ_ONCE(observer_initialized)) {
+        mutex_unlock(&observer_lock);
+        return;
+    }
+
+    WRITE_ONCE(observer_initialized, false);
     unwatch_one_dir(&g_watch);
+    /*
+     * fsnotify mark destruction is deferred until after an SRCU grace
+     * period. Wait for that reaper here while the module is still alive;
+     * after this returns there can be no outstanding event callback using
+     * ksu_ops or ksu_handle_inode_event().
+     */
+    fsnotify_wait_marks_destroyed();
     fsnotify_put_group(g);
+    g = NULL;
+    mutex_unlock(&observer_lock);
+
+    cancel_work_sync(&track_throne_work);
     pr_info("observer exit done\n");
 }

--- a/kernel/manager/throne_tracker.c
+++ b/kernel/manager/throne_tracker.c
@@ -1,6 +1,7 @@
 #include <linux/err.h>
 #include <linux/fs.h>
 #include <linux/list.h>
+#include <linux/mutex.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 #include <linux/types.h>
@@ -15,12 +16,19 @@
 uid_t ksu_manager_appid = KSU_INVALID_APPID;
 
 #define SYSTEM_PACKAGES_LIST_PATH "/data/system/packages.list"
+#define PACKAGES_READ_CHUNK 4096
+#define PACKAGES_LINE_PREFIX (KSU_MAX_PACKAGE_NAME + 32)
+#define DATA_PATH_LEN 384 // 384 is enough for /data/app/<package>/base.apk
 
 struct uid_data {
     struct list_head list;
     u32 uid;
     char package[KSU_MAX_PACKAGE_NAME];
 };
+
+static DEFINE_MUTEX(throne_lock);
+static char manager_package[KSU_MAX_PACKAGE_NAME];
+static char manager_apk_path[DATA_PATH_LEN];
 
 static void crown_manager(const char *apk, struct list_head *uid_data)
 {
@@ -38,13 +46,13 @@ static void crown_manager(const char *apk, struct list_head *uid_data)
     list_for_each_entry (np, list, list) {
         if (strncmp(np->package, pkg, KSU_MAX_PACKAGE_NAME) == 0) {
             pr_info("Crowning manager: %s(uid=%d)\n", pkg, np->uid);
+            strscpy(manager_package, pkg, sizeof(manager_package));
+            strscpy(manager_apk_path, apk, sizeof(manager_apk_path));
             ksu_set_manager_appid(np->uid);
             break;
         }
     }
 }
-
-#define DATA_PATH_LEN 384 // 384 is enough for /data/app/<package>/base.apk
 
 struct data_path {
     char dirpath[DATA_PATH_LEN];
@@ -54,6 +62,7 @@ struct data_path {
 
 struct apk_path_hash {
     unsigned int hash;
+    u64 ino;
     bool exists;
     struct list_head list;
 };
@@ -124,7 +133,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name, int name
             struct apk_path_hash *pos, *n;
             unsigned int hash = full_name_hash(NULL, dirpath, strlen(dirpath));
             list_for_each_entry (pos, &apk_path_hash_list, list) {
-                if (hash == pos->hash) {
+                if (hash == pos->hash && ino == pos->ino) {
                     pos->exists = true;
                     return FILLDIR_ACTOR_CONTINUE;
                 }
@@ -148,6 +157,7 @@ FILLDIR_RETURN_TYPE my_actor(struct dir_context *ctx, const char *name, int name
                     return FILLDIR_ACTOR_CONTINUE;
                 }
                 apk_data->hash = hash;
+                apk_data->ino = ino;
                 apk_data->exists = true;
                 list_add_tail(&apk_data->list, &apk_path_hash_list);
             }
@@ -247,113 +257,157 @@ static bool is_uid_exist(uid_t uid, char *package, void *data)
     return exist;
 }
 
+static int add_uid_line(char *line, struct list_head *uid_list)
+{
+    struct uid_data *data;
+    char *tmp = line;
+    char *package;
+    char *uid;
+    u32 value;
+
+    package = strsep(&tmp, " ");
+    uid = strsep(&tmp, " ");
+    if (!uid || !package || strnlen(package, KSU_MAX_PACKAGE_NAME) >= KSU_MAX_PACKAGE_NAME)
+        return 0;
+    if (kstrtou32(uid, 10, &value))
+        return 0;
+
+    data = kzalloc(sizeof(*data), GFP_KERNEL);
+    if (!data)
+        return -ENOMEM;
+
+    data->uid = value;
+    strscpy(data->package, package, sizeof(data->package));
+    list_add_tail(&data->list, uid_list);
+    return 0;
+}
+
+static int read_uid_list(struct file *fp, struct list_head *uid_list)
+{
+    char line[PACKAGES_LINE_PREFIX];
+    char *chunk;
+    size_t line_len = 0;
+    loff_t pos = 0;
+    ssize_t count;
+    int ret = 0;
+
+    chunk = kmalloc(PACKAGES_READ_CHUNK, GFP_KERNEL);
+    if (!chunk)
+        return -ENOMEM;
+
+    while ((count = kernel_read(fp, chunk, PACKAGES_READ_CHUNK, &pos)) > 0) {
+        ssize_t i;
+
+        for (i = 0; i < count; i++) {
+            if (chunk[i] == '\n') {
+                line[line_len] = '\0';
+                ret = add_uid_line(line, uid_list);
+                if (ret)
+                    goto out;
+                line_len = 0;
+            } else if (line_len < sizeof(line) - 1) {
+                line[line_len++] = chunk[i];
+            }
+        }
+    }
+
+    if (count < 0) {
+        ret = count;
+        goto out;
+    }
+
+    if (line_len) {
+        line[line_len] = '\0';
+        ret = add_uid_line(line, uid_list);
+    }
+
+out:
+    kfree(chunk);
+    return ret;
+}
+
+static bool manager_entry_exists(struct list_head *uid_list)
+{
+    struct uid_data *np;
+    uid_t appid;
+
+    if (!ksu_is_manager_appid_valid() || !manager_package[0] || !manager_apk_path[0])
+        return false;
+
+    appid = ksu_get_manager_appid();
+    list_for_each_entry (np, uid_list, list) {
+        if (np->uid != appid)
+            continue;
+        if (strncmp(np->package, manager_package, sizeof(manager_package)))
+            continue;
+        return is_manager_apk(manager_apk_path);
+    }
+    return false;
+}
+
 void track_throne(bool prune_only)
 {
-    struct file *fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
-    if (IS_ERR(fp)) {
-        pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n", __func__, PTR_ERR(fp));
-        return;
-    }
-
+    struct file *fp;
     struct list_head uid_list;
+    struct uid_data *np, *n;
+    int ret;
+
+    mutex_lock(&throne_lock);
     INIT_LIST_HEAD(&uid_list);
 
-    char chr = 0;
-    loff_t pos = 0;
-    loff_t line_start = 0;
-    char buf[KSU_MAX_PACKAGE_NAME];
-    for (;;) {
-        ssize_t count = kernel_read(fp, &chr, sizeof(chr), &pos);
-        if (count != sizeof(chr))
-            break;
-        if (chr != '\n')
-            continue;
-
-        count = kernel_read(fp, buf, sizeof(buf) - 1, &line_start);
-        if (count <= 0) {
-            break;
-        }
-        buf[count] = '\0';
-
-        struct uid_data *data = kzalloc(sizeof(struct uid_data), GFP_KERNEL);
-        if (!data) {
-            filp_close(fp, 0);
-            goto out;
-        }
-
-        char *tmp = buf;
-        const char *delim = " ";
-        char *package = strsep(&tmp, delim);
-        char *uid = strsep(&tmp, delim);
-        if (!uid || !package) {
-            kfree(data);
-            pr_err("update_uid: package or uid is NULL!\n");
-            break;
-        }
-
-        u32 res;
-        if (kstrtou32(uid, 10, &res)) {
-            kfree(data);
-            pr_err("update_uid: uid parse err\n");
-            break;
-        }
-        data->uid = res;
-        strscpy(data->package, package, sizeof(data->package));
-        list_add_tail(&data->list, &uid_list);
-        // reset line start
-        line_start = pos;
+    fp = filp_open(SYSTEM_PACKAGES_LIST_PATH, O_RDONLY, 0);
+    if (IS_ERR(fp)) {
+        pr_err("%s: open " SYSTEM_PACKAGES_LIST_PATH " failed: %ld\n", __func__, PTR_ERR(fp));
+        goto out_unlock;
     }
+
+    ret = read_uid_list(fp, &uid_list);
     filp_close(fp, 0);
-
-    // now update uid list
-    struct uid_data *np;
-    struct uid_data *n;
-
-    if (prune_only)
-        goto prune;
-
-    // first, check if manager_uid exist!
-    bool manager_exist = false;
-    list_for_each_entry (np, &uid_list, list) {
-        if (np->uid == ksu_get_manager_appid()) {
-            manager_exist = true;
-            break;
-        }
+    if (ret) {
+        pr_err("%s: read " SYSTEM_PACKAGES_LIST_PATH " failed: %d\n", __func__, ret);
+        goto out;
     }
 
-    if (!manager_exist) {
+#ifndef CONFIG_KSU_DISABLE_MANAGER
+    if (!prune_only && !manager_entry_exists(&uid_list)) {
         if (ksu_is_manager_appid_valid()) {
-            pr_info("manager is uninstalled, invalidate it!\n");
+            pr_info("manager is uninstalled or replaced, invalidate it!\n");
             ksu_invalidate_manager_uid();
-            goto prune;
+            manager_package[0] = '\0';
+            manager_apk_path[0] = '\0';
         }
         pr_info("Searching manager...\n");
         search_manager("/data/app", 2, &uid_list);
         pr_info("Search manager finished\n");
     }
+#endif
 
-prune:
-    // then prune the allowlist
     ksu_prune_allowlist(is_uid_exist, &uid_list);
 out:
-    // free uid_list
     list_for_each_entry_safe (np, n, &uid_list, list) {
         list_del(&np->list);
         kfree(np);
     }
+out_unlock:
+    mutex_unlock(&throne_lock);
 }
 
 void __init ksu_throne_tracker_init()
 {
-    // nothing to do
+    manager_package[0] = '\0';
+    manager_apk_path[0] = '\0';
 }
 
 void __exit ksu_throne_tracker_exit()
 {
     struct apk_path_hash *pos, *n;
 
+    mutex_lock(&throne_lock);
     list_for_each_entry_safe (pos, n, &apk_path_hash_list, list) {
         list_del(&pos->list);
         kfree(pos);
     }
+    manager_package[0] = '\0';
+    manager_apk_path[0] = '\0';
+    mutex_unlock(&throne_lock);
 }

--- a/kernel/policy/app_profile.c
+++ b/kernel/policy/app_profile.c
@@ -3,6 +3,7 @@
 #include "linux/kallsyms.h"
 #include <linux/capability.h>
 #include <linux/cred.h>
+#include <linux/err.h>
 #include <linux/sched.h>
 #include <linux/sched/user.h>
 #include <linux/sched/signal.h>
@@ -186,7 +187,8 @@ int escape_with_root_profile(void)
     // https://github.com/torvalds/linux/commit/905ae01c4ae2ae3df05bb141801b1db4b7d83c61#diff-ff6060da281bd9ef3f24e17b77a9b0b5b2ed2d7208bb69b29107bee69732bd31
     // on older kernels, per-UID process accounting lives in user_struct.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
-    if (set_cred_ucounts(cred)) {
+    ret = set_cred_ucounts(cred);
+    if (ret) {
         goto out_abort_creds;
     }
 #endif
@@ -238,14 +240,31 @@ void __init ksu_app_profile_init(void)
 #if NEED_BACKPORT_COMPAT
     unsigned long size = 0;
     int ret;
+    void *call_site;
     void *raw_spin_lock_irq_sym = find_kernel_symbol_exact("_raw_spin_lock_irq");
     void *seccomp_filter_release_sym = find_kernel_symbol_exact("seccomp_filter_release");
+
+    if (!raw_spin_lock_irq_sym || !seccomp_filter_release_sym) {
+        pr_warn("seccomp compatibility symbols unavailable, use safe release path\n");
+        has_call_to_spin_lock = true;
+        return;
+    }
+
     ret = kallsyms_lookup_size_offset(seccomp_filter_release_sym, &size, NULL);
     if (!ret || !size) {
-        pr_err("failed to get size of seccomp_filter_release: %d, use 128\n", ret);
-        size = 128;
+        pr_warn("failed to get seccomp_filter_release size: %d, use safe release path\n", ret);
+        has_call_to_spin_lock = true;
+        return;
     }
-    has_call_to_spin_lock = scan_call_to(seccomp_filter_release_sym, size, raw_spin_lock_irq_sym) != NULL;
+
+    call_site = scan_call_to(seccomp_filter_release_sym, size, raw_spin_lock_irq_sym);
+    if (IS_ERR(call_site)) {
+        pr_warn("failed to inspect seccomp_filter_release: %ld, use safe release path\n", PTR_ERR(call_site));
+        has_call_to_spin_lock = true;
+        return;
+    }
+
+    has_call_to_spin_lock = call_site != NULL;
     pr_info("seccomp_filter_release has_call_to_spin_lock = %d\n", has_call_to_spin_lock);
 #endif
 }

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -1,4 +1,5 @@
 #include "feature/selinux_hide.h"
+#include <linux/atomic.h>
 #include <linux/err.h>
 #include <linux/fs.h>
 #include <linux/namei.h>
@@ -13,19 +14,15 @@
 
 bool ksu_module_mounted __read_mostly = false;
 bool ksu_boot_completed __read_mostly = false;
+static atomic_t post_fs_data_done = ATOMIC_INIT(0);
+static atomic_t boot_completed_done = ATOMIC_INIT(0);
 
 void on_post_fs_data(void)
 {
-    static bool done = false;
-
-    if (done) {
-        pr_info("on_post_fs_data already done\n");
+    if (atomic_xchg(&post_fs_data_done, 1))
         return;
-    }
 
-    done = true;
     pr_info("on_post_fs_data!\n");
-
     ksu_load_allow_list();
     ksu_observer_init();
     // Sanity check for safe mode only needs early-boot input samples.
@@ -58,13 +55,16 @@ int nuke_ext4_sysfs(const char *mnt)
 
 void on_module_mounted(void)
 {
+    WRITE_ONCE(ksu_module_mounted, true);
     pr_info("on_module_mounted!\n");
-    ksu_module_mounted = true;
 }
 
 void on_boot_completed(void)
 {
-    ksu_boot_completed = true;
+    if (atomic_xchg(&boot_completed_done, 1))
+        return;
+
+    WRITE_ONCE(ksu_boot_completed, true);
     pr_info("on_boot_completed!\n");
     track_throne(true);
     ksu_selinux_hide_drop_backup_if_unused();

--- a/kernel/runtime/ksud_integration.c
+++ b/kernel/runtime/ksud_integration.c
@@ -12,6 +12,7 @@
 #include <linux/version.h>
 #include <linux/input-event-codes.h>
 #include <linux/kprobes.h>
+#include <linux/module.h>
 #include <linux/printk.h>
 #include <linux/types.h>
 #include <linux/uaccess.h>
@@ -49,10 +50,13 @@ static const char KERNEL_SU_RC[] =
     "\n";
 // clang-format on
 
-static void stop_init_rc_hook();
+static int stop_init_rc_hook(void);
 static void stop_execve_hook();
 
 static struct work_struct stop_input_hook_work;
+static bool init_rc_read_hooked;
+static bool init_rc_fstat_hooked;
+static bool init_rc_hooks_ready;
 
 #define MAX_ARG_STRINGS 0x7FFFFFFF
 struct user_arg_ptr {
@@ -182,6 +186,7 @@ void ksu_handle_execveat_ksud(const char *path, struct user_arg_ptr *argv)
 static ssize_t (*orig_read)(struct file *, char __user *, size_t, loff_t *);
 static ssize_t (*orig_read_iter)(struct kiocb *, struct iov_iter *);
 static struct file_operations fops_proxy;
+static const struct file_operations *orig_rc_fops;
 static ssize_t ksu_rc_pos = 0;
 const size_t ksu_rc_len = sizeof(KERNEL_SU_RC) - 1;
 
@@ -420,43 +425,72 @@ static bool is_init_rc(struct file *fp)
     return true;
 }
 
+static int ksu_rc_release_proxy(struct inode *inode, struct file *filp)
+{
+    const struct file_operations *orig = READ_ONCE(orig_rc_fops);
+    int ret = 0;
+
+    if (orig && orig->release)
+        ret = orig->release(inode, filp);
+    if (orig) {
+        WRITE_ONCE(orig_rc_fops, NULL);
+        fops_put(orig);
+    }
+    return ret;
+}
+
 static void ksu_install_rc_hook(struct file *file)
 {
-    if (!is_init_rc(file)) {
+    static bool rc_hooked = false;
+    const struct file_operations *new_fops;
+    const struct file_operations *orig_fops;
+    int ret;
+
+    if (!READ_ONCE(init_rc_hooks_ready) || !is_init_rc(file))
         return;
-    }
 
     // we only process the first read
-    static bool rc_hooked = false;
-    if (rc_hooked) {
-        // we don't need these hooks, unregister it!
+    if (rc_hooked)
+        return;
 
+    orig_fops = fops_get(file->f_op);
+    if (!orig_fops) {
+        pr_warn("failed to pin original init.rc fops\n");
         return;
     }
-    rc_hooked = true;
-    stop_init_rc_hook();
 
-    // now we can sure that the init process is reading
-    // `/system/etc/init/init.rc`
+    memcpy(&fops_proxy, orig_fops, sizeof(struct file_operations));
+    orig_read = orig_fops->read;
+    orig_read_iter = orig_fops->read_iter;
+    if (orig_read)
+        fops_proxy.read = read_proxy;
+    if (orig_read_iter)
+        fops_proxy.read_iter = read_iter_proxy;
+    fops_proxy.owner = THIS_MODULE;
+    fops_proxy.release = ksu_rc_release_proxy;
+
+    new_fops = fops_get(&fops_proxy);
+    if (!new_fops) {
+        fops_put(orig_fops);
+        pr_warn("failed to pin init.rc proxy fops\n");
+        return;
+    }
+
+    ret = stop_init_rc_hook();
+    if (ret) {
+        fops_put(new_fops);
+        fops_put(orig_fops);
+        pr_err("failed to stop init_rc syscall hooks: %d\n", ret);
+        return;
+    }
 
     load_module_rc_once();
 
     pr_info("read init.rc, comm: %s, rc_count: %zu, module_rc: %zu\n", current->comm, ksu_rc_len, module_rc_len);
 
-    // Now we need to proxy the read and modify the result!
-    // But, we can not modify the file_operations directly, because it's in read-only memory.
-    // We just replace the whole file_operations with a proxy one.
-    memcpy(&fops_proxy, file->f_op, sizeof(struct file_operations));
-    orig_read = file->f_op->read;
-    if (orig_read) {
-        fops_proxy.read = read_proxy;
-    }
-    orig_read_iter = file->f_op->read_iter;
-    if (orig_read_iter) {
-        fops_proxy.read_iter = read_iter_proxy;
-    }
-    // replace the file_operations
-    file->f_op = &fops_proxy;
+    WRITE_ONCE(orig_rc_fops, orig_fops);
+    replace_fops(file, new_fops);
+    rc_hooked = true;
 }
 
 static void ksu_handle_sys_read(unsigned int fd, char __user **buf_ptr, size_t *count_ptr)
@@ -560,23 +594,28 @@ void ksu_execveat_hook_ksud(const struct pt_regs *regs)
 }
 
 static long (*orig_sys_read)(const struct pt_regs *regs);
+static long (*orig_sys_fstat)(const struct pt_regs *regs);
+
 static long ksu_sys_read(const struct pt_regs *regs)
 {
     unsigned int fd = PT_REGS_PARM1(regs);
     char __user **buf_ptr = (char __user **)&PT_REGS_PARM2(regs);
     size_t *count_ptr = (size_t *)&PT_REGS_PARM3(regs);
 
-    ksu_handle_sys_read(fd, buf_ptr, count_ptr);
+    if (likely(READ_ONCE(init_rc_hooks_ready)))
+        ksu_handle_sys_read(fd, buf_ptr, count_ptr);
     return orig_sys_read(regs);
 }
 
-static long (*orig_sys_fstat)(const struct pt_regs *regs);
 static long ksu_sys_fstat(const struct pt_regs *regs)
 {
     unsigned int fd = PT_REGS_PARM1(regs);
     void __user *statbuf = (void __user *)PT_REGS_PARM2(regs);
     bool is_rc = false;
     long ret;
+
+    if (unlikely(!READ_ONCE(init_rc_hooks_ready)))
+        return orig_sys_fstat(regs);
 
     struct file *file = fget(fd);
     if (file) {
@@ -628,11 +667,46 @@ static void do_stop_input_hook(struct work_struct *work)
     unregister_kprobe(&input_event_kp);
 }
 
-static void stop_init_rc_hook()
+static int stop_init_rc_hook(void)
 {
-    ksu_syscall_table_unhook(__NR_read);
-    ksu_syscall_table_unhook(__NR_fstat);
+    bool was_ready = READ_ONCE(init_rc_hooks_ready);
+    bool fstat_removed = false;
+    int rollback;
+    int ret;
+
+    WRITE_ONCE(init_rc_hooks_ready, false);
+
+    if (init_rc_fstat_hooked) {
+        ret = ksu_syscall_table_unhook(__NR_fstat);
+        if (ret) {
+            pr_err("failed to unhook init_rc fstat: %d\n", ret);
+            WRITE_ONCE(init_rc_hooks_ready, was_ready);
+            return ret;
+        }
+        init_rc_fstat_hooked = false;
+        fstat_removed = true;
+    }
+
+    if (init_rc_read_hooked) {
+        ret = ksu_syscall_table_unhook(__NR_read);
+        if (ret) {
+            pr_err("failed to unhook init_rc read: %d\n", ret);
+            if (fstat_removed) {
+                rollback = ksu_syscall_table_hook(__NR_fstat, ksu_sys_fstat, &orig_sys_fstat);
+                if (rollback) {
+                    pr_err("failed to rollback init_rc fstat hook: %d\n", rollback);
+                    return -EUCLEAN;
+                }
+                init_rc_fstat_hooked = true;
+            }
+            WRITE_ONCE(init_rc_hooks_ready, was_ready);
+            return ret;
+        }
+        init_rc_read_hooked = false;
+    }
+
     pr_info("unregister init_rc syscall hook\n");
+    return 0;
 }
 
 void ksu_stop_input_hook_runtime(void)
@@ -649,15 +723,34 @@ void ksu_stop_input_hook_runtime(void)
 // ksud: module support
 void __init ksu_ksud_init()
 {
+    int rollback;
     int ret;
 
-    ksu_syscall_table_hook(__NR_read, ksu_sys_read, &orig_sys_read);
-    ksu_syscall_table_hook(__NR_fstat, ksu_sys_fstat, &orig_sys_fstat);
+    ret = ksu_syscall_table_hook(__NR_read, ksu_sys_read, &orig_sys_read);
+    if (ret) {
+        pr_err("ksud: failed to hook read: %d\n", ret);
+        goto init_input_hook;
+    }
+    init_rc_read_hooked = true;
 
+    ret = ksu_syscall_table_hook(__NR_fstat, ksu_sys_fstat, &orig_sys_fstat);
+    if (ret) {
+        pr_err("ksud: failed to hook fstat: %d\n", ret);
+        rollback = ksu_syscall_table_unhook(__NR_read);
+        if (rollback) {
+            pr_err("ksud: failed to rollback read hook: %d\n", rollback);
+        } else {
+            init_rc_read_hooked = false;
+        }
+        goto init_input_hook;
+    }
+    init_rc_fstat_hooked = true;
+    WRITE_ONCE(init_rc_hooks_ready, true);
+
+init_input_hook:
+    INIT_WORK(&stop_input_hook_work, do_stop_input_hook);
     ret = register_kprobe(&input_event_kp);
     pr_info("ksud: input_event_kp: %d\n", ret);
-
-    INIT_WORK(&stop_input_hook_work, do_stop_input_hook);
 }
 
 void __exit ksu_ksud_exit()
@@ -665,6 +758,7 @@ void __exit ksu_ksud_exit()
     // TODO:
     // this should be done before unregister vfs_read_kp
     // stop_init_rc_hook();
+    cancel_work_sync(&stop_input_hook_work);
     unregister_kprobe(&input_event_kp);
 
     if (module_rc_buf) {

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -89,10 +89,9 @@ void apply_kernelsu_rules()
     ksu_typeattribute(db, KERNEL_SU_DOMAIN, "netdomain");
     ksu_typeattribute(db, KERNEL_SU_DOMAIN, "bluetoothdomain");
 
-    // Create unconstrained file type
+    // Keep the legacy file type for module sepolicy compatibility.
     ksu_type(db, KERNEL_SU_FILE, "file_type");
     ksu_typeattribute(db, KERNEL_SU_FILE, "mlstrustedobject");
-    ksu_allow(db, "domain", KERNEL_SU_FILE, ALL, ALL);
 
     // allow all!
     ksu_allow(db, KERNEL_SU_DOMAIN, ALL, ALL, ALL);

--- a/kernel/sulog/event.c
+++ b/kernel/sulog/event.c
@@ -1,6 +1,7 @@
 #include <asm/current.h>
 #include <linux/compat.h>
 #include <linux/cred.h>
+#include <linux/err.h>
 #include <linux/gfp.h>
 #include <linux/minmax.h>
 #include <linux/overflow.h>
@@ -40,9 +41,8 @@ struct user_arg_ptr {
 static struct ksu_event_queue sulog_queue;
 
 struct ksu_sulog_pending_event {
-    __u16 event_type;
+    struct ksu_event_queue_entry *entry;
     void *payload;
-    __u32 payload_len;
 };
 
 struct ksu_sulog_identity {
@@ -195,18 +195,27 @@ static __u32 ksu_sulog_flatten_argv(const char __user *const __user *argv_user, 
     return used + 1;
 }
 
+static void ksu_sulog_free_pending(struct ksu_sulog_pending_event *pending)
+{
+    if (!pending)
+        return;
+    if (pending->entry)
+        ksu_event_queue_entry_free(pending->entry);
+    kfree(pending);
+}
+
 static struct ksu_sulog_pending_event *ksu_sulog_capture(__u16 event_type, const char __user *filename_user,
                                                          const char __user *const __user *argv_user, gfp_t gfp)
 {
-    struct ksu_sulog_pending_event *pending = NULL;
+    struct ksu_sulog_pending_event *pending;
     struct ksu_sulog_event *event;
-    void *payload = NULL;
     __u32 payload_len;
     __u32 filename_len;
     __u32 argv_len;
     __u32 remaining;
     char *filename_buf;
     char *argv_buf;
+
     if (!ksu_sulog_is_enabled())
         return NULL;
 
@@ -214,41 +223,43 @@ static struct ksu_sulog_pending_event *ksu_sulog_capture(__u16 event_type, const
     if (!pending)
         goto out_drop;
 
-    payload = kzalloc(KSU_SULOG_MAX_PAYLOAD_LEN, gfp);
-    if (!payload)
+    pending->entry = ksu_event_queue_entry_alloc(&sulog_queue, event_type, 0, KSU_SULOG_MAX_PAYLOAD_LEN, gfp);
+    if (IS_ERR(pending->entry)) {
+        pending->entry = NULL;
         goto out_free_pending;
+    }
 
-    event = payload;
+    pending->payload = ksu_event_queue_entry_payload(pending->entry);
+    memset(pending->payload, 0, KSU_SULOG_MAX_PAYLOAD_LEN);
+    event = pending->payload;
     ksu_sulog_fill_task_info(event, event_type, 0);
 
     remaining = KSU_SULOG_MAX_PAYLOAD_LEN - sizeof(*event);
-    filename_buf = (char *)payload + sizeof(*event);
+    filename_buf = (char *)pending->payload + sizeof(*event);
     filename_len = ksu_sulog_copy_filename(filename_user, filename_buf, min(remaining, KSU_SULOG_MAX_FILENAME_LEN));
     if (!filename_len)
-        goto out_free_payload;
+        goto out_free_pending;
 
     remaining -= filename_len;
     argv_buf = filename_buf + filename_len;
     argv_len = ksu_sulog_flatten_argv(argv_user, argv_buf, remaining);
     if (!argv_len)
-        goto out_free_payload;
+        goto out_free_pending;
 
     event->filename_len = filename_len;
     event->argv_len = argv_len;
 
     if (check_add_overflow((__u32)sizeof(*event), filename_len, &payload_len) ||
         check_add_overflow(payload_len, argv_len, &payload_len))
-        goto out_free_payload;
+        goto out_free_pending;
 
-    pending->event_type = event_type;
-    pending->payload = payload;
-    pending->payload_len = payload_len;
+    if (ksu_event_queue_entry_set_len(pending->entry, payload_len))
+        goto out_free_pending;
+
     return pending;
 
-out_free_payload:
-    kfree(payload);
 out_free_pending:
-    kfree(pending);
+    ksu_sulog_free_pending(pending);
 out_drop:
     ksu_event_queue_drop(&sulog_queue);
     return NULL;
@@ -280,14 +291,6 @@ void __exit ksu_sulog_events_exit(void)
     ksu_event_queue_destroy(&sulog_queue);
 }
 
-static void ksu_sulog_free_pending(struct ksu_sulog_pending_event *pending)
-{
-    if (!pending)
-        return;
-    kfree(pending->payload);
-    kfree(pending);
-}
-
 struct ksu_sulog_pending_event *ksu_sulog_capture_root_execve(const char __user *filename_user,
                                                               const char __user *const __user *argv_user, gfp_t gfp)
 {
@@ -304,12 +307,14 @@ void ksu_sulog_emit_pending(struct ksu_sulog_pending_event *pending, int retval,
 {
     struct ksu_sulog_event *event;
 
+    (void)gfp;
     if (!pending)
         return;
 
     event = pending->payload;
     event->retval = retval;
-    ksu_event_queue_push(&sulog_queue, pending->event_type, 0, pending->payload, pending->payload_len, gfp);
+    if (!ksu_event_queue_entry_push(&sulog_queue, pending->entry))
+        pending->entry = NULL;
     ksu_sulog_free_pending(pending);
 }
 

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -17,6 +17,7 @@
 #include "selinux/selinux.h"
 #include "infra/file_wrapper.h"
 #include "hook/tp_marker.h"
+#include "hook/syscall_hook_manager.h"
 #include "policy/app_profile.h"
 #include "sulog/event.h"
 #include "sulog/fd.h"
@@ -101,37 +102,26 @@ static int do_report_event(void __user *arg)
     }
 
     switch (cmd.event) {
-    case EVENT_POST_FS_DATA: {
-        static bool post_fs_data_lock = false;
-        if (!post_fs_data_lock) {
-            post_fs_data_lock = true;
-            if (ksu_late_loaded) {
-                pr_info("post-fs-data skipped (late load)\n");
-            } else {
-                pr_info("post-fs-data triggered\n");
-                on_post_fs_data();
-            }
+    case EVENT_POST_FS_DATA:
+        if (ksu_late_loaded) {
+            pr_info("post-fs-data skipped (late load)\n");
+        } else {
+            pr_info("post-fs-data triggered\n");
+            on_post_fs_data();
         }
         break;
-    }
-    case EVENT_BOOT_COMPLETED: {
-        static bool boot_complete_lock = false;
-        if (!boot_complete_lock) {
-            boot_complete_lock = true;
-            if (ksu_late_loaded) {
-                pr_info("boot_complete skipped (late load)\n");
-            } else {
-                pr_info("boot_complete triggered\n");
-                on_boot_completed();
-            }
+    case EVENT_BOOT_COMPLETED:
+        if (ksu_late_loaded) {
+            pr_info("boot_complete skipped (late load)\n");
+        } else {
+            pr_info("boot_complete triggered\n");
+            on_boot_completed();
         }
         break;
-    }
-    case EVENT_MODULE_MOUNTED: {
+    case EVENT_MODULE_MOUNTED:
         pr_info("module mounted!\n");
         on_module_mounted();
         break;
-    }
     default:
         break;
     }
@@ -468,12 +458,20 @@ static int do_manage_mark(void __user *arg)
         break;
     }
     case KSU_MARK_UNMARK: {
+        /*
+         * SYSCALL_TRACEPOINT is shared by all sys_enter consumers. Preserve
+         * the existing tooling API when KernelSU is the proven sole consumer,
+         * but refuse to clear shared marks while perf/ftrace/eBPF also owns it.
+         */
+        if (!ksu_syscall_tracepoint_allows_selective_marks())
+            return -EBUSY;
+
         if (cmd.pid == 0) {
             ksu_unmark_all_process();
         } else {
             ret = ksu_set_task_mark(cmd.pid, false);
             if (ret < 0) {
-                pr_err("manage_mark: set_unmark failed for pid %d: %d\n", cmd.pid, ret);
+                pr_err("manage_mark: unset_mark failed for pid %d: %d\n", cmd.pid, ret);
                 return ret;
             }
         }
@@ -527,44 +525,95 @@ static int do_nuke_ext4_sysfs(void __user *arg)
     return nuke_ext4_sysfs(mnt);
 }
 
+#define KSU_MAX_UMOUNT_ENTRIES 512U
+#define KSU_MAX_UMOUNT_LAYERS 512U
+
 struct list_head mount_list = LIST_HEAD_INIT(mount_list);
 DECLARE_RWSEM(mount_list_lock);
+static unsigned int mount_list_count;
+
+static int copy_umount_path(char *buf, size_t size, const char __user *path)
+{
+    long len;
+
+    if (!path)
+        return -EINVAL;
+
+    len = strncpy_from_user(buf, path, size);
+    if (len < 0)
+        return -EFAULT;
+    if (len == 0)
+        return -EINVAL;
+    if (len >= size)
+        return -ENAMETOOLONG;
+
+    return 0;
+}
+
+static void free_mount_entry(struct mount_entry *entry)
+{
+    list_del(&entry->list);
+    kfree(entry->umountable);
+    kfree(entry);
+    if (mount_list_count)
+        --mount_list_count;
+}
+
+static void update_mount_entry_layers(struct mount_entry *entry)
+{
+    unsigned int layers = entry->unmanaged ? 1U : 0U;
+
+    if (entry->managed && entry->managed_layers > layers)
+        layers = entry->managed_layers;
+    entry->layers = layers;
+}
 
 static int add_try_umount(void __user *arg)
 {
     struct mount_entry *new_entry, *entry, *tmp;
     struct ksu_add_try_umount_cmd cmd;
     char buf[256] = { 0 };
+    int ret;
 
     if (copy_from_user(&cmd, arg, sizeof cmd))
         return -EFAULT;
 
     switch (cmd.mode) {
-    case KSU_UMOUNT_WIPE: {
-        struct mount_entry *entry, *tmp;
+    case KSU_UMOUNT_WIPE:
         down_write(&mount_list_lock);
         list_for_each_entry_safe (entry, tmp, &mount_list, list) {
             pr_info("wipe_umount_list: removing entry: %s\n", entry->umountable);
-            list_del(&entry->list);
-            kfree(entry->umountable);
-            kfree(entry);
+            free_mount_entry(entry);
+        }
+        mount_list_count = 0;
+        up_write(&mount_list_lock);
+        return 0;
+
+    case KSU_UMOUNT_MANAGED_WIPE:
+        down_write(&mount_list_lock);
+        list_for_each_entry_safe (entry, tmp, &mount_list, list) {
+            if (!entry->managed)
+                continue;
+            if (entry->unmanaged) {
+                entry->managed = false;
+                entry->managed_layers = 0;
+                update_mount_entry_layers(entry);
+                continue;
+            }
+            pr_info("wipe_managed_umount_list: removing entry: %s\n", entry->umountable);
+            free_mount_entry(entry);
         }
         up_write(&mount_list_lock);
-
         return 0;
-    }
 
-    case KSU_UMOUNT_ADD: {
-        long len = strncpy_from_user(buf, (const char __user *)cmd.arg, 256);
-        if (len <= 0)
-            return -EFAULT;
-
-        buf[sizeof(buf) - 1] = '\0';
+    case KSU_UMOUNT_ADD:
+        ret = copy_umount_path(buf, sizeof(buf), (const char __user *)cmd.arg);
+        if (ret)
+            return ret;
 
         new_entry = kzalloc(sizeof(*new_entry), GFP_KERNEL);
         if (!new_entry)
             return -ENOMEM;
-
         new_entry->umountable = kstrdup(buf, GFP_KERNEL);
         if (!new_entry->umountable) {
             kfree(new_entry);
@@ -572,64 +621,138 @@ static int add_try_umount(void __user *arg)
         }
 
         down_write(&mount_list_lock);
-
-        // disallow dupes
-        // if this gets too many, we can consider moving this whole task to a kthread
         list_for_each_entry (entry, &mount_list, list) {
-            if (!strcmp(entry->umountable, buf)) {
+            if (strcmp(entry->umountable, buf))
+                continue;
+            if (entry->unmanaged) {
                 pr_info("cmd_add_try_umount: %s is already here!\n", buf);
                 up_write(&mount_list_lock);
                 kfree(new_entry->umountable);
                 kfree(new_entry);
                 return -EEXIST;
             }
+            entry->unmanaged = true;
+            entry->flags = cmd.flags;
+            update_mount_entry_layers(entry);
+            up_write(&mount_list_lock);
+            kfree(new_entry->umountable);
+            kfree(new_entry);
+            pr_info("cmd_add_try_umount: %s merged with managed entry!\n", buf);
+            return 0;
         }
-
-        // now check flags and add
-        // this also serves as a null check
-        if (cmd.flags)
-            new_entry->flags = cmd.flags;
-        else
-            new_entry->flags = 0;
-
-        // debug
+        if (mount_list_count >= KSU_MAX_UMOUNT_ENTRIES) {
+            up_write(&mount_list_lock);
+            kfree(new_entry->umountable);
+            kfree(new_entry);
+            return -E2BIG;
+        }
+        new_entry->flags = cmd.flags;
+        new_entry->layers = 1;
+        new_entry->managed_layers = 0;
+        new_entry->managed = false;
+        new_entry->unmanaged = true;
         list_add(&new_entry->list, &mount_list);
+        ++mount_list_count;
         up_write(&mount_list_lock);
         pr_info("cmd_add_try_umount: %s added!\n", buf);
-
         return 0;
-    }
 
-    // this is just strcmp'd wipe anyway
-    case KSU_UMOUNT_DEL: {
-        long len = strncpy_from_user(buf, (const char __user *)cmd.arg, sizeof(buf) - 1);
-        if (len <= 0)
-            return -EFAULT;
+    case KSU_UMOUNT_MANAGED_SET:
+        if (!cmd.flags || cmd.flags > KSU_MAX_UMOUNT_LAYERS)
+            return -EINVAL;
+        ret = copy_umount_path(buf, sizeof(buf), (const char __user *)cmd.arg);
+        if (ret)
+            return ret;
 
-        buf[sizeof(buf) - 1] = '\0';
+        down_write(&mount_list_lock);
+        list_for_each_entry (entry, &mount_list, list) {
+            if (strcmp(entry->umountable, buf))
+                continue;
+            entry->managed = true;
+            entry->managed_layers = cmd.flags;
+            if (!entry->unmanaged)
+                entry->flags = 0;
+            update_mount_entry_layers(entry);
+            up_write(&mount_list_lock);
+            pr_info("cmd_set_managed_umount: %s layers=%u\n", buf, cmd.flags);
+            return 0;
+        }
+        if (mount_list_count >= KSU_MAX_UMOUNT_ENTRIES) {
+            up_write(&mount_list_lock);
+            return -E2BIG;
+        }
+        up_write(&mount_list_lock);
+
+        new_entry = kzalloc(sizeof(*new_entry), GFP_KERNEL);
+        if (!new_entry)
+            return -ENOMEM;
+        new_entry->umountable = kstrdup(buf, GFP_KERNEL);
+        if (!new_entry->umountable) {
+            kfree(new_entry);
+            return -ENOMEM;
+        }
+        new_entry->flags = 0;
+        new_entry->layers = cmd.flags;
+        new_entry->managed_layers = cmd.flags;
+        new_entry->managed = true;
+        new_entry->unmanaged = false;
+
+        down_write(&mount_list_lock);
+        /* Another setter/add can race allocation; merge instead of duplicating. */
+        list_for_each_entry (entry, &mount_list, list) {
+            if (strcmp(entry->umountable, buf))
+                continue;
+            entry->managed = true;
+            entry->managed_layers = cmd.flags;
+            if (!entry->unmanaged)
+                entry->flags = 0;
+            update_mount_entry_layers(entry);
+            up_write(&mount_list_lock);
+            kfree(new_entry->umountable);
+            kfree(new_entry);
+            return 0;
+        }
+        if (mount_list_count >= KSU_MAX_UMOUNT_ENTRIES) {
+            up_write(&mount_list_lock);
+            kfree(new_entry->umountable);
+            kfree(new_entry);
+            return -E2BIG;
+        }
+        list_add(&new_entry->list, &mount_list);
+        ++mount_list_count;
+        up_write(&mount_list_lock);
+        pr_info("cmd_set_managed_umount: %s added layers=%u\n", buf, cmd.flags);
+        return 0;
+
+    case KSU_UMOUNT_DEL:
+        ret = copy_umount_path(buf, sizeof(buf), (const char __user *)cmd.arg);
+        if (ret)
+            return ret;
 
         down_write(&mount_list_lock);
         list_for_each_entry_safe (entry, tmp, &mount_list, list) {
-            if (!strcmp(entry->umountable, buf)) {
+            if (strcmp(entry->umountable, buf))
+                continue;
+            if (!entry->unmanaged)
+                break;
+            entry->unmanaged = false;
+            if (entry->managed) {
+                entry->flags = 0;
+                update_mount_entry_layers(entry);
+                pr_info("cmd_add_try_umount: manual ownership removed: %s\n", entry->umountable);
+            } else {
                 pr_info("cmd_add_try_umount: entry removed: %s\n", entry->umountable);
-                list_del(&entry->list);
-                kfree(entry->umountable);
-                kfree(entry);
+                free_mount_entry(entry);
             }
+            break;
         }
         up_write(&mount_list_lock);
-
         return 0;
-    }
 
-    default: {
+    default:
         pr_err("cmd_add_try_umount: invalid operation %u\n", cmd.mode);
         return -EINVAL;
     }
-
-    } // switch(cmd.mode)
-
-    return 0;
 }
 
 static int do_set_init_pgrp(void __user *arg)
@@ -888,5 +1011,6 @@ void ksu_supercall_cleanup_state(void)
         kfree(entry->umountable);
         kfree(entry);
     }
+    mount_list_count = 0;
     up_write(&mount_list_lock);
 }

--- a/kernel/supercall/supercall.c
+++ b/kernel/supercall/supercall.c
@@ -4,6 +4,7 @@
 #include <linux/file.h>
 #include <linux/fs.h>
 #include <linux/kprobes.h>
+#include <linux/module.h>
 #include <linux/pid.h>
 #include <linux/slab.h>
 #include <linux/syscalls.h>
@@ -14,6 +15,7 @@
 #include "uapi/supercall.h"
 #include "supercall/internal.h"
 #include "arch.h"
+#include "hook/syscall_hook_manager.h"
 #include "util.h"
 #include "klog.h" // IWYU pragma: keep
 
@@ -22,15 +24,54 @@ struct ksu_install_fd_tw {
     int __user *outp;
 };
 
+static bool can_use_supercall(void)
+{
+    return manager_or_root() || allowed_for_su();
+}
+
+static bool can_install_driver_fd(void)
+{
+    if (ksu_module_unload_recovery_allowed())
+        return only_root();
+    if (ksu_module_unload_in_progress())
+        return false;
+    return can_use_supercall();
+}
+
 static int anon_ksu_release(struct inode *inode, struct file *filp)
 {
-    pr_info("ksu fd released\n");
+    pr_debug("ksu fd released\n");
     return 0;
 }
 
 static long anon_ksu_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
-    return ksu_supercall_handle_ioctl(cmd, (void __user *)arg);
+    long ret;
+
+    if (cmd == KSU_IOCTL_PREPARE_UNLOAD || cmd == KSU_IOCTL_COMMIT_UNLOAD || cmd == KSU_IOCTL_ABORT_UNLOAD) {
+        if (!only_root())
+            return -EPERM;
+
+        if (cmd == KSU_IOCTL_PREPARE_UNLOAD)
+            return ksu_prepare_module_unload();
+        if (cmd == KSU_IOCTL_COMMIT_UNLOAD)
+            return ksu_commit_module_unload();
+        return ksu_abort_module_unload();
+    }
+
+    if (!ksu_module_unload_try_enter())
+        return -ESHUTDOWN;
+
+    if (!can_use_supercall()) {
+        ret = -EPERM;
+        goto out;
+    }
+
+    ret = ksu_supercall_handle_ioctl(cmd, (void __user *)arg);
+
+out:
+    ksu_module_unload_leave();
+    return ret;
 }
 
 static const struct file_operations anon_ksu_fops = {
@@ -45,21 +86,33 @@ int ksu_install_fd(void)
     struct file *filp;
     int fd;
 
+    if (!ksu_module_control_try_enter())
+        return -ESHUTDOWN;
+
+    if (ksu_module_unload_recovery_allowed() && !only_root()) {
+        fd = -EPERM;
+        goto out;
+    }
+
     fd = get_unused_fd_flags(O_CLOEXEC);
     if (fd < 0) {
         pr_err("ksu_install_fd: failed to get unused fd\n");
-        return fd;
+        goto out;
     }
 
     filp = anon_inode_getfile("[ksu_driver]", &anon_ksu_fops, NULL, O_RDWR | O_CLOEXEC);
     if (IS_ERR(filp)) {
         pr_err("ksu_install_fd: failed to create anon inode file\n");
         put_unused_fd(fd);
-        return PTR_ERR(filp);
+        fd = PTR_ERR(filp);
+        goto out;
     }
 
     fd_install(fd, filp);
-    pr_info("ksu fd installed: %d for pid %d\n", fd, current->pid);
+    pr_debug("ksu fd installed: %d for pid %d\n", fd, current->pid);
+
+out:
+    ksu_module_unload_leave();
     return fd;
 }
 
@@ -68,13 +121,15 @@ static void ksu_install_fd_tw_func(struct callback_head *cb)
     struct ksu_install_fd_tw *tw = container_of(cb, struct ksu_install_fd_tw, cb);
     int fd = ksu_install_fd();
 
-    pr_info("[%d] install ksu fd: %d\n", current->pid, fd);
+    pr_debug("[%d] install ksu fd: %d\n", current->pid, fd);
     if (copy_to_user(tw->outp, &fd, sizeof(fd))) {
         pr_err("install ksu fd reply err\n");
-        ksu_close_fd(fd);
+        if (fd >= 0)
+            ksu_close_fd(fd);
     }
 
     kfree(tw);
+    module_put(THIS_MODULE);
 }
 
 static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
@@ -83,7 +138,7 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
     int magic1 = (int)PT_REGS_PARM1(real_regs);
     int magic2 = (int)PT_REGS_PARM2(real_regs);
 
-    if (magic1 == KSU_INSTALL_MAGIC1 && magic2 == KSU_INSTALL_MAGIC2) {
+    if (magic1 == KSU_INSTALL_MAGIC1 && magic2 == KSU_INSTALL_MAGIC2 && can_install_driver_fd()) {
         struct ksu_install_fd_tw *tw;
         unsigned long arg4 = (unsigned long)PT_REGS_SYSCALL_PARM4(real_regs);
 
@@ -94,7 +149,15 @@ static int reboot_handler_pre(struct kprobe *p, struct pt_regs *regs)
         tw->outp = (int __user *)arg4;
         tw->cb.func = ksu_install_fd_tw_func;
 
+        // task_work stores a callback into module text. Only pin a live module;
+        // once delete_module() has moved it to GOING, no new callback may be queued.
+        if (!try_module_get(THIS_MODULE)) {
+            kfree(tw);
+            return 0;
+        }
+
         if (task_work_add(current, &tw->cb, TWA_RESUME)) {
+            module_put(THIS_MODULE);
             kfree(tw);
             pr_warn("install fd add task_work failed\n");
         }

--- a/manager/app/src/main/AndroidManifest.xml
+++ b/manager/app/src/main/AndroidManifest.xml
@@ -85,6 +85,7 @@
         <service
             android:name=".magica.MagicaService"
             android:directBootAware="true"
+            android:enabled="false"
             android:exported="false"
             android:isolatedProcess="true"
             android:useAppZygote="true" />
@@ -98,14 +99,11 @@
             android:name=".magica.BootCompletedReceiver"
             android:directBootAware="true"
             android:enabled="false"
-            android:exported="true"
+            android:exported="false"
             android:process=":magica_boot">
             <intent-filter>
                 <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="me.weishu.kernelsu.magica.LAUNCH" />
             </intent-filter>
         </receiver>
     </application>

--- a/manager/app/src/main/java/me/weishu/kernelsu/KernelSUApplication.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/KernelSUApplication.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import me.weishu.kernelsu.data.repository.SettingsRepositoryImpl
+import me.weishu.kernelsu.magica.MagicaService
 import me.weishu.kernelsu.ui.viewmodel.SuperUserViewModel
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -40,6 +41,12 @@ class KernelSUApplication : Application(), ViewModelStoreOwner {
     override fun onCreate() {
         super.onCreate()
         ksuApp = this
+
+        runCatching {
+            if (Natives.isManager) {
+                MagicaService.setEnabled(this, false)
+            }
+        }
 
         if (!isUserUnlocked()) {
             return

--- a/manager/app/src/main/java/me/weishu/kernelsu/magica/BootCompletedReceiver.java
+++ b/manager/app/src/main/java/me/weishu/kernelsu/magica/BootCompletedReceiver.java
@@ -18,17 +18,18 @@ public class BootCompletedReceiver extends BroadcastReceiver {
         }
         var action = intent.getAction();
         if (!Intent.ACTION_LOCKED_BOOT_COMPLETED.equals(action)
-                && !Intent.ACTION_BOOT_COMPLETED.equals(action)
-                && !"me.weishu.kernelsu.magica.LAUNCH".equals(action)) {
+                && !Intent.ACTION_BOOT_COMPLETED.equals(action)) {
             return;
         }
         if (KsuCliKt.rootAvailable()) return;
-        try {
-            context.startService(new Intent(context, MagicaService.class));
-            Log.i(TAG, "MagicaService started from boot action: " + action);
-        } catch (Throwable e) {
 
-            Log.e(TAG, "Failed to start MagicaService from boot action: " + action, e);
+        PendingResult pendingResult = goAsync();
+        try {
+            MagicaService.start(context, pendingResult::finish);
+            Log.i(TAG, "MagicaService bootstrap started from boot action: " + action);
+        } catch (Throwable e) {
+            pendingResult.finish();
+            Log.e(TAG, "Failed to bootstrap MagicaService from boot action: " + action, e);
         }
     }
 }

--- a/manager/app/src/main/java/me/weishu/kernelsu/magica/MagicaService.java
+++ b/manager/app/src/main/java/me/weishu/kernelsu/magica/MagicaService.java
@@ -1,13 +1,124 @@
 package me.weishu.kernelsu.magica;
 
+import static me.weishu.kernelsu.magica.AppZygotePreload.TAG;
+
 import android.app.Service;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.Intent;
+import android.content.ServiceConnection;
+import android.content.pm.PackageManager;
 import android.os.Binder;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class MagicaService extends Service {
+    private static final long BOOTSTRAP_TIMEOUT_MS = 8_000L;
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
+
+    public static void setEnabled(Context context, boolean enabled) {
+        context.getPackageManager().setComponentEnabledSetting(
+                new ComponentName(context, MagicaService.class),
+                enabled
+                        ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                        : PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP);
+    }
+
+    public static void start(Context context) {
+        start(context, null);
+    }
+
+    public static void start(Context context, @Nullable Runnable onFinished) {
+        Context appContext = context.getApplicationContext();
+        BootstrapConnection connection = new BootstrapConnection(appContext, onFinished);
+
+        setEnabled(appContext, true);
+        connection.scheduleTimeout();
+        try {
+            if (!appContext.bindService(
+                    new Intent(appContext, MagicaService.class),
+                    connection,
+                    Context.BIND_AUTO_CREATE)) {
+                connection.abort();
+                throw new IllegalStateException("Failed to bind MagicaService");
+            }
+        } catch (RuntimeException e) {
+            connection.abort();
+            throw e;
+        }
+    }
+
+    private static final class BootstrapConnection implements ServiceConnection {
+        private final Context context;
+        @Nullable private final Runnable onFinished;
+        private final AtomicBoolean finished = new AtomicBoolean();
+        private final Runnable timeout = () -> finish(true);
+
+        BootstrapConnection(Context context, @Nullable Runnable onFinished) {
+            this.context = context;
+            this.onFinished = onFinished;
+        }
+
+        void scheduleTimeout() {
+            MAIN_HANDLER.postDelayed(timeout, BOOTSTRAP_TIMEOUT_MS);
+        }
+
+        void abort() {
+            if (!finished.compareAndSet(false, true)) return;
+            MAIN_HANDLER.removeCallbacks(timeout);
+            setEnabled(context, false);
+        }
+
+        private void finish(boolean unbind) {
+            if (!finished.compareAndSet(false, true)) return;
+
+            MAIN_HANDLER.removeCallbacks(timeout);
+            try {
+                setEnabled(context, false);
+            } catch (RuntimeException e) {
+                Log.e(TAG, "Failed to disable MagicaService", e);
+            }
+
+            if (unbind) {
+                try {
+                    context.unbindService(this);
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+
+            if (onFinished != null) {
+                onFinished.run();
+            }
+        }
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service) {
+            finish(true);
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name) {
+            finish(true);
+        }
+
+        @Override
+        public void onBindingDied(ComponentName name) {
+            finish(true);
+        }
+
+        @Override
+        public void onNullBinding(ComponentName name) {
+            finish(true);
+        }
+    }
+
     @Nullable
     @Override
     public IBinder onBind(Intent intent) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package me.weishu.kernelsu.ui.screen.home
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,7 +54,7 @@ fun HomePager(
         onOpenUrl = uriHandler::openUri,
         onJailbreakClick = {
             loadingDialog.showLoading()
-            context.startService(Intent(context, MagicaService::class.java))
+            MagicaService.start(context)
             // Manager will be force-stopped and restarted by late-load on success.
             // If that doesn't happen within timeout, jailbreak likely failed.
             scope.launch(Dispatchers.IO) {

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -6,8 +6,9 @@
 
 #include "uapi/app_profile.h"
 
+// 3: managed metamodule mount layer synchronization
 // 2: allowlist v4 root profile flags
-static const __u32 KERNEL_SU_UAPI_VERSION = 2;
+static const __u32 KERNEL_SU_UAPI_VERSION = 3;
 
 /* Magic numbers for reboot hook to install fd */
 static const __u32 KSU_INSTALL_MAGIC1 = 0xDEADBEEF;
@@ -136,17 +137,19 @@ struct ksu_nuke_ext4_sysfs_cmd {
 
 struct ksu_add_try_umount_cmd {
     __aligned_u64 arg; /* char ptr, this is the mountpoint */
-    __u32 flags; /* this is the flag we use for it */
-    __u8 mode; /* denotes what to do with it 0:wipe_list 1:add_to_list 2:delete_entry */
+    __u32 flags; /* umount flags, or layer count for KSU_UMOUNT_MANAGED_SET */
+    __u8 mode; /* KSU_UMOUNT_* operation */
 };
 
 struct ksu_get_sulog_fd_cmd {
     __u32 flags; /* Input: reserved for future use, must be 0 */
 };
 
-static const __u8 KSU_UMOUNT_WIPE = 0; /* ignore everything and wipe list */
-static const __u8 KSU_UMOUNT_ADD = 1; /* add entry (path + flags) */
-static const __u8 KSU_UMOUNT_DEL = 2; /* delete entry, strcmp */
+static const __u8 KSU_UMOUNT_WIPE = 0; /* wipe all entries */
+static const __u8 KSU_UMOUNT_ADD = 1; /* add one unmanaged entry (path + flags) */
+static const __u8 KSU_UMOUNT_DEL = 2; /* delete one entry by path */
+static const __u8 KSU_UMOUNT_MANAGED_WIPE = 3; /* wipe only auto-managed entries */
+static const __u8 KSU_UMOUNT_MANAGED_SET = 4; /* set managed path layer count in flags */
 
 /* IOCTL command definitions */
 static const __u32 KSU_IOCTL_GRANT_ROOT = _IOC(_IOC_NONE, 'K', 1, 0);
@@ -176,5 +179,8 @@ static const __u32 KSU_IOCTL_ADD_TRY_UMOUNT = _IOC(_IOC_WRITE, 'K', 18, 0);
 static const __u32 KSU_IOCTL_SET_INIT_PGRP = _IO('K', 19);
 static const __u32 KSU_IOCTL_GET_SULOG_FD = _IOW('K', 20, struct ksu_get_sulog_fd_cmd);
 static const __u32 KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT = _IO('K', 21);
+static const __u32 KSU_IOCTL_PREPARE_UNLOAD = _IO('K', 22);
+static const __u32 KSU_IOCTL_COMMIT_UNLOAD = _IO('K', 23);
+static const __u32 KSU_IOCTL_ABORT_UNLOAD = _IO('K', 24);
 
 #endif

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -3,14 +3,30 @@ use anyhow::bail;
 
 use crate::ksu_uapi;
 use std::fs;
-use std::os::fd::RawFd;
-use std::sync::OnceLock;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
-// Global driver fd cache
-static DRIVER_FD: OnceLock<RawFd> = OnceLock::new();
+enum DriverFdState {
+    Empty,
+    Owned(OwnedFd),
+    TakenForUnload,
+}
+
+static DRIVER_FD: Mutex<DriverFdState> = Mutex::new(DriverFdState::Empty);
 static INFO_CACHE: OnceLock<ksu_uapi::ksu_get_info_cmd> = OnceLock::new();
 
-fn scan_driver_fd() -> Option<RawFd> {
+fn lock_driver_fd() -> MutexGuard<'static, DriverFdState> {
+    DRIVER_FD
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn dup_fd_cloexec(fd: RawFd) -> Option<OwnedFd> {
+    let duplicated = unsafe { libc::fcntl(fd, libc::F_DUPFD_CLOEXEC, 0) };
+    (duplicated >= 0).then(|| unsafe { OwnedFd::from_raw_fd(duplicated) })
+}
+
+fn scan_driver_fd() -> Option<OwnedFd> {
     let fd_dir = fs::read_dir("/proc/self/fd").ok()?;
 
     for entry in fd_dir.flatten() {
@@ -18,8 +34,13 @@ fn scan_driver_fd() -> Option<RawFd> {
             let link_path = format!("/proc/self/fd/{fd_num}");
             if let Ok(target) = fs::read_link(&link_path) {
                 let target_str = target.to_string_lossy();
-                if target_str.contains("[ksu_driver]") {
-                    return Some(fd_num);
+                if target_str.contains("[ksu_driver]")
+                    && let Some(duplicated) = dup_fd_cloexec(fd_num)
+                {
+                    // Never create a second OwnedFd for the same raw descriptor.
+                    // The duplicate has independent ownership even if the
+                    // descriptor discovered through /proc closes concurrently.
+                    return Some(duplicated);
                 }
             }
         }
@@ -28,31 +49,67 @@ fn scan_driver_fd() -> Option<RawFd> {
     None
 }
 
-// Get cached driver fd
-fn init_driver_fd() -> Option<RawFd> {
-    let fd = scan_driver_fd();
-    if fd.is_none() {
-        let mut fd = -1;
-        unsafe {
-            libc::syscall(
-                libc::SYS_reboot,
-                ksu_uapi::KSU_INSTALL_MAGIC1,
-                ksu_uapi::KSU_INSTALL_MAGIC2,
-                0,
-                &mut fd,
-            );
-        };
-        if fd >= 0 { Some(fd) } else { None }
-    } else {
-        fd
+fn request_driver_fd() -> Option<OwnedFd> {
+    let mut fd = -1;
+    unsafe {
+        libc::syscall(
+            libc::SYS_reboot,
+            ksu_uapi::KSU_INSTALL_MAGIC1,
+            ksu_uapi::KSU_INSTALL_MAGIC2,
+            0,
+            &mut fd,
+        );
+    };
+    (fd >= 0).then(|| unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn init_driver_fd() -> Option<OwnedFd> {
+    scan_driver_fd().or_else(request_driver_fd)
+}
+
+fn ensure_driver_fd_locked(state: &mut DriverFdState) -> Option<RawFd> {
+    if matches!(&*state, DriverFdState::Empty)
+        && let Some(fd) = init_driver_fd()
+    {
+        *state = DriverFdState::Owned(fd);
+    }
+
+    match state {
+        DriverFdState::Owned(fd) => Some(fd.as_raw_fd()),
+        DriverFdState::Empty | DriverFdState::TakenForUnload => None,
     }
 }
 
-// ioctl wrapper using libc
-fn ksuctl<T>(request: u32, arg: *mut T) -> std::io::Result<i32> {
+pub fn install_driver_fd() -> Option<OwnedFd> {
+    request_driver_fd()
+}
+
+pub fn take_driver_fd() -> Option<OwnedFd> {
+    let mut state = lock_driver_fd();
+    ensure_driver_fd_locked(&mut state)?;
+
+    match std::mem::replace(&mut *state, DriverFdState::TakenForUnload) {
+        DriverFdState::Owned(fd) => Some(fd),
+        other => {
+            *state = other;
+            None
+        }
+    }
+}
+
+pub fn restore_driver_fd(fd: OwnedFd) {
+    let mut state = lock_driver_fd();
+    if matches!(
+        &*state,
+        DriverFdState::TakenForUnload | DriverFdState::Empty
+    ) {
+        *state = DriverFdState::Owned(fd);
+    }
+}
+
+fn ksuctl_fd<T>(fd: RawFd, request: u32, arg: *mut T) -> std::io::Result<i32> {
     use std::io;
 
-    let fd = *DRIVER_FD.get_or_init(|| init_driver_fd().unwrap_or(-1));
     unsafe {
         let ret = libc::ioctl(fd as libc::c_int, request as i32, arg);
         if ret < 0 {
@@ -63,7 +120,20 @@ fn ksuctl<T>(request: u32, arg: *mut T) -> std::io::Result<i32> {
     }
 }
 
-// API implementations
+#[allow(clippy::significant_drop_tightening)]
+fn ksuctl<T>(request: u32, arg: *mut T) -> std::io::Result<i32> {
+    use std::io;
+
+    // Keep the cache lock through ioctl so unload cannot take and close this
+    // descriptor while the syscall is using its raw fd number.
+    let mut state = lock_driver_fd();
+    if matches!(&*state, DriverFdState::TakenForUnload) {
+        return Err(io::Error::from_raw_os_error(libc::EBUSY));
+    }
+    let fd = ensure_driver_fd_locked(&mut state).unwrap_or(-1);
+    ksuctl_fd(fd, request, arg)
+}
+
 pub fn get_info() -> ksu_uapi::ksu_get_info_cmd {
     *INFO_CACHE.get_or_init(|| {
         let mut cmd = ksu_uapi::ksu_get_info_cmd {
@@ -153,8 +223,6 @@ pub fn set_sepolicy(payload: *const u8, payload_len: u64) -> std::io::Result<i32
     ksuctl(ksu_uapi::KSU_IOCTL_SET_SEPOLICY, &raw mut ioctl_cmd)
 }
 
-/// Get feature value and support status from kernel
-/// Returns (value, supported)
 pub fn get_feature(feature_id: u32) -> std::io::Result<(u64, bool)> {
     let mut cmd = ksu_uapi::ksu_get_feature_cmd {
         feature_id,
@@ -165,7 +233,6 @@ pub fn get_feature(feature_id: u32) -> std::io::Result<(u64, bool)> {
     Ok((cmd.value, cmd.supported != 0))
 }
 
-/// Set feature value in kernel
 pub fn set_feature(feature_id: u32, value: u64) -> std::io::Result<()> {
     let mut cmd = ksu_uapi::ksu_set_feature_cmd { feature_id, value };
     ksuctl(ksu_uapi::KSU_IOCTL_SET_FEATURE, &raw mut cmd)?;
@@ -187,7 +254,6 @@ pub fn get_sulog_fd() -> std::io::Result<RawFd> {
     Ok(result)
 }
 
-/// Get mark status for a process (pid=0 returns total marked count)
 pub fn mark_get(pid: i32) -> std::io::Result<u32> {
     let mut cmd = ksu_uapi::ksu_manage_mark_cmd {
         operation: ksu_uapi::KSU_MARK_GET,
@@ -198,7 +264,6 @@ pub fn mark_get(pid: i32) -> std::io::Result<u32> {
     Ok(cmd.result)
 }
 
-/// Mark a process (pid=0 marks all processes)
 pub fn mark_set(pid: i32) -> std::io::Result<()> {
     let mut cmd = ksu_uapi::ksu_manage_mark_cmd {
         operation: ksu_uapi::KSU_MARK_MARK,
@@ -209,7 +274,6 @@ pub fn mark_set(pid: i32) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Unmark a process (pid=0 unmarks all processes)
 pub fn mark_unset(pid: i32) -> std::io::Result<()> {
     let mut cmd = ksu_uapi::ksu_manage_mark_cmd {
         operation: ksu_uapi::KSU_MARK_UNMARK,
@@ -220,7 +284,6 @@ pub fn mark_unset(pid: i32) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Refresh mark for all running processes
 pub fn mark_refresh() -> std::io::Result<()> {
     let mut cmd = ksu_uapi::ksu_manage_mark_cmd {
         operation: ksu_uapi::KSU_MARK_REFRESH,
@@ -233,14 +296,13 @@ pub fn mark_refresh() -> std::io::Result<()> {
 
 pub fn nuke_ext4_sysfs(mnt: &str) -> anyhow::Result<()> {
     let c_mnt = std::ffi::CString::new(mnt)?;
-    let mut ioctl_cmd = ksu_uapi::ksu_nuke_ext4_sysfs_cmd {
+    let mut ioctl_cmd = crate::ksu_uapi::ksu_nuke_ext4_sysfs_cmd {
         arg: c_mnt.as_ptr() as u64,
     };
     ksuctl(ksu_uapi::KSU_IOCTL_NUKE_EXT4_SYSFS, &raw mut ioctl_cmd)?;
     Ok(())
 }
 
-/// Wipe all entries from umount list
 pub fn umount_list_wipe() -> std::io::Result<()> {
     let mut cmd = ksu_uapi::ksu_add_try_umount_cmd {
         arg: 0,
@@ -251,7 +313,16 @@ pub fn umount_list_wipe() -> std::io::Result<()> {
     Ok(())
 }
 
-/// Add mount point to umount list
+pub fn umount_list_managed_wipe() -> std::io::Result<()> {
+    let mut cmd = ksu_uapi::ksu_add_try_umount_cmd {
+        arg: 0,
+        flags: 0,
+        mode: ksu_uapi::KSU_UMOUNT_MANAGED_WIPE,
+    };
+    ksuctl(ksu_uapi::KSU_IOCTL_ADD_TRY_UMOUNT, &raw mut cmd)?;
+    Ok(())
+}
+
 pub fn umount_list_add(path: &str, flags: u32) -> anyhow::Result<()> {
     let c_path = std::ffi::CString::new(path)?;
     let mut cmd = ksu_uapi::ksu_add_try_umount_cmd {
@@ -263,7 +334,17 @@ pub fn umount_list_add(path: &str, flags: u32) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Delete mount point from umount list
+pub fn umount_list_managed_set(path: &str, layers: u32) -> anyhow::Result<()> {
+    let c_path = std::ffi::CString::new(path)?;
+    let mut cmd = ksu_uapi::ksu_add_try_umount_cmd {
+        arg: c_path.as_ptr() as u64,
+        flags: layers,
+        mode: ksu_uapi::KSU_UMOUNT_MANAGED_SET,
+    };
+    ksuctl(ksu_uapi::KSU_IOCTL_ADD_TRY_UMOUNT, &raw mut cmd)?;
+    Ok(())
+}
+
 pub fn umount_list_del(path: &str) -> anyhow::Result<()> {
     let c_path = std::ffi::CString::new(path)?;
     let mut cmd = ksu_uapi::ksu_add_try_umount_cmd {
@@ -275,7 +356,6 @@ pub fn umount_list_del(path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Set current process's process group to init_group (pgid = 0)
 pub fn set_init_pgrp() -> std::io::Result<()> {
     ksuctl(
         ksu_uapi::KSU_IOCTL_SET_INIT_PGRP,
@@ -292,5 +372,32 @@ pub fn set_ksu_no_new_privs() -> anyhow::Result<()> {
     if result != 0 {
         bail!("unexpected result: {result}");
     }
+    Ok(())
+}
+
+pub fn prepare_unload_on(fd: RawFd) -> std::io::Result<()> {
+    ksuctl_fd(
+        fd,
+        ksu_uapi::KSU_IOCTL_PREPARE_UNLOAD,
+        std::ptr::null_mut::<u8>(),
+    )?;
+    Ok(())
+}
+
+pub fn commit_unload_on(fd: RawFd) -> std::io::Result<()> {
+    ksuctl_fd(
+        fd,
+        ksu_uapi::KSU_IOCTL_COMMIT_UNLOAD,
+        std::ptr::null_mut::<u8>(),
+    )?;
+    Ok(())
+}
+
+pub fn abort_unload_on(fd: RawFd) -> std::io::Result<()> {
+    ksuctl_fd(
+        fd,
+        ksu_uapi::KSU_IOCTL_ABORT_UNLOAD,
+        std::ptr::null_mut::<u8>(),
+    )?;
     Ok(())
 }

--- a/userspace/ksud/src/late_load.rs
+++ b/userspace/ksud/src/late_load.rs
@@ -1,10 +1,15 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail, ensure};
 use log::{info, warn};
 use rustix::cstr;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use crate::module::{handle_updated_modules, prune_modules};
 use crate::{assets, defs, init_event, metamodule, restorecon, utils};
+
+const ZYGOTE_STOP_RETRIES: usize = 100;
+const ZYGOTE_STOP_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn dump_process_info(label: &str) {
     use rustix::process::{getgid, getgroups, getpid, getuid};
@@ -33,6 +38,87 @@ fn dump_process_info(label: &str) {
         groups.join(","),
         selinux.trim(),
     );
+}
+
+fn zygote_services_stopped() -> bool {
+    matches!(
+        utils::getprop("init.svc.zygote").as_deref(),
+        Some("stopped")
+    ) && utils::getprop("init.svc.zygote_secondary").is_none_or(|state| state == "stopped")
+}
+
+fn stop_android_services_for_mount() -> Result<()> {
+    let status = Command::new("stop")
+        .status()
+        .context("failed to execute Android stop command")?;
+    if !status.success() {
+        if let Err(start_err) = start_android_services() {
+            return Err(start_err).context(format!(
+                "Android stop exited with status {status}; recovery start also failed"
+            ));
+        }
+        bail!("Android stop exited with status {status}; Android service state restored");
+    }
+
+    for _ in 0..ZYGOTE_STOP_RETRIES {
+        if zygote_services_stopped() {
+            return Ok(());
+        }
+        thread::sleep(ZYGOTE_STOP_RETRY_DELAY);
+    }
+
+    if let Err(start_err) = start_android_services() {
+        return Err(start_err).context(
+            "zygote services did not stop before metamodule mount synchronization; recovery start failed",
+        );
+    }
+    bail!(
+        "zygote services did not stop before metamodule mount synchronization; Android service state restored"
+    )
+}
+
+fn start_android_services() -> Result<()> {
+    let status = Command::new("start")
+        .status()
+        .context("failed to execute Android start command")?;
+    ensure!(
+        status.success(),
+        "Android start exited with status {status}"
+    );
+    Ok(())
+}
+
+fn mount_metamodule_without_app_spawn(module_dir: &str) -> Result<()> {
+    info!("late-load: stopping Android services before metamodule mount synchronization");
+    stop_android_services_for_mount()?;
+
+    if let Err(err) = metamodule::exec_mount_script(module_dir) {
+        match metamodule::register_module_mounts() {
+            Ok(()) => {
+                warn!(
+                    "late-load: metamodule mount failed but isolation resync is safe; restarting Android services"
+                );
+                if let Err(start_err) = start_android_services() {
+                    return Err(start_err).context(format!(
+                        "metamodule mount failed: {err:#}; isolation recovered, but Android service restart failed"
+                    ));
+                }
+                return Err(err).context(
+                    "metamodule mount failed; isolation recovered and Android services restarted",
+                );
+            }
+            Err(sync_err) => {
+                warn!(
+                    "late-load: metamodule mount and isolation resync failed; leaving Android services stopped"
+                );
+                return Err(err).context(format!(
+                    "isolation resync also failed: {sync_err:#}; Android services left stopped"
+                ));
+            }
+        }
+    }
+
+    start_android_services().context("failed to restart Android services after metamodule mount")
 }
 
 pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Result<()> {
@@ -67,6 +153,9 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         info!("kernelsu.ko loaded successfully!");
         dump_process_info("after load_module");
     }
+
+    crate::ksucalls::ensure_uapi_version_matched()
+        .context("KernelSU UAPI mismatch after late load")?;
 
     // We need to reset stdin/stdout/stderr; otherwise, sending file descriptors via cmd transactions
     // will be blocked by SELinux because its fsec->sid is still u:r:su:s0 instead of u:r:ksu:s0.
@@ -115,10 +204,9 @@ pub fn run(package_name: &String, kmi: Option<String>, allow_shell: bool) -> Res
         warn!("load system.prop failed: {e}");
     }
 
-    // 10. Execute metamodule mount script (OverlayFS)
-    if let Err(e) = metamodule::exec_mount_script(defs::MODULE_DIR) {
-        warn!("execute metamodule mount failed: {e}");
-    }
+    // 10. Stop zygote-backed app spawning while the metamodule creates mounts
+    // and the kernel isolation list is synchronized from the resulting stack.
+    mount_metamodule_without_app_spawn(defs::MODULE_DIR)?;
 
     // 11. Execute post-mount stage scripts (blocking)
     init_event::run_stage("post-mount", true);

--- a/userspace/ksud/src/metamodule.rs
+++ b/userspace/ksud/src/metamodule.rs
@@ -4,16 +4,16 @@
 //! Metamodules are special modules that manage how regular modules are mounted
 //! and provide hooks for module installation/uninstallation.
 
-use anyhow::{Context, Result, ensure};
-use log::{info, warn};
+use anyhow::{Context, Result, anyhow, ensure};
+use log::{debug, info, warn};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     process::Command,
 };
 
 use crate::module::ModuleType::All;
-use crate::{assets, defs};
+use crate::{assets, defs, ksucalls};
 
 /// Determine whether the provided module properties mark it as a metamodule
 pub fn is_metamodule(props: &HashMap<String, String>) -> bool {
@@ -78,6 +78,325 @@ pub fn get_metamodule_id() -> Option<String> {
 /// Check if metamodule exists
 pub fn has_metamodule() -> bool {
     get_metamodule_path().is_some()
+}
+
+fn unescape_mountinfo_field(field: &str) -> String {
+    let bytes = field.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\'
+            && i + 3 < bytes.len()
+            && matches!(bytes[i + 1], b'0'..=b'7')
+            && matches!(bytes[i + 2], b'0'..=b'7')
+            && matches!(bytes[i + 3], b'0'..=b'7')
+        {
+            out.push(
+                (bytes[i + 1] - b'0') * 64 + (bytes[i + 2] - b'0') * 8 + (bytes[i + 3] - b'0'),
+            );
+            i += 4;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn path_is_at_or_under(path: &str, base: &str) -> bool {
+    let base = base.trim_end_matches('/');
+    path == base
+        || path
+            .strip_prefix(base)
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+fn is_module_mount_root(root: &str) -> bool {
+    path_is_at_or_under(root, "/adb/modules")
+        || path_is_at_or_under(root, "/adb/metamodule")
+        || path_is_at_or_under(root, defs::MODULE_DIR)
+        || path_is_at_or_under(root, defs::METAMODULE_DIR)
+}
+
+fn io_errno(err: &anyhow::Error) -> Option<i32> {
+    err.downcast_ref::<std::io::Error>()
+        .and_then(std::io::Error::raw_os_error)
+}
+
+#[derive(Debug)]
+struct MountInfoEntry {
+    id: u64,
+    parent_id: u64,
+    root: String,
+    target: String,
+    source: String,
+}
+
+fn read_mountinfo() -> Result<Vec<MountInfoEntry>> {
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo")
+        .context("Failed to inspect module mounts")?;
+    let mut entries = Vec::new();
+
+    for line in mountinfo.lines() {
+        let Some((left, right)) = line.split_once(" - ") else {
+            continue;
+        };
+        let mut left = left.split_ascii_whitespace();
+        let Some(id) = left.next().and_then(|s| s.parse::<u64>().ok()) else {
+            continue;
+        };
+        let Some(parent_id) = left.next().and_then(|s| s.parse::<u64>().ok()) else {
+            continue;
+        };
+        if left.next().is_none() {
+            continue;
+        }
+        let Some(root) = left.next() else {
+            continue;
+        };
+        let Some(target) = left.next() else {
+            continue;
+        };
+
+        let mut right = right.split_ascii_whitespace();
+        if right.next().is_none() {
+            continue;
+        }
+        let Some(source) = right.next() else {
+            continue;
+        };
+
+        entries.push(MountInfoEntry {
+            id,
+            parent_id,
+            root: unescape_mountinfo_field(root),
+            target: unescape_mountinfo_field(target),
+            source: unescape_mountinfo_field(source),
+        });
+    }
+
+    Ok(entries)
+}
+
+fn is_module_mount(entry: &MountInfoEntry) -> bool {
+    entry.source == "KSU" || is_module_mount_root(&entry.root)
+}
+
+fn top_entry_for_target<'a>(
+    entries: &'a [MountInfoEntry],
+    target: &str,
+) -> Result<Option<&'a MountInfoEntry>> {
+    let target_entries = entries
+        .iter()
+        .filter(|entry| entry.target == target)
+        .collect::<Vec<_>>();
+    if target_entries.is_empty() {
+        return Ok(None);
+    }
+
+    let parent_ids = target_entries
+        .iter()
+        .map(|entry| entry.parent_id)
+        .collect::<HashSet<_>>();
+    let tops = target_entries
+        .into_iter()
+        .filter(|entry| !parent_ids.contains(&entry.id))
+        .collect::<Vec<_>>();
+
+    if tops.len() != 1 {
+        return Err(anyhow!(
+            "Ambiguous mount stack for {target}: found {} top candidates",
+            tops.len()
+        ));
+    }
+    Ok(tops.into_iter().next())
+}
+
+fn module_mount_layers(entries: &[MountInfoEntry]) -> Result<Vec<(String, u32)>> {
+    let module_targets = entries
+        .iter()
+        .filter(|entry| is_module_mount(entry))
+        .map(|entry| entry.target.clone())
+        .collect::<HashSet<_>>();
+    let by_id = entries
+        .iter()
+        .map(|entry| (entry.id, entry))
+        .collect::<HashMap<_, _>>();
+    let mut mounts = Vec::new();
+
+    for target in module_targets {
+        let Some(mut current) = top_entry_for_target(entries, &target)? else {
+            continue;
+        };
+        let mut layers = 0u32;
+
+        while current.target == target && is_module_mount(current) {
+            layers = layers
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("Too many mount layers for {target}"))?;
+            let Some(parent) = by_id.get(&current.parent_id).copied() else {
+                break;
+            };
+            if parent.target != target {
+                break;
+            }
+            current = parent;
+        }
+
+        if layers == 0 {
+            warn!(
+                "Module mount exists below a foreign top layer at {target}; refusing path-based isolation for this target"
+            );
+            continue;
+        }
+        mounts.push((target, layers));
+    }
+
+    mounts.sort_by(|(a, _), (b, _)| {
+        let a_depth = a.bytes().filter(|ch| *ch == b'/').count();
+        let b_depth = b.bytes().filter(|ch| *ch == b'/').count();
+        a_depth.cmp(&b_depth).then_with(|| a.cmp(b))
+    });
+    Ok(mounts)
+}
+
+#[cfg(target_os = "android")]
+fn detach_top_module_mount(target: &str) -> Result<bool> {
+    ensure!(target != "/", "Refusing to detach the root mount");
+    let entries = read_mountinfo()?;
+    let Some(top) = top_entry_for_target(&entries, target)? else {
+        return Ok(false);
+    };
+    if !is_module_mount(top) {
+        return Ok(false);
+    }
+
+    let target = std::ffi::CString::new(target).context("Module mount path contains NUL")?;
+    let ret = unsafe { libc::umount2(target.as_ptr(), libc::MNT_DETACH) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("Failed to detach unregistered module mount");
+    }
+    Ok(true)
+}
+
+fn register_module_mounts_legacy(mounts: &[(String, u32)]) -> Result<()> {
+    let mut first_error = None;
+
+    for (mount, _) in mounts {
+        match ksucalls::umount_list_add(mount, 0) {
+            Ok(()) => {}
+            Err(err) if io_errno(&err) == Some(libc::EEXIST) => {
+                debug!("Module mount already registered: {mount}");
+            }
+            Err(err) => {
+                warn!("Failed to register module mount {mount}: {err:#}");
+                if first_error.is_none() {
+                    first_error =
+                        Some(err.context(format!("Failed to register module mount {mount}")));
+                }
+            }
+        }
+    }
+
+    ksucalls::report_module_mounted();
+    if let Some(err) = first_error {
+        return Err(err);
+    }
+    Ok(())
+}
+
+pub fn register_module_mounts() -> Result<()> {
+    let initial_mounts = module_mount_layers(&read_mountinfo()?)?;
+
+    match ksucalls::umount_list_managed_wipe() {
+        Ok(()) => {
+            if initial_mounts.is_empty() {
+                return Ok(());
+            }
+        }
+        Err(err) if matches!(err.raw_os_error(), Some(libc::EINVAL | libc::ENOTTY)) => {
+            if ksucalls::get_info().uapi_version >= 3 {
+                return Err(err).context(
+                    "Kernel reports UAPI v3+ but managed mount synchronization is unavailable",
+                );
+            }
+            if initial_mounts.is_empty() {
+                return Ok(());
+            }
+            debug!("Managed umount synchronization unavailable; using legacy registration");
+            return register_module_mounts_legacy(&initial_mounts);
+        }
+        Err(err) => return Err(err).context("Failed to reset managed module mount isolation"),
+    }
+
+    let mut first_error = None;
+    loop {
+        let mounts = module_mount_layers(&read_mountinfo()?)?;
+        ksucalls::umount_list_managed_wipe()
+            .context("Failed to reset managed module mount isolation")?;
+
+        if mounts.is_empty() {
+            if let Some(err) = first_error {
+                return Err(err);
+            }
+            return Ok(());
+        }
+
+        let mut failed = Vec::new();
+        for (mount, layers) in &mounts {
+            if let Err(err) = ksucalls::umount_list_managed_set(mount, *layers) {
+                warn!("Failed to protect module mount {mount} ({layers} layers): {err:#}");
+                if first_error.is_none() {
+                    first_error = Some(err.context(format!(
+                        "Failed to protect module mount {mount} ({layers} layers)"
+                    )));
+                }
+                failed.push((mount.clone(), *layers));
+            }
+        }
+
+        if failed.is_empty() {
+            ksucalls::report_module_mounted();
+            if let Some(err) = first_error {
+                return Err(err);
+            }
+            return Ok(());
+        }
+
+        #[cfg(target_os = "android")]
+        {
+            let mut detached_any = false;
+            for (mount, layers) in failed.iter().rev() {
+                let mut detached = 0u32;
+                while detached < *layers {
+                    match detach_top_module_mount(mount) {
+                        Ok(true) => {
+                            detached += 1;
+                            detached_any = true;
+                        }
+                        Ok(false) => break,
+                        Err(err) => {
+                            warn!(
+                                "Failed to fail-close module mount {mount} after registration failure: {err:#}"
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+            if detached_any {
+                continue;
+            }
+        }
+
+        ksucalls::report_module_mounted();
+        return Err(
+            first_error.unwrap_or_else(|| anyhow!("Module mount isolation synchronization failed"))
+        );
+    }
 }
 
 /// Check if it's safe to install a regular module
@@ -267,10 +586,27 @@ pub fn exec_mount_script(module_dir: &str) -> Result<()> {
         .env("MODULE_DIR", module_dir)
         .status()?;
 
-    ensure!(
-        result.success(),
-        "Metamodule mount script failed with status: {result:?}"
-    );
+    // Inspect and register mounts even when the script failed so partial mounts
+    // do not silently escape app-namespace isolation. If both the script and
+    // registration fail, preserve the registration failure because it carries
+    // the safety-critical isolation state.
+    let registration = register_module_mounts();
+
+    match (result.success(), registration) {
+        (true, Ok(())) => {}
+        (true, Err(err)) => return Err(err),
+        (false, Ok(())) => {
+            ensure!(
+                false,
+                "Metamodule mount script failed with status: {result:?}"
+            );
+        }
+        (false, Err(err)) => {
+            return Err(err).context(format!(
+                "Metamodule mount script also failed with status: {result:?}"
+            ));
+        }
+    }
 
     info!("Metamodule mount script executed successfully");
     Ok(())

--- a/userspace/ksud/src/unload.rs
+++ b/userspace/ksud/src/unload.rs
@@ -1,12 +1,19 @@
-use anyhow::Result;
+use anyhow::{Context, Result, anyhow, ensure};
 use log::{info, warn};
 use std::fs;
+use std::os::fd::AsRawFd;
 use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
-use crate::utils;
+use crate::{ksucalls, utils};
 
-/// Find PIDs of processes running in the KernelSU su domain (u:r:ksu:s0).
-/// Returns a list of PIDs excluding our own.
+const PREPARE_UNLOAD_RETRIES: usize = 20;
+const DELETE_MODULE_RETRIES: usize = 20;
+const UNLOAD_RETRY_DELAY: Duration = Duration::from_millis(50);
+const ZYGOTE_STOP_RETRIES: usize = 100;
+const ZYGOTE_STOP_RETRY_DELAY: Duration = Duration::from_millis(50);
+
 fn find_su_domain_pids() -> Vec<i32> {
     let my_pid = std::process::id() as i32;
     let mut pids = Vec::new();
@@ -36,8 +43,12 @@ fn find_su_domain_pids() -> Vec<i32> {
     pids
 }
 
-/// Find PIDs of processes holding ksu_driver or ksu_fdwrapper file descriptors.
-/// Returns a list of PIDs excluding our own.
+fn is_ksu_fd_target(target: &str) -> bool {
+    target.contains("[ksu_driver]")
+        || target.contains("[ksu_fdwrapper]")
+        || target.contains("[ksu_sulog]")
+}
+
 fn find_ksu_fd_holders() -> Vec<i32> {
     let my_pid = std::process::id() as i32;
     let mut pids = Vec::new();
@@ -62,12 +73,11 @@ fn find_ksu_fd_holders() -> Vec<i32> {
 
         for fd_entry in fds.flatten() {
             let link_path = fd_entry.path();
-            if let Ok(target) = fs::read_link(&link_path) {
-                let target_str = target.to_string_lossy();
-                if target_str.contains("[ksu_driver]") || target_str.contains("[ksu_fdwrapper]") {
-                    pids.push(pid);
-                    break;
-                }
+            if let Ok(target) = fs::read_link(&link_path)
+                && is_ksu_fd_target(&target.to_string_lossy())
+            {
+                pids.push(pid);
+                break;
             }
         }
     }
@@ -83,8 +93,15 @@ fn kill_pids(pids: &[i32], signal: i32) {
     }
 }
 
-/// Close all ksu_driver and ksu_fdwrapper fds held by the current process.
-fn close_ksu_fds() {
+fn close_fd(fd: i32) {
+    if fd >= 0 {
+        unsafe {
+            libc::close(fd);
+        }
+    }
+}
+
+fn close_ksu_fds_except(keep_fd: Option<i32>) {
     let Ok(entries) = fs::read_dir("/proc/self/fd") else {
         return;
     };
@@ -93,64 +110,248 @@ fn close_ksu_fds() {
         let Ok(fd) = entry.file_name().to_string_lossy().parse::<i32>() else {
             continue;
         };
+        if keep_fd == Some(fd) {
+            continue;
+        }
+
         if let Ok(target) = fs::read_link(entry.path()) {
             let target_str = target.to_string_lossy();
-            if target_str.contains("[ksu_driver]") || target_str.contains("[ksu_fdwrapper]") {
-                info!("unload: closing fd {fd} -> {target_str}");
-                unsafe {
-                    libc::close(fd);
-                }
+            if !is_ksu_fd_target(&target_str) {
+                continue;
             }
+
+            info!("unload: closing fd {fd} -> {target_str}");
+            close_fd(fd);
         }
     }
 }
 
+fn run_android_service_control(command: &str) -> Result<()> {
+    let status = Command::new(command)
+        .status()
+        .with_context(|| format!("failed to execute Android {command}"))?;
+    ensure!(status.success(), "Android {command} exited with {status}");
+    Ok(())
+}
+
+fn zygote_services_stopped() -> bool {
+    matches!(
+        utils::getprop("init.svc.zygote").as_deref(),
+        Some("stopped")
+    ) && utils::getprop("init.svc.zygote_secondary").is_none_or(|state| state == "stopped")
+}
+
+fn wait_for_zygote_services_stopped() -> Result<()> {
+    for _ in 0..ZYGOTE_STOP_RETRIES {
+        if zygote_services_stopped() {
+            return Ok(());
+        }
+        thread::sleep(ZYGOTE_STOP_RETRY_DELAY);
+    }
+
+    Err(anyhow!(
+        "zygote services did not stop before KernelSU unload teardown"
+    ))
+}
+
+fn prepare_unload_with_retry(fd: i32) -> std::io::Result<()> {
+    for attempt in 0..PREPARE_UNLOAD_RETRIES {
+        match ksucalls::prepare_unload_on(fd) {
+            Ok(()) => return Ok(()),
+            Err(err)
+                if err.raw_os_error() == Some(libc::EBUSY)
+                    && attempt + 1 < PREPARE_UNLOAD_RETRIES =>
+            {
+                thread::sleep(UNLOAD_RETRY_DELAY);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!()
+}
+
+fn commit_unload_with_retry(fd: i32) -> std::io::Result<()> {
+    for attempt in 0..PREPARE_UNLOAD_RETRIES {
+        match ksucalls::commit_unload_on(fd) {
+            Ok(()) => return Ok(()),
+            Err(err)
+                if err.raw_os_error() == Some(libc::EBUSY)
+                    && attempt + 1 < PREPARE_UNLOAD_RETRIES =>
+            {
+                thread::sleep(UNLOAD_RETRY_DELAY);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!()
+}
+
+fn delete_module_with_retry() -> Result<()> {
+    for attempt in 0..DELETE_MODULE_RETRIES {
+        match rustix::system::delete_module(c"kernelsu", libc::O_NONBLOCK) {
+            Ok(()) => return Ok(()),
+            Err(err) if err == rustix::io::Errno::NOENT => return Ok(()),
+            Err(err)
+                if (err == rustix::io::Errno::AGAIN || err == rustix::io::Errno::BUSY)
+                    && attempt + 1 < DELETE_MODULE_RETRIES =>
+            {
+                thread::sleep(UNLOAD_RETRY_DELAY);
+            }
+            Err(err) => return Err(err).context("delete_module kernelsu failed"),
+        }
+    }
+
+    unreachable!()
+}
+
+fn abort_unload_with_fd(fd: i32) -> Result<()> {
+    ksucalls::abort_unload_on(fd).context("abort KernelSU unload failed")
+}
+
+fn recover_after_delete_failure() -> Result<()> {
+    let recovery_fd =
+        ksucalls::install_driver_fd().context("KernelSU recovery driver fd unavailable")?;
+    let result = abort_unload_with_fd(recovery_fd.as_raw_fd());
+
+    // Keep the recovery descriptor owned by the shared cache regardless of the
+    // abort result. It pins a still-loaded module and prevents a stale raw-fd
+    // cache if the caller continues running after this failed unload attempt.
+    ksucalls::restore_driver_fd(recovery_fd);
+    result
+}
+
 pub fn unload() -> Result<()> {
+    ensure!(
+        ksucalls::is_lkm(),
+        "KernelSU unload is only supported in LKM mode"
+    );
+
     info!("unload: starting KernelSU unload sequence");
 
-    // 0. Switch cgroups so we don't get killed along with our parent shell
     utils::switch_cgroups();
 
-    // 1. stop (Android init stop command - stops all services)
     info!("unload: stopping Android services...");
-    let _ = Command::new("stop").status();
+    let stop_result =
+        run_android_service_control("stop").and_then(|()| wait_for_zygote_services_stopped());
+    if let Err(stop_err) = stop_result {
+        warn!("unload: Android stop failed, restoring service state...");
+        if let Err(start_err) = run_android_service_control("start") {
+            return Err(stop_err.context(format!(
+                "Android service stop failed and recovery start also failed: {start_err:#}"
+            )));
+        }
+        return Err(stop_err).context("Android service stop failed; teardown not started");
+    }
 
-    // 2. Kill all su domain processes and processes holding ksu fds (except ourselves)
-    info!("unload: killing su domain processes...");
-    let su_pids = find_su_domain_pids();
-    if !su_pids.is_empty() {
-        info!(
-            "unload: found {} su domain processes, sending SIGKILL",
-            su_pids.len()
+    let mut hooks_prepared = false;
+    let mut runtime_recovered = false;
+    let mut unsafe_prepare_failure = false;
+
+    let result = (|| -> Result<()> {
+        info!("unload: killing su domain processes...");
+        let su_pids = find_su_domain_pids();
+        if !su_pids.is_empty() {
+            info!(
+                "unload: found {} su domain processes, sending SIGKILL",
+                su_pids.len()
+            );
+            kill_pids(&su_pids, libc::SIGKILL);
+        }
+
+        info!("unload: killing processes holding ksu fds...");
+        let fd_pids = find_ksu_fd_holders();
+        if !fd_pids.is_empty() {
+            info!(
+                "unload: found {} processes holding ksu fds, sending SIGKILL",
+                fd_pids.len()
+            );
+            kill_pids(&fd_pids, libc::SIGKILL);
+        }
+
+        let mut control_fd =
+            Some(ksucalls::take_driver_fd().context("KernelSU driver fd unavailable")?);
+        let control_raw = control_fd.as_ref().unwrap().as_raw_fd();
+        close_ksu_fds_except(Some(control_raw));
+
+        info!("unload: preparing kernel hooks for removal...");
+        if let Err(err) = prepare_unload_with_retry(control_raw) {
+            unsafe_prepare_failure = err.raw_os_error() == Some(libc::EUCLEAN);
+            ksucalls::restore_driver_fd(control_fd.take().unwrap());
+            return Err(err).context("prepare KernelSU unload failed");
+        }
+        hooks_prepared = true;
+
+        info!("unload: committing kernel hook removal...");
+        if let Err(commit_err) = commit_unload_with_retry(control_raw) {
+            let abort_result = abort_unload_with_fd(control_raw);
+            ksucalls::restore_driver_fd(control_fd.take().unwrap());
+
+            match abort_result {
+                Ok(()) => {
+                    runtime_recovered = true;
+                    return Err(commit_err)
+                        .context("commit KernelSU unload failed; runtime restored");
+                }
+                Err(abort_err) => {
+                    return Err(anyhow!(
+                        "commit KernelSU unload failed: {commit_err}; recovery failed: {abort_err:#}"
+                    ));
+                }
+            }
+        }
+
+        // COMMIT released the custom hook guard. Drop the owned control FD so
+        // its fops module reference is also gone before delete_module(). The
+        // shared cache is already empty, so it cannot retain this stale number.
+        drop(control_fd.take());
+        close_ksu_fds_except(None);
+
+        info!("unload: removing kernelsu module...");
+        if let Err(delete_err) = delete_module_with_retry() {
+            warn!("unload: module removal failed after commit, restoring runtime hooks...");
+            match recover_after_delete_failure() {
+                Ok(()) => {
+                    runtime_recovered = true;
+                    return Err(delete_err)
+                        .context("KernelSU module removal failed; runtime restored");
+                }
+                Err(recovery_err) => {
+                    return Err(delete_err.context(format!(
+                        "KernelSU module removal failed and runtime recovery failed: {recovery_err:#}"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    })();
+
+    let restart_safe =
+        result.is_ok() || runtime_recovered || (!hooks_prepared && !unsafe_prepare_failure);
+    let restart_result = if restart_safe {
+        info!("unload: restarting Android services...");
+        Some(run_android_service_control("start"))
+    } else {
+        warn!(
+            "unload: kernel teardown did not reach a safe running state; leaving Android services stopped"
         );
-        kill_pids(&su_pids, libc::SIGKILL);
+        None
+    };
+
+    if let Some(Err(restart_err)) = restart_result {
+        return match result {
+            Ok(()) => {
+                Err(restart_err.context("KernelSU unloaded but Android service restart failed"))
+            }
+            Err(unload_err) => Err(unload_err.context(format!(
+                "Android service restart also failed: {restart_err:#}"
+            ))),
+        };
     }
 
-    info!("unload: killing processes holding ksu fds...");
-    let fd_pids = find_ksu_fd_holders();
-    if !fd_pids.is_empty() {
-        info!(
-            "unload: found {} processes holding ksu fds, sending SIGKILL",
-            fd_pids.len()
-        );
-        kill_pids(&fd_pids, libc::SIGKILL);
-    }
-
-    // 3. Close all our own ksu_driver and ksu_fdwrapper fds
-    info!("unload: closing all ksu fds...");
-    close_ksu_fds();
-
-    // 4. delete_module("kernelsu")
-    info!("unload: removing kernelsu module...");
-    if let Err(e) = rustix::system::delete_module(c"kernelsu", 0) {
-        warn!("unload: delete_module kernelsu failed: {e}");
-    }
-
-    // 5. start (Android init start command - restarts all services)
-    info!("unload: restarting Android services...");
-    let _ = Command::new("start").status();
-
-    // 6. Exit
-    info!("unload: done, exiting ksud");
-    std::process::exit(0);
+    result?;
+    info!("unload: done");
+    Ok(())
 }


### PR DESCRIPTION
Fix kernel correctness and performance issues, harden manager tracking, reduce tracing overhead, improve module mount isolation, and fix allowlist migration, umount list bounds, and syscall hook cleanup.