### PR TITLE
fix(kernel): Reject all signature block id except v2

### DIFF
--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -250,6 +250,7 @@ static __always_inline bool check_v2_signature(char *path, unsigned expected_siz
             v2_signing_blocks++;
             v2_signing_valid = check_block(fp, &pos, pair_end, expected_size, expected_sha256);
         } else if (id != 0x42726577u) { // APK verity padding
+            // https://cs.android.com/android/platform/superproject/+/android-latest-release:tools/apksig/src/main/java/com/android/apksig/internal/apk/ApkSigningBlockUtils.java;l=102;drc=ebe4dfd4fd6550c949a6c7c2427484bf5e96500b
 #ifdef CONFIG_KSU_DEBUG
             pr_info("Unexpected signature block id: 0x%08x\n", id);
 #endif

--- a/kernel/manager/apk_sign.c
+++ b/kernel/manager/apk_sign.c
@@ -152,8 +152,6 @@ static __always_inline bool check_v2_signature(char *path, unsigned expected_siz
 
     bool v2_signing_valid = false;
     int v2_signing_blocks = 0;
-    bool v3_signing_exist = false;
-    bool v3_1_signing_exist = false;
 
     int i;
     struct file *fp = filp_open(path, O_RDONLY, 0);
@@ -251,16 +249,11 @@ static __always_inline bool check_v2_signature(char *path, unsigned expected_siz
         if (id == 0x7109871au) {
             v2_signing_blocks++;
             v2_signing_valid = check_block(fp, &pos, pair_end, expected_size, expected_sha256);
-        } else if (id == 0xf05368c0u) {
-            // http://aospxref.com/android-14.0.0_r2/xref/frameworks/base/core/java/android/util/apk/ApkSignatureSchemeV3Verifier.java#73
-            v3_signing_exist = true;
-        } else if (id == 0x1b93ad61u) {
-            // http://aospxref.com/android-14.0.0_r2/xref/frameworks/base/core/java/android/util/apk/ApkSignatureSchemeV3Verifier.java#74
-            v3_1_signing_exist = true;
-        } else {
+        } else if (id != 0x42726577u) { // APK verity padding
 #ifdef CONFIG_KSU_DEBUG
-            pr_info("Unknown id: 0x%08x\n", id);
+            pr_info("Unexpected signature block id: 0x%08x\n", id);
 #endif
+            goto invalid;
         }
         pos = pair_end;
     }
@@ -278,11 +271,6 @@ invalid:
     v2_signing_valid = false;
 clean:
     filp_close(fp, 0);
-
-    if (v2_signing_valid && (v3_signing_exist || v3_1_signing_exist)) {
-        pr_err("Unexpected v3 signature scheme found!\n");
-        return false;
-    }
 
     return v2_signing_valid;
 }


### PR DESCRIPTION
Old code doesn't check for v3.2 signature block id and is unsafe. To ensure no additional block id is forgotten in the future, let's just allow ids we need.