### PR TITLE
kernel, ksud: allow filter kernel modules at load time

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -32,6 +32,7 @@ endif
 kernelsu-objs += policy/allowlist.o
 kernelsu-objs += policy/app_profile.o
 kernelsu-objs += policy/feature.o
+kernelsu-objs += feature/module_load_filter.o
 
 kernelsu-objs += runtime/boot_event.o
 kernelsu-objs += runtime/ksud_integration.o

--- a/kernel/core/init.c
+++ b/kernel/core/init.c
@@ -25,6 +25,7 @@
 #include "hook/syscall_hook.h"
 #include "feature/adb_root.h"
 #include "feature/selinux_hide.h"
+#include "feature/module_load_filter.h"
 #include "infra/symbol_resolver.h"
 
 #if defined(__x86_64__) && !defined(CONFIG_KSU_X86_PATCH_SYSCALL_DISPATCHER)
@@ -82,6 +83,9 @@ module_param(allow_shell, bool, 0);
 
 bool ksu_no_custom_rc = false;
 module_param_named(norc, ksu_no_custom_rc, bool, 0);
+
+char ksu_block_modules[256];
+module_param_string(block_modules, ksu_block_modules, sizeof(ksu_block_modules), 0);
 
 int __init kernelsu_init(void)
 {
@@ -170,6 +174,8 @@ int __init kernelsu_init(void)
     } else {
         ksu_syscall_hook_manager_init();
 
+        ksu_module_load_filter_hook_init();
+
         ksu_allowlist_init();
 
         ksu_throne_tracker_init();
@@ -212,6 +218,7 @@ void __exit kernelsu_exit(void)
     ksu_adb_root_exit();
     ksu_sulog_exit();
     ksu_feature_exit();
+    ksu_module_load_filter_hook_exit();
 
     put_cred(ksu_cred);
 }

--- a/kernel/feature/module_load_filter.c
+++ b/kernel/feature/module_load_filter.c
@@ -1,0 +1,324 @@
+#include <asm/elf.h>
+#include <linux/elf.h>
+#include <linux/file.h>
+#include <linux/fs.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/slab.h>
+#include <linux/string.h>
+#include <linux/uaccess.h>
+#include <uapi/linux/module.h>
+
+#include "feature/module_load_filter.h"
+#include "klog.h" // IWYU pragma: keep
+#include "arch.h"
+#include "hook/syscall_hook.h"
+
+struct ksu_module_name {
+    const char *name;
+    size_t len;
+};
+
+struct ksu_elf_reader {
+    const char __user *umod;
+    unsigned long umod_len;
+    struct file *file;
+    loff_t file_size;
+};
+
+static int ksu_reader_read(struct ksu_elf_reader *r, loff_t offset, void *buf, size_t len)
+{
+    loff_t total = r->umod ? (loff_t)r->umod_len : r->file_size;
+
+    if (len == 0)
+        return -EINVAL;
+    if (offset < 0 || (loff_t)len > total || offset > total - (loff_t)len)
+        return -ERANGE;
+
+    if (r->umod) {
+        if (copy_from_user(buf, r->umod + offset, len))
+            return -EFAULT;
+        return 0;
+    }
+
+    loff_t pos = offset;
+    ssize_t n = kernel_read(r->file, buf, len, &pos);
+    if (n < 0 || (size_t)n != len)
+        return -EIO;
+    return 0;
+}
+
+static bool check_module_should_block(const char *name, size_t name_len, bool normalize_filename,
+                                      struct ksu_module_name *blocked)
+{
+    const char *cursor = ksu_block_modules;
+    const char *end = cursor + strnlen(cursor, sizeof(ksu_block_modules));
+
+    while (cursor < end) {
+        const char *separator = memchr(cursor, ',', end - cursor);
+        size_t entry_len = separator ? (size_t)(separator - cursor) : (size_t)(end - cursor);
+
+        if (entry_len && name_len == entry_len) {
+            size_t i;
+
+            for (i = 0; i < name_len; i++) {
+                char a = name[i];
+                char b = cursor[i];
+
+                if (normalize_filename && a == '-')
+                    a = '_';
+
+                if (b == '-')
+                    b = '_';
+
+                if (a != b)
+                    break;
+            }
+
+            if (i == name_len) {
+                blocked->name = cursor;
+                blocked->len = entry_len;
+                return true;
+            }
+        }
+
+        if (!separator)
+            break;
+
+        cursor = separator + 1;
+    }
+
+    return false;
+}
+
+static bool ksu_is_block_module(struct ksu_elf_reader *r, struct ksu_module_name *blocked)
+{
+    Elf_Ehdr ehdr;
+    Elf_Shdr *shdrs = NULL;
+    char *shstrtab = NULL;
+    char *modinfo = NULL;
+    Elf_Shdr *shstr_sh;
+    Elf_Shdr *modinfo_sh = NULL;
+    unsigned int shnum, i;
+    unsigned long shtab_bytes;
+    bool should_block = false;
+
+    if (ksu_reader_read(r, 0, &ehdr, sizeof(ehdr)))
+        return false;
+
+    if (memcmp(ehdr.e_ident, ELFMAG, SELFMAG) != 0)
+        return false;
+    if (ehdr.e_ident[EI_CLASS] != ELF_CLASS || ehdr.e_ident[EI_DATA] != ELF_DATA ||
+        ehdr.e_ident[EI_VERSION] != EV_CURRENT)
+        return false;
+    if (ehdr.e_type != ET_REL || !elf_check_arch(&ehdr) || ehdr.e_version != EV_CURRENT)
+        return false;
+    if (ehdr.e_shentsize != sizeof(Elf_Shdr))
+        return false;
+
+    shnum = ehdr.e_shnum;
+    if (shnum == 0 || shnum > 512)
+        return false;
+    if (ehdr.e_shstrndx >= shnum)
+        return false;
+
+    shtab_bytes = (unsigned long)shnum * sizeof(Elf_Shdr);
+    shdrs = kmalloc(shtab_bytes, GFP_KERNEL);
+    if (!shdrs)
+        return false;
+    if (ksu_reader_read(r, ehdr.e_shoff, shdrs, shtab_bytes))
+        goto out;
+
+    shstr_sh = &shdrs[ehdr.e_shstrndx];
+    if (shstr_sh->sh_type != SHT_STRTAB || shstr_sh->sh_size == 0 || shstr_sh->sh_size > 65536)
+        goto out;
+    shstrtab = kmalloc(shstr_sh->sh_size, GFP_KERNEL);
+    if (!shstrtab)
+        goto out;
+    if (ksu_reader_read(r, shstr_sh->sh_offset, shstrtab, shstr_sh->sh_size))
+        goto out;
+
+    for (i = 0; i < shnum; i++) {
+        Elf_Shdr *sh = &shdrs[i];
+        const char *name;
+        unsigned long remaining;
+
+        if (sh->sh_name >= shstr_sh->sh_size)
+            continue;
+        name = shstrtab + sh->sh_name;
+        remaining = shstr_sh->sh_size - sh->sh_name;
+        if (strnlen(name, remaining) >= remaining)
+            continue;
+        if (sh->sh_type == SHT_PROGBITS && strcmp(name, ".modinfo") == 0) {
+            modinfo_sh = sh;
+            break;
+        }
+    }
+    if (!modinfo_sh)
+        goto out;
+
+    if (modinfo_sh->sh_size == 0 || modinfo_sh->sh_size > 16384)
+        goto out;
+    modinfo = kmalloc(modinfo_sh->sh_size, GFP_KERNEL);
+    if (!modinfo)
+        goto out;
+    if (ksu_reader_read(r, modinfo_sh->sh_offset, modinfo, modinfo_sh->sh_size))
+        goto out;
+
+    {
+        const char *p = modinfo;
+        const char *end = modinfo + modinfo_sh->sh_size;
+
+        while (p < end) {
+            const char *nul = memchr(p, '\0', end - p);
+            size_t entlen;
+
+            if (!nul)
+                break;
+            entlen = nul - p;
+            if (entlen > 5 && memcmp(p, "name=", 5) == 0) {
+                const char *val = p + 5;
+                size_t vlen = entlen - 5;
+
+                should_block = check_module_should_block(val, vlen, false, blocked);
+                break;
+            }
+            p = nul + 1;
+        }
+    }
+
+out:
+    kfree(modinfo);
+    kfree(shstrtab);
+    kfree(shdrs);
+    return should_block;
+}
+
+int ksu_handle_init_module(const void __user *umod, unsigned long umod_len)
+{
+    struct ksu_module_name blocked = { 0 };
+    struct ksu_elf_reader r = {
+        .umod = (const char __user *)umod,
+        .umod_len = umod_len,
+        .file = NULL,
+        .file_size = 0,
+    };
+
+    if (!ksu_block_modules[0])
+        return 0;
+
+    if (r.umod && r.umod_len >= sizeof(Elf_Ehdr) && ksu_is_block_module(&r, &blocked)) {
+        pr_info("module_load_filter: block %.*s load due to it in blocklist\n", (int)blocked.len, blocked.name);
+        return 0;
+    }
+
+    return 1;
+}
+
+int ksu_handle_finit_module(int fd, int flags)
+{
+    struct ksu_module_name blocked = { 0 };
+    struct file *file;
+    bool should_block = false;
+
+    if (!ksu_block_modules[0])
+        return 0;
+
+    file = fget(fd);
+
+    if (!file)
+        return 0;
+
+#ifdef MODULE_INIT_COMPRESSED_FILE
+    if (flags & MODULE_INIT_COMPRESSED_FILE) {
+        static const char *const compression_suffixes[] = { ".gz", ".xz", ".zst" };
+        const struct qstr *filename = &file->f_path.dentry->d_name;
+        size_t name_len = filename->len;
+        size_t i;
+
+        for (i = 0; i < ARRAY_SIZE(compression_suffixes); i++) {
+            const char *suffix = compression_suffixes[i];
+            size_t suffix_len = strlen(suffix);
+
+            if (name_len > suffix_len && !memcmp(filename->name + name_len - suffix_len, suffix, suffix_len)) {
+                name_len -= suffix_len;
+                break;
+            }
+        }
+
+        if (i != ARRAY_SIZE(compression_suffixes)) {
+            if (name_len > 3 && !memcmp(filename->name + name_len - 3, ".ko", 3)) {
+                name_len -= 3;
+                should_block = check_module_should_block(filename->name, name_len, true, &blocked);
+            }
+        }
+    } else
+#endif
+    {
+        struct ksu_elf_reader r = {
+            .umod = NULL,
+            .umod_len = 0,
+            .file = file,
+            .file_size = i_size_read(file_inode(file)),
+        };
+
+        // https://github.com/torvalds/linux/commit/b1ae6dc41eaaa98bb75671e0f3665bfda248c3e7
+        // linux kernel 5.17+
+        should_block = r.file_size >= (loff_t)sizeof(Elf_Ehdr) && ksu_is_block_module(&r, &blocked);
+    }
+
+    fput(file);
+
+    if (should_block) {
+        pr_info("module_load_filter: block %.*s load due to it in blocklist\n", (int)blocked.len, blocked.name);
+        return 0;
+    }
+
+    return 1;
+}
+
+// init_module(2): sys_init_module(void __user *umod, unsigned long len,
+//                                const char __user *uargs)
+static long (*orig_sys_init_module)(const struct pt_regs *regs);
+static long ksu_sys_init_module(const struct pt_regs *regs)
+{
+    int ret = ksu_handle_init_module((const void __user *)PT_REGS_PARM1(regs), (unsigned long)PT_REGS_PARM2(regs));
+
+    if (!ret)
+        return ret;
+
+    return orig_sys_init_module(regs);
+}
+
+// finit_module(2): sys_finit_module(int fd, const char __user *uargs, int flags)
+static long (*orig_sys_finit_module)(const struct pt_regs *regs);
+static long ksu_sys_finit_module(const struct pt_regs *regs)
+{
+    int ret = ksu_handle_finit_module((int)PT_REGS_PARM1(regs), (int)PT_REGS_PARM3(regs));
+
+    if (!ret)
+        return ret;
+
+    return orig_sys_finit_module(regs);
+}
+
+void __init ksu_module_load_filter_hook_init(void)
+{
+    if (!ksu_block_modules[0]) {
+        pr_info("module_load_filter: no modules should be blocked\n");
+        return;
+    }
+
+    ksu_syscall_table_hook(__NR_init_module, ksu_sys_init_module, &orig_sys_init_module);
+    ksu_syscall_table_hook(__NR_finit_module, ksu_sys_finit_module, &orig_sys_finit_module);
+    pr_info("module_load_filter: target modules: %s\n", ksu_block_modules);
+}
+
+void __exit ksu_module_load_filter_hook_exit(void)
+{
+    if (!ksu_block_modules[0])
+        return;
+
+    ksu_syscall_table_unhook(__NR_init_module);
+    ksu_syscall_table_unhook(__NR_finit_module);
+}

--- a/kernel/feature/module_load_filter.h
+++ b/kernel/feature/module_load_filter.h
@@ -1,0 +1,17 @@
+#ifndef __KSU_H_MODULE_LOAD_FILTER
+#define __KSU_H_MODULE_LOAD_FILTER
+
+#include <linux/types.h>
+
+// 256 should enough
+extern char ksu_block_modules[256];
+
+// return is errno, use if to check
+// when the if statement is false, return ret to the userspace.
+int ksu_handle_init_module(const void __user *umod, unsigned long umod_len);
+int ksu_handle_finit_module(int fd, int flags);
+
+void ksu_module_load_filter_hook_init(void);
+void ksu_module_load_filter_hook_exit(void);
+
+#endif

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -523,7 +523,7 @@ pub struct BootPatchArgs {
     #[arg(
         long,
         value_name = "NAMES",
-        default_value = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new"
+        default_value = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new,mkp"
     )]
     block_modules: Option<String>,
 

--- a/userspace/ksud/src/boot_patch.rs
+++ b/userspace/ksud/src/boot_patch.rs
@@ -18,6 +18,20 @@ use regex_lite::Regex;
 
 use crate::assets;
 
+const KSU_BLOCK_MODULES_CONFIG: &str = "ksu_block_modules";
+const KSU_BLOCK_MODULES_MAX_LEN: usize = 255;
+
+fn valid_block_modules(modules: &str) -> bool {
+    modules.len() <= KSU_BLOCK_MODULES_MAX_LEN
+        && (modules.is_empty()
+            || modules.split(',').all(|name| {
+                !name.is_empty()
+                    && name
+                        .bytes()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'-')
+            }))
+}
+
 #[cfg(target_os = "android")]
 mod android {
     use super::Result;
@@ -505,6 +519,14 @@ pub struct BootPatchArgs {
     #[arg(long, default_value = "false")]
     no_custom_rc: bool,
 
+    /// Block what module loading
+    #[arg(
+        long,
+        value_name = "NAMES",
+        default_value = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new"
+    )]
+    block_modules: Option<String>,
+
     #[cfg(not(target_os = "android"))]
     #[arg(long, default_value = "aarch64")]
     arch: String,
@@ -529,6 +551,7 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             enable_adbd,
             adb_debug_prop,
             no_install,
+            block_modules,
             #[cfg(target_os = "android")]
             ota,
             #[cfg(target_os = "android")]
@@ -542,6 +565,13 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
             arch,
             ramdisk,
         } = args;
+
+        if let Some(modules) = &block_modules {
+            ensure!(
+                valid_block_modules(modules),
+                "blocked preset module list must be at most 255 bytes and contain only letters, digits, '_' or '-'"
+            );
+        }
 
         println!(include_str!("banner"));
 
@@ -758,6 +788,16 @@ pub fn patch(args: BootPatchArgs) -> Result<()> {
 
         // remove legacy config file
         cpio.rm("allow_shell", false);
+
+        if let Some(modules) = block_modules {
+            if !modules.is_empty() {
+                println!("- Blocking modules: {modules}");
+            }
+            cpio.add(
+                KSU_BLOCK_MODULES_CONFIG,
+                CpioEntry::regular(0o644, Box::new(modules.into_bytes())),
+            )?;
+        }
 
         if enable_adbd || adb_debug_prop.is_some() {
             println!("- Adding adb_debug props");

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 use std::io::{ErrorKind, Write};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use rustix::fs::{Mode, symlink, unlink};
 use rustix::{
     fd::AsFd,
@@ -14,6 +14,48 @@ use rustix::{
 
 struct AutoUmount {
     mountpoints: Vec<String>,
+}
+
+const KSU_CONFIG_PATH: &str = "/ksu_config";
+const KSU_BLOCK_MODULES_PATH: &str = "/ksu_block_modules";
+const KSU_BLOCK_MODULES_MAX_LEN: usize = 255;
+const KSU_DEFAULT_BLOCK_MODULES: &str = "vr";
+
+fn valid_block_modules(modules: &str) -> bool {
+    modules.len() <= KSU_BLOCK_MODULES_MAX_LEN
+        && (modules.is_empty()
+            || modules.split(',').all(|name| {
+                !name.is_empty()
+                    && name
+                        .bytes()
+                        .all(|ch| ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'-')
+            }))
+}
+
+fn load_module_params() -> Result<CString> {
+    let mut params = std::fs::read(KSU_CONFIG_PATH).unwrap_or_default();
+
+    let blocked_modules = match std::fs::read_to_string(KSU_BLOCK_MODULES_PATH) {
+        Ok(modules) => modules,
+        Err(err) if err.kind() == ErrorKind::NotFound => KSU_DEFAULT_BLOCK_MODULES.to_owned(),
+        Err(err) => {
+            return Err(err).with_context(|| format!("Cannot read {KSU_BLOCK_MODULES_PATH}"));
+        }
+    };
+
+    ensure!(
+        valid_block_modules(&blocked_modules),
+        "Invalid blocked preset module list"
+    );
+    if params
+        .last()
+        .is_some_and(|byte| !byte.is_ascii_whitespace())
+    {
+        params.push(b' ');
+    }
+    params.extend_from_slice(format!("block_modules={blocked_modules}").as_bytes());
+
+    CString::new(params).context("KernelSU module parameters contain a NUL byte")
 }
 
 impl Drop for AutoUmount {
@@ -129,8 +171,7 @@ pub fn init() -> Result<()> {
 fn load_module_from_path(path: &str) -> Result<()> {
     anyhow::ensure!(rustix::process::getpid().is_init(), "Invalid process");
     let buffer = std::fs::read(path).with_context(|| format!("Cannot read file {}", path))?;
-    let params = std::fs::read("/ksu_config").unwrap_or_default();
-    let params = unsafe { CString::from_vec_unchecked(params) };
+    let params = load_module_params()?;
     log::info!("load kernelsu with params {params:?}");
     ksuinit::load_module(&buffer, &params)
 }

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -19,7 +19,7 @@ struct AutoUmount {
 const KSU_CONFIG_PATH: &str = "/ksu_config";
 const KSU_BLOCK_MODULES_PATH: &str = "/ksu_block_modules";
 const KSU_BLOCK_MODULES_MAX_LEN: usize = 255;
-const KSU_DEFAULT_BLOCK_MODULES: &str = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new";
+const KSU_DEFAULT_BLOCK_MODULES: &str = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new,mkp";
 
 fn valid_block_modules(modules: &str) -> bool {
     modules.len() <= KSU_BLOCK_MODULES_MAX_LEN

--- a/userspace/ksuinit/src/init.rs
+++ b/userspace/ksuinit/src/init.rs
@@ -19,7 +19,7 @@ struct AutoUmount {
 const KSU_CONFIG_PATH: &str = "/ksu_config";
 const KSU_BLOCK_MODULES_PATH: &str = "/ksu_block_modules";
 const KSU_BLOCK_MODULES_MAX_LEN: usize = 255;
-const KSU_DEFAULT_BLOCK_MODULES: &str = "vr";
+const KSU_DEFAULT_BLOCK_MODULES: &str = "vr,vklp,oplus_secure_guard,oplus_secure_guard_new";
 
 fn valid_block_modules(modules: &str) -> bool {
     modules.len() <= KSU_BLOCK_MODULES_MAX_LEN


### PR DESCRIPTION
This pull request implement a way to block kernel modules load, the most usecase is to block `vr`, `vklp`, `oplus_secure_guard`, `oplus_secure_guard_new` they were vivo and oppo's anti root kernel module

Also added `blocked-modules` param for `ksud boot-patch` command to let user can control that

default blocked modules is
`vr,vklp,oplus_secure_guard,oplus_secure_guard_new,mkp`, same with this commit's inital purpose

```sh
ksud boot-patch --block-modules foo,bar ...

ksud boot-patch --block-modules= ...
```

---------