### PR TITLE
kernel: Do not use kallsyms_on_each_match_symbol on x86-64

### DIFF
--- a/kernel/infra/symbol_resolver.c
+++ b/kernel/infra/symbol_resolver.c
@@ -32,7 +32,7 @@ static int (*kallsyms_on_each_symbol_fn)(int (*fn)(void *, const char *, struct 
                                          void *data) = NULL;
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0) && !defined(__x86_64__)
 #define HAVE_ON_EACH_MATCH_SYMBOL 1
 #else
 #define HAVE_ON_EACH_MATCH_SYMBOL 0


### PR DESCRIPTION
On x86-64, `kallsyms_on_each_match_symbol` is blocked by IBT on kernel 7.0:

```
Missing ENDBR: kallsyms_on_each_match_symbol+0x0/0x140
```