### PR TITLE
kernel: Export original sepolicy through supercall

### DIFF
--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -91,14 +91,16 @@ static ssize_t my_write_context(struct file *file, char *buf, size_t size)
     ssize_t length;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    struct selinux_policy *backup = ksu_get_backup_sepolicy();
+
     length = avc_has_perm(current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY, SECURITY__CHECK_CONTEXT, NULL);
     if (length)
         goto out;
-    length = security_context_to_sid_with_policy(backup_sepolicy, buf, size, &sid, SECSID_NULL, GFP_KERNEL);
+    length = security_context_to_sid_with_policy(backup, buf, size, &sid, SECSID_NULL, GFP_KERNEL);
     if (length)
         goto out;
 
-    length = security_sid_to_context_with_policy(backup_sepolicy, sid, &canon, &len);
+    length = security_sid_to_context_with_policy(backup, sid, &canon, &len);
     if (length)
         goto out;
 
@@ -144,6 +146,8 @@ static ssize_t my_write_access(struct file *file, char *buf, size_t size)
     ssize_t length;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
+    struct selinux_policy *backup = ksu_get_backup_sepolicy();
+
     length = avc_has_perm(current_sid(), SECINITSID_SECURITY, SECCLASS_SECURITY, SECURITY__COMPUTE_AV, NULL);
 #else
     length =
@@ -167,15 +171,15 @@ static ssize_t my_write_access(struct file *file, char *buf, size_t size)
         goto out;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-    length = security_context_to_sid_with_policy(backup_sepolicy, scon, strlen(scon), &ssid, SECSID_NULL, GFP_KERNEL);
+    length = security_context_to_sid_with_policy(backup, scon, strlen(scon), &ssid, SECSID_NULL, GFP_KERNEL);
     if (length)
         goto out;
 
-    length = security_context_to_sid_with_policy(backup_sepolicy, tcon, strlen(tcon), &tsid, SECSID_NULL, GFP_KERNEL);
+    length = security_context_to_sid_with_policy(backup, tcon, strlen(tcon), &tsid, SECSID_NULL, GFP_KERNEL);
     if (length)
         goto out;
 
-    security_compute_av_user_with_policy(backup_sepolicy, ssid, tsid, tclass, &avd);
+    security_compute_av_user_with_policy(backup, ssid, tsid, tclass, &avd);
 #else
     length = security_context_str_to_sid(&fake_state, scon, &ssid, GFP_KERNEL);
     if (length)
@@ -231,7 +235,9 @@ static int __nocfi my_setprocattr(const char *name, void *value, size_t size)
             size--;
         }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
-        error = security_context_to_sid_with_policy(backup_sepolicy, str, size, &sid, SECSID_NULL, GFP_KERNEL);
+        struct selinux_policy *backup = ksu_get_backup_sepolicy();
+
+        error = security_context_to_sid_with_policy(backup, str, size, &sid, SECSID_NULL, GFP_KERNEL);
 #else
         error = security_context_to_sid(&fake_state, str, size, &sid, GFP_KERNEL);
 #endif
@@ -322,9 +328,11 @@ static void hook_selinux_status_open();
 static void ksu_selinux_hide_unhook();
 static int ksu_selinux_hide_enable()
 {
+    struct selinux_policy *backup = ksu_get_backup_sepolicy();
     int ret;
+
     pr_info("selinux_hide: init selinux hide\n");
-    if (!backup_sepolicy) {
+    if (!backup) {
         pr_err("no backup sepolicy available, please save feature and reboot to retry!\n");
         return -EAGAIN;
     }
@@ -346,7 +354,7 @@ static int ksu_selinux_hide_enable()
     }
 #else
     fake_state.initialized = true;
-    fake_state.policy = backup_sepolicy;
+    fake_state.policy = backup;
 #endif
 
     context_write = &selinux_write_op[SEL_CONTEXT];

--- a/kernel/feature/selinux_hide.c
+++ b/kernel/feature/selinux_hide.c
@@ -522,19 +522,7 @@ void __exit ksu_selinux_hide_exit()
         __free_page(fake_status);
     fake_status = NULL;
     mutex_unlock(&selinux_state.status_lock);
-}
-
-void ksu_selinux_hide_drop_backup_if_unused()
-{
-    mutex_lock(&selinux_hide_mutex);
-    if (!ksu_selinux_hide_running && backup_sepolicy) {
-        pr_info("selinux_hide is not enabled - drop backup_sepolicy\n");
-        sidtab_destroy(backup_sepolicy->sidtab);
-        kfree(backup_sepolicy->sidtab);
-        ksu_destroy_sepolicy(backup_sepolicy);
-        backup_sepolicy = NULL;
-    }
-    mutex_unlock(&selinux_hide_mutex);
+    ksu_drop_backup_sepolicy();
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)

--- a/kernel/feature/selinux_hide.h
+++ b/kernel/feature/selinux_hide.h
@@ -3,7 +3,6 @@
 
 void ksu_selinux_hide_init();
 void ksu_selinux_hide_exit();
-void ksu_selinux_hide_drop_backup_if_unused();
 void ksu_selinux_hide_handle_second_stage();
 void ksu_selinux_hide_handle_post_fs_data();
 

--- a/kernel/include/ksu.h
+++ b/kernel/include/ksu.h
@@ -10,7 +10,6 @@
 extern struct cred *ksu_cred;
 extern bool ksu_late_loaded;
 extern bool allow_shell;
-extern struct selinux_policy *backup_sepolicy;
 extern bool ksu_no_custom_rc;
 
 static inline int startswith(char *s, char *prefix)

--- a/kernel/runtime/boot_event.c
+++ b/kernel/runtime/boot_event.c
@@ -67,5 +67,4 @@ void on_boot_completed(void)
     ksu_boot_completed = true;
     pr_info("on_boot_completed!\n");
     track_throne(true);
-    ksu_selinux_hide_drop_backup_if_unused();
 }

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -1,5 +1,6 @@
 #include "linux/rcupdate.h"
 #include "security.h"
+#include <linux/atomic.h>
 #include <linux/uaccess.h>
 #include <linux/types.h>
 #include <linux/version.h>
@@ -17,8 +18,8 @@
 #include "linux/lsm_audit.h" // IWYU pragma: keep
 #include "xfrm.h"
 
-struct selinux_policy *backup_sepolicy;
-static DEFINE_MUTEX(backup_sepolicy_lock);
+/* Published once after initialization and cleared after all users have stopped. */
+static atomic_long_t backup_sepolicy = ATOMIC_LONG_INIT(0);
 
 #define SELINUX_POLICY_INSTEAD_SELINUX_SS
 
@@ -47,7 +48,7 @@ static void reset_avc_cache()
 
 void apply_kernelsu_rules()
 {
-    struct selinux_policy *pol, *old_pol = selinux_state.policy;
+    struct selinux_policy *backup, *pol, *old_pol = selinux_state.policy;
     struct policydb *db;
 
     if (!getenforce()) {
@@ -55,31 +56,26 @@ void apply_kernelsu_rules()
     }
 
     mutex_lock(&selinux_state.policy_mutex);
-    mutex_lock(&backup_sepolicy_lock);
-    backup_sepolicy =
-        ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
-    if (IS_ERR(backup_sepolicy)) {
-        pr_err("failed to create backup sepolicy: %ld\n", PTR_ERR(backup_sepolicy));
-        backup_sepolicy = NULL;
+    backup = ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
+    if (IS_ERR(backup)) {
+        pr_err("failed to create backup sepolicy: %ld\n", PTR_ERR(backup));
     } else {
-        backup_sepolicy->sidtab = kzalloc(sizeof(*backup_sepolicy->sidtab), GFP_KERNEL);
-        if (!backup_sepolicy->sidtab) {
+        backup->sidtab = kzalloc(sizeof(*backup->sidtab), GFP_KERNEL);
+        if (!backup->sidtab) {
             pr_err("failed to alloc backup sidtab\n");
-            ksu_destroy_sepolicy(backup_sepolicy);
-            backup_sepolicy = NULL;
+            ksu_destroy_sepolicy(backup);
         } else {
-            int ret = policydb_load_isids(&backup_sepolicy->policydb, backup_sepolicy->sidtab);
+            int ret = policydb_load_isids(&backup->policydb, backup->sidtab);
             if (ret) {
                 pr_err("failed to load isids for backup sepolicy: %d!\n", ret);
-                kfree(backup_sepolicy->sidtab);
-                ksu_destroy_sepolicy(backup_sepolicy);
-                backup_sepolicy = NULL;
+                kfree(backup->sidtab);
+                ksu_destroy_sepolicy(backup);
             } else {
-                pr_info("backup sepolicy success! latest_granting=%d\n", backup_sepolicy->latest_granting);
+                atomic_long_set_release(&backup_sepolicy, (long)backup);
+                pr_info("backup sepolicy success! latest_granting=%d\n", backup->latest_granting);
             }
         }
     }
-    mutex_unlock(&backup_sepolicy_lock);
     pol = ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(pol)) {
         pr_err("failed to dup selinux_policy: %ld\n", PTR_ERR(pol));
@@ -169,22 +165,25 @@ out_unlock:
     mutex_unlock(&selinux_state.policy_mutex);
 }
 
+struct selinux_policy *ksu_get_backup_sepolicy(void)
+{
+    return (struct selinux_policy *)atomic_long_read_acquire(&backup_sepolicy);
+}
+
 int ksu_export_backup_sepolicy(struct file *file)
 {
+    struct selinux_policy *backup = ksu_get_backup_sepolicy();
     const char *cursor;
     void *data;
     size_t len;
     int ret;
 
-    mutex_lock(&backup_sepolicy_lock);
-    if (!backup_sepolicy) {
-        ret = -ENOENT;
-        goto out_unlock;
-    }
+    if (!backup)
+        return -ENOENT;
 
-    ret = ksu_serialize_sepolicy(backup_sepolicy, &data, &len);
+    ret = ksu_serialize_sepolicy(backup, &data, &len);
     if (ret)
-        goto out_unlock;
+        return ret;
 
     cursor = data;
     while (len) {
@@ -206,23 +205,20 @@ int ksu_export_backup_sepolicy(struct file *file)
 
 out_free:
     kvfree(data);
-
-out_unlock:
-    mutex_unlock(&backup_sepolicy_lock);
     return ret;
 }
 
 void ksu_drop_backup_sepolicy(void)
 {
-    mutex_lock(&backup_sepolicy_lock);
-    if (backup_sepolicy) {
-        pr_info("drop backup_sepolicy\n");
-        sidtab_destroy(backup_sepolicy->sidtab);
-        kfree(backup_sepolicy->sidtab);
-        ksu_destroy_sepolicy(backup_sepolicy);
-        backup_sepolicy = NULL;
-    }
-    mutex_unlock(&backup_sepolicy_lock);
+    struct selinux_policy *backup = (struct selinux_policy *)atomic_long_xchg(&backup_sepolicy, 0);
+
+    if (!backup)
+        return;
+
+    pr_info("drop backup_sepolicy\n");
+    sidtab_destroy(backup->sidtab);
+    kfree(backup->sidtab);
+    ksu_destroy_sepolicy(backup);
 }
 
 #define KSU_SEPOLICY_MAX_BATCH_SIZE (8U * 1024U * 1024U)

--- a/kernel/selinux/rules.c
+++ b/kernel/selinux/rules.c
@@ -4,6 +4,8 @@
 #include <linux/types.h>
 #include <linux/version.h>
 #include <linux/lockdep.h>
+#include <linux/mutex.h>
+#include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/string.h>
 
@@ -16,6 +18,7 @@
 #include "xfrm.h"
 
 struct selinux_policy *backup_sepolicy;
+static DEFINE_MUTEX(backup_sepolicy_lock);
 
 #define SELINUX_POLICY_INSTEAD_SELINUX_SS
 
@@ -52,6 +55,7 @@ void apply_kernelsu_rules()
     }
 
     mutex_lock(&selinux_state.policy_mutex);
+    mutex_lock(&backup_sepolicy_lock);
     backup_sepolicy =
         ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(backup_sepolicy)) {
@@ -75,6 +79,7 @@ void apply_kernelsu_rules()
             }
         }
     }
+    mutex_unlock(&backup_sepolicy_lock);
     pol = ksu_dup_sepolicy(rcu_dereference_protected(old_pol, lockdep_is_held(&selinux_state.policy_mutex)));
     if (IS_ERR(pol)) {
         pr_err("failed to dup selinux_policy: %ld\n", PTR_ERR(pol));
@@ -162,6 +167,62 @@ void apply_kernelsu_rules()
     reset_avc_cache();
 out_unlock:
     mutex_unlock(&selinux_state.policy_mutex);
+}
+
+int ksu_export_backup_sepolicy(struct file *file)
+{
+    const char *cursor;
+    void *data;
+    size_t len;
+    int ret;
+
+    mutex_lock(&backup_sepolicy_lock);
+    if (!backup_sepolicy) {
+        ret = -ENOENT;
+        goto out_unlock;
+    }
+
+    ret = ksu_serialize_sepolicy(backup_sepolicy, &data, &len);
+    if (ret)
+        goto out_unlock;
+
+    cursor = data;
+    while (len) {
+        ssize_t written = kernel_write(file, cursor, len, &file->f_pos);
+
+        if (written < 0) {
+            ret = written;
+            goto out_free;
+        }
+        if (!written) {
+            ret = -EIO;
+            goto out_free;
+        }
+
+        cursor += written;
+        len -= written;
+    }
+    ret = 0;
+
+out_free:
+    kvfree(data);
+
+out_unlock:
+    mutex_unlock(&backup_sepolicy_lock);
+    return ret;
+}
+
+void ksu_drop_backup_sepolicy(void)
+{
+    mutex_lock(&backup_sepolicy_lock);
+    if (backup_sepolicy) {
+        pr_info("drop backup_sepolicy\n");
+        sidtab_destroy(backup_sepolicy->sidtab);
+        kfree(backup_sepolicy->sidtab);
+        ksu_destroy_sepolicy(backup_sepolicy);
+        backup_sepolicy = NULL;
+    }
+    mutex_unlock(&backup_sepolicy_lock);
 }
 
 #define KSU_SEPOLICY_MAX_BATCH_SIZE (8U * 1024U * 1024U)

--- a/kernel/selinux/sepolicy.c
+++ b/kernel/selinux/sepolicy.c
@@ -894,6 +894,62 @@ bool ksu_genfscon(struct policydb *db, const char *fs_name, const char *path, co
 
 // ======== sepolicy ========
 
+static void ksu_fixup_sepolicy_config(const struct selinux_policy *pol, void *data, size_t len)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+    // https://android-review.googlesource.com/c/kernel/common/+/3009995/11/security/selinux/ss/policydb.c
+    // The Android-specific netlink config bits are not emitted by older policydb writers.
+    static const size_t kConfigOff = 20;
+    if (len >= kConfigOff + sizeof(u32)) {
+        u32 *config_ptr = (u32 *)((unsigned long)data + kConfigOff);
+        pr_info("old config: %u\n", *config_ptr);
+        if (pol->policydb.android_netlink_route) {
+            pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE\n");
+            *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE;
+        }
+        if (pol->policydb.android_netlink_getneigh) {
+            pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH\n");
+            *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH;
+        }
+        pr_info("new config: %u\n", *config_ptr);
+    }
+#else
+    (void)pol;
+    (void)data;
+    (void)len;
+#endif
+}
+
+int ksu_serialize_sepolicy(struct selinux_policy *pol, void **data, size_t *len)
+{
+    int ret;
+    size_t alloc_len;
+    struct policy_file fp;
+    void *buf;
+
+    // Preserve room for policydb_read() to add each type to its own attribute map.
+    alloc_len = pol->policydb.len + (size_t)pol->policydb.p_types.nprim * (sizeof(u32) + sizeof(u64));
+    buf = vmalloc(alloc_len);
+    if (!buf) {
+        pr_err("alloc policy buffer len %zu\n", alloc_len);
+        return -ENOMEM;
+    }
+
+    fp.data = buf;
+    fp.len = alloc_len;
+    ret = policydb_write(&pol->policydb, &fp);
+    if (ret) {
+        pr_err("sepolicy: policydb_write: %d\n", ret);
+        kvfree(buf);
+        return ret;
+    }
+
+    *len = alloc_len - fp.len;
+    ksu_fixup_sepolicy_config(pol, buf, *len);
+    *data = buf;
+    return 0;
+}
+
 void ksu_destroy_sepolicy(struct selinux_policy *pol)
 {
     policydb_destroy(&pol->policydb);
@@ -905,50 +961,13 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol)
     int ret;
     size_t len;
     struct selinux_policy *new_pol;
-    void *data;
+    void *data = NULL;
     struct policy_file fp;
 
-    // Some device policy db seems not marking type itself in type_attr_map_array
-    // policydb_read() adds each type to its own attribute map, so old_pol->policydb.len may be smaller
-    // preserve one ebitmap entry for this condition to avoid trigger -EINVAL
-    len = old_pol->policydb.len + (size_t)old_pol->policydb.p_types.nprim * (sizeof(u32) + sizeof(u64));
-
-    data = vmalloc(len);
-    if (!data) {
-        pr_err("alloc policy buffer len %zu\n", len);
-        ret = -ENOMEM;
+    ret = ksu_serialize_sepolicy(old_pol, &data, &len);
+    if (ret)
         goto out_free_data;
-    }
 
-    fp.data = data;
-    fp.len = len;
-
-    ret = policydb_write(&old_pol->policydb, &fp);
-    if (ret) {
-        pr_err("sepolicy: policydb_write: %d\n", ret);
-        goto out_free_data;
-    }
-    len -= fp.len;
-    // https://android.googlesource.com/kernel/common/+/35a7845718734ae638b85b420534cb859498dab6%5E%21
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
-    // https://android-review.googlesource.com/c/kernel/common/+/3009995/11/security/selinux/ss/policydb.c
-    // fixup config
-    // 4*2+8+4
-    static const size_t kConfigOff = 20;
-    if (len >= kConfigOff + sizeof(u32)) {
-        u32 *config_ptr = (u32 *)((unsigned long)data + kConfigOff);
-        pr_info("old config: %u\n", *config_ptr);
-        if (old_pol->policydb.android_netlink_route) {
-            pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE\n");
-            *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_ROUTE;
-        }
-        if (old_pol->policydb.android_netlink_getneigh) {
-            pr_info("adding POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH\n");
-            *config_ptr |= POLICYDB_CONFIG_ANDROID_NETLINK_GETNEIGH;
-        }
-        pr_info("new config: %u\n", *config_ptr);
-    }
-#endif
     new_pol = kmemdup(old_pol, sizeof(*old_pol), GFP_KERNEL);
     if (!new_pol) {
         ret = -ENOMEM;

--- a/kernel/selinux/sepolicy.h
+++ b/kernel/selinux/sepolicy.h
@@ -10,6 +10,8 @@ struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol);
 
 int ksu_serialize_sepolicy(struct selinux_policy *pol, void **data, size_t *len);
 
+struct selinux_policy *ksu_get_backup_sepolicy(void);
+
 int ksu_export_backup_sepolicy(struct file *file);
 
 void ksu_drop_backup_sepolicy(void);

--- a/kernel/selinux/sepolicy.h
+++ b/kernel/selinux/sepolicy.h
@@ -2,10 +2,17 @@
 #define __KSU_H_SEPOLICY
 
 #include <linux/types.h>
+#include <linux/fs.h>
 
 #include "ss/policydb.h"
 
 struct selinux_policy *ksu_dup_sepolicy(struct selinux_policy *old_pol);
+
+int ksu_serialize_sepolicy(struct selinux_policy *pol, void **data, size_t *len);
+
+int ksu_export_backup_sepolicy(struct file *file);
+
+void ksu_drop_backup_sepolicy(void);
 
 void ksu_destroy_sepolicy(struct selinux_policy *orig);
 

--- a/kernel/supercall/dispatch.c
+++ b/kernel/supercall/dispatch.c
@@ -1,5 +1,7 @@
 #include <linux/capability.h>
 #include <linux/cred.h>
+#include <linux/file.h>
+#include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
@@ -15,6 +17,7 @@
 #include "feature/kernel_umount.h"
 #include "manager/manager_identity.h"
 #include "selinux/selinux.h"
+#include "selinux/sepolicy.h"
 #include "infra/file_wrapper.h"
 #include "hook/tp_marker.h"
 #include "policy/app_profile.h"
@@ -682,6 +685,38 @@ static int do_get_sulog_fd(void __user *arg)
     return ksu_install_sulog_fd();
 }
 
+static int do_export_sepolicy(void __user *arg)
+{
+    struct ksu_export_sepolicy_cmd cmd;
+    struct file *file;
+    int ret;
+
+    if (copy_from_user(&cmd, arg, sizeof(cmd))) {
+        pr_err("export_sepolicy: copy_from_user failed\n");
+        return -EFAULT;
+    }
+
+    if (cmd.flags) {
+        pr_err("export_sepolicy: unsupported flags 0x%x\n", cmd.flags);
+        return -EINVAL;
+    }
+
+    file = fget(cmd.fd);
+    if (!file)
+        return -EBADF;
+
+    if (!(file->f_mode & FMODE_WRITE)) {
+        ret = -EBADF;
+        goto out_fput;
+    }
+
+    ret = ksu_export_backup_sepolicy(file);
+
+out_fput:
+    fput(file);
+    return ret;
+}
+
 static int do_disable_escape_to_root(void __user *arg)
 {
     set_thread_flag(TIF_KSU_DISABLE_ESCAPE_WITH_ROOT);
@@ -827,6 +862,12 @@ static const struct ksu_ioctl_cmd_map ksu_ioctl_handlers[] = {
         .cmd = KSU_IOCTL_GET_SULOG_FD,
         .name = "GET_SULOG_FD",
         .handler = do_get_sulog_fd,
+        .perm_check = only_root
+    },
+    {
+        .cmd = KSU_IOCTL_EXPORT_SEPOLICY,
+        .name = "EXPORT_SEPOLICY",
+        .handler = do_export_sepolicy,
         .perm_check = only_root
     },
     { 

--- a/uapi/supercall.h
+++ b/uapi/supercall.h
@@ -7,7 +7,8 @@
 #include "uapi/app_profile.h"
 
 // 2: allowlist v4 root profile flags
-static const __u32 KERNEL_SU_UAPI_VERSION = 2;
+// 3: export the original sepolicy
+static const __u32 KERNEL_SU_UAPI_VERSION = 3;
 
 /* Magic numbers for reboot hook to install fd */
 static const __u32 KSU_INSTALL_MAGIC1 = 0xDEADBEEF;
@@ -144,6 +145,11 @@ struct ksu_get_sulog_fd_cmd {
     __u32 flags; /* Input: reserved for future use, must be 0 */
 };
 
+struct ksu_export_sepolicy_cmd {
+    __u32 fd; /* Input: writable userspace fd to receive the policy */
+    __u32 flags; /* Input: reserved for future use, must be 0 */
+};
+
 static const __u8 KSU_UMOUNT_WIPE = 0; /* ignore everything and wipe list */
 static const __u8 KSU_UMOUNT_ADD = 1; /* add entry (path + flags) */
 static const __u8 KSU_UMOUNT_DEL = 2; /* delete entry, strcmp */
@@ -176,5 +182,6 @@ static const __u32 KSU_IOCTL_ADD_TRY_UMOUNT = _IOC(_IOC_WRITE, 'K', 18, 0);
 static const __u32 KSU_IOCTL_SET_INIT_PGRP = _IO('K', 19);
 static const __u32 KSU_IOCTL_GET_SULOG_FD = _IOW('K', 20, struct ksu_get_sulog_fd_cmd);
 static const __u32 KSU_IOCTL_DISABLE_ESCAPE_TO_ROOT = _IO('K', 21);
+static const __u32 KSU_IOCTL_EXPORT_SEPOLICY = _IOW('K', 22, struct ksu_export_sepolicy_cmd);
 
 #endif

--- a/userspace/ksud/src/cli.rs
+++ b/userspace/ksud/src/cli.rs
@@ -273,6 +273,12 @@ enum Sepolicy {
         file: String,
     },
 
+    /// Export the original sepolicy saved by the kernel
+    Export {
+        /// destination file path
+        file: String,
+    },
+
     /// Check if sepolicy statement is supported/valid
     Check {
         /// sepolicy statements
@@ -633,6 +639,7 @@ pub fn run() -> Result<()> {
         Commands::Sepolicy { command } => match command {
             Sepolicy::Patch { sepolicy } => crate::sepolicy::live_patch(&sepolicy),
             Sepolicy::Apply { file } => crate::sepolicy::apply_file(file),
+            Sepolicy::Export { file } => crate::sepolicy::export(file),
             Sepolicy::Check { sepolicy } => crate::sepolicy::check_rule(&sepolicy),
         },
         Commands::LateLoad {

--- a/userspace/ksud/src/ksucalls.rs
+++ b/userspace/ksud/src/ksucalls.rs
@@ -153,6 +153,15 @@ pub fn set_sepolicy(payload: *const u8, payload_len: u64) -> std::io::Result<i32
     ksuctl(ksu_uapi::KSU_IOCTL_SET_SEPOLICY, &raw mut ioctl_cmd)
 }
 
+pub fn export_sepolicy(fd: RawFd) -> std::io::Result<()> {
+    let mut cmd = ksu_uapi::ksu_export_sepolicy_cmd {
+        fd: fd as u32,
+        flags: 0,
+    };
+    ksuctl(ksu_uapi::KSU_IOCTL_EXPORT_SEPOLICY, &raw mut cmd)?;
+    Ok(())
+}
+
 /// Get feature value and support status from kernel
 /// Returns (value, supported)
 pub fn get_feature(feature_id: u32) -> std::io::Result<(u64, bool)> {

--- a/userspace/ksud/src/sepolicy.rs
+++ b/userspace/ksud/src/sepolicy.rs
@@ -7,7 +7,7 @@ use nom::{
     character::complete::{space0, space1},
     combinator::map,
 };
-use std::{path::Path, vec};
+use std::{fs::OpenOptions, os::fd::AsRawFd, path::Path, vec};
 
 type SeObject<'a> = Vec<&'a str>;
 
@@ -760,6 +760,19 @@ pub fn live_patch(policy: &str) -> Result<()> {
     }
     apply_rules_batch(&result, false)?;
     Ok(())
+}
+
+pub fn export<P: AsRef<Path>>(path: P) -> Result<()> {
+    let path = path.as_ref();
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .with_context(|| format!("Failed to open sepolicy output {}", path.display()))?;
+
+    crate::ksucalls::export_sepolicy(file.as_raw_fd())
+        .with_context(|| format!("Failed to export sepolicy to {}", path.display()))
 }
 
 pub fn apply_file<P: AsRef<Path>>(path: P) -> Result<()> {


### PR DESCRIPTION
Add UAPI v3 EXPORT_SEPOLICY ioctl support. The command accepts a writable userspace file descriptor, validates it in the supercall dispatcher, and writes the serialized backup policy directly from the kernel while handling short writes and propagating errors.

Factor policydb serialization out of ksu_dup_sepolicy so duplication and export share the same buffer sizing and policydb_write path. Preserve the Android netlink route and getneigh configuration bits on kernels before 6.18 for both consumers.

Protect backup_sepolicy creation, export, and destruction with a mutex. Keep the original policy available after boot completion so it can be exported on demand, then release it during SELinux hide shutdown.

Add the ksud sepolicy export <file> command, which creates or truncates the destination and passes its writable fd through the new ioctl.

Verified with cargo ndk check/clippy/fmt and Android 6.1 and 6.18 DDK module builds including symbol checks.