### PR TITLE
build: allow pinning KSU version via environment override

### DIFF
--- a/kernel/Kbuild
+++ b/kernel/Kbuild
@@ -112,6 +112,12 @@ endif
 
 
 # Calculate version if git version is available
+ifdef KSU_VERSION_OVERRIDE
+# Allow pinning the version (e.g. to match an official manager release)
+KSU_VERSION := $(KSU_VERSION_OVERRIDE)
+$(info -- KernelSU version (override): $(KSU_VERSION))
+ccflags-y += -DKSU_VERSION=$(KSU_VERSION)
+else
 ifdef KSU_GIT_VERSION_VALID
 # ksu_version: major * 10000 + git version + 200 for historical reasons
 $(eval KSU_VERSION=$(shell expr 30000 + $(KSU_GIT_VERSION)))
@@ -121,6 +127,7 @@ else
 # If there is no .git directory, use default version
 $(warning "KSU_GIT_VERSION not defined! It is better to make KernelSU a git repository!")
 ccflags-y += -DKSU_VERSION=16
+endif
 endif
 
 KSU_NEW_DCACHE_FLUSH := $(shell grep -q __flush_dcache_area $(srctree)/arch/arm64/include/asm/cacheflush.h ; echo $$?)

--- a/userspace/ksud/build.rs
+++ b/userspace/ksud/build.rs
@@ -219,13 +219,24 @@ fn assemble_bootstrap() {
 fn main() {
     assemble_bootstrap();
 
-    let (code, name) = match get_git_version() {
-        Ok((code, name)) => (code, name),
-        Err(_) => {
-            // show warning if git is not installed
-            println!("cargo:warning=Failed to get git version, using 0.0.0");
-            (0, "0.0.0".to_string())
-        }
+    // Allow pinning the version (e.g. to match an official manager release)
+    let (code, name) = match (
+        env::var("KSU_VERSION_CODE"),
+        env::var("KSU_VERSION_NAME"),
+    ) {
+        (Ok(code), Ok(name)) => (
+            code.parse()
+                .unwrap_or_else(|_| panic!("invalid KSU_VERSION_CODE: {code}")),
+            name,
+        ),
+        _ => match get_git_version() {
+            Ok((code, name)) => (code, name),
+            Err(_) => {
+                // show warning if git is not installed
+                println!("cargo:warning=Failed to get git version, using 0.0.0");
+                (0, "0.0.0".to_string())
+            }
+        },
     };
     if env::var("KSU_PACKAGE_NAME").is_err() {
         println!("cargo:rustc-env=KSU_PACKAGE_NAME=me.weishu.kernelsu");


### PR DESCRIPTION
## What

Add opt-in environment overrides to pin the KernelSU version instead of deriving it from `git rev-list --count HEAD`:

- **kernel Kbuild**: `KSU_VERSION_OVERRIDE` sets `KSU_VERSION` verbatim
- **ksud build.rs**: `KSU_VERSION_CODE` + `KSU_VERSION_NAME` (both required) replace the git-derived versionCode/versionName

When unset, behavior is completely unchanged.

## Why

Version is currently `30000 + git commit count`. Any downstream fork or out-of-tree build pipeline that adds commits on top of a release tag (e.g. porting vendor-specific patches like Samsung KDP) ends up with a versionCode that no longer matches any official manager release. The manager then shows a spurious "manager version mismatch" warning even though the UAPI is fully compatible.

Concretely: building on top of `v3.3.0` (2601 commits) with 2 extra commits reports `32603` while the official manager is `32601`.

## Example

Pin a CI build to the v3.3.0 release:

```yaml
env:
  KSU_VERSION: 32601
```

```
make ... KSU_VERSION_OVERRIDE=$KSU_VERSION
KSU_VERSION_CODE=32601 KSU_VERSION_NAME=3.3.0 cargo build ...
```
