### PR TITLE
fix(kernel): Fix kernel panic in ksu_observer_exit

### DIFF
--- a/kernel/manager/pkg_observer.c
+++ b/kernel/manager/pkg_observer.c
@@ -35,8 +35,14 @@ static int ksu_handle_inode_event(struct fsnotify_mark *mark, u32 mask, struct i
     return 0;
 }
 
+static void ksu_free_mark(struct fsnotify_mark *mark)
+{
+    kfree(mark);
+}
+
 static const struct fsnotify_ops ksu_ops = {
     .handle_inode_event = ksu_handle_inode_event,
+    .free_mark = ksu_free_mark,
 };
 
 static int add_mark_on_inode(struct inode *inode, u32 mask, struct fsnotify_mark **out)

--- a/kernel/manager/pkg_observer.c
+++ b/kernel/manager/pkg_observer.c
@@ -119,6 +119,7 @@ int ksu_observer_init(void)
 void __exit ksu_observer_exit(void)
 {
     unwatch_one_dir(&g_watch);
-    fsnotify_put_group(g);
+    if (g)
+        fsnotify_put_group(g);
     pr_info("observer exit done\n");
 }


### PR DESCRIPTION
This PR fixes 2 errors:

```
[  117.820044] Oops: general protection fault: 0000 [#1] SMP NOPTI
[  117.820049] CPU: 11 UID: 0 PID: 6307 Comm: kworker/u66:15 Tainted: G     U     OE       7.1.9-arch1-2 #1 PREEMPT(full)  1dcb44188b0ac1c68b4b4adc32aedf169215449b
[  117.820052] Tainted: [U]=USER, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[  117.820053] Hardware name: ASUSTeK COMPUTER INC. ASUS Zenbook 14 UX3405CA_UX3405CA/UX3405CA, BIOS UX3405CA.314 11/20/2025
[  117.820054] Workqueue: events_unbound fsnotify_mark_destroy_workfn
[  117.820061] RIP: 0010:0x0
[  117.820111] Code: Unable to access opcode bytes at 0xffffffffffffffd6.
...snip...
[  117.820120] Call Trace:
[  117.820121]  <TASK>
[  117.820122]  fsnotify_mark_destroy_workfn+0xf6/0x150
[  117.820125]  process_one_work+0x19f/0x390
```

```
[59872.737057] Oops: general protection fault, kernel NULL pointer dereference 0x8: 0000 [#1] SMP NOPTI
[59872.737062] CPU: 6 UID: 0 PID: 39657 Comm: ksuinit Tainted: G     U  W  OE       7.1.9-arch1-2 #1 PREEMPT(full)  1dcb44188b0ac1c68b4b4adc32aedf169215449b
[59872.737066] Tainted: [U]=USER, [W]=WARN, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[59872.737067] Hardware name: ASUSTeK COMPUTER INC. ASUS Zenbook 14 UX3405CA_UX3405CA/UX3405CA, BIOS UX3405CA.314 11/20/2025
[59872.737068] RIP: 0010:fsnotify_put_group+0x11/0xd0
...snip...
[59872.737085] Call Trace:
[59872.737087]  <TASK>
[59872.737091]  ksu_observer_exit+0x7d/0x90 [kernelsu 916bf01b631d888e75a104021b29a1459186f2cc]
[59872.737102]  cleanup_module+0x26/0x70 [kernelsu 916bf01b631d888e75a104021b29a1459186f2cc]
[59872.737109]  __do_sys_delete_module+0x1de/0x350
```