### PR TITLE
feat: warn when ksud haven't init

### DIFF
--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMaterial.kt
@@ -96,6 +96,15 @@ fun HomePagerMaterial(
             if (state.checkUpdateEnabled) {
                 UpdateCard(state = state, actions = actions)
             }
+            if (state.showKsudWarning) {
+                WarningCard(
+                    message = stringResource(
+                        if (state.isLateLoadMode) R.string.home_late_load_warning
+                        else R.string.home_ksud_not_loaded_warning
+                    ),
+                    onClick = actions.onKsudWarningClick,
+                )
+            }
             if (state.showManagerPrBuildWarning) {
                 WarningCard(stringResource(id = R.string.home_pr_build_warning), level = WarningLevel.Notice)
             } else if (state.showKernelPrBuildWarning) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeMiuix.kt
@@ -130,6 +130,15 @@ fun HomePagerMiuix(
                         if (state.checkUpdateEnabled) {
                             UpdateCard(state = state, actions = actions)
                         }
+                        if (state.showKsudWarning) {
+                            WarningCard(
+                                message = stringResource(
+                                    if (state.isLateLoadMode) R.string.home_late_load_warning
+                                    else R.string.home_ksud_not_loaded_warning
+                                ),
+                                onClick = actions.onKsudWarningClick,
+                            )
+                        }
                         if (state.showManagerPrBuildWarning) {
                             WarningCard(stringResource(id = R.string.home_pr_build_warning), level = WarningLevel.Notice)
                         } else if (state.showKernelPrBuildWarning) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeScreen.kt
@@ -21,12 +21,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.weishu.kernelsu.R
+import me.weishu.kernelsu.data.repository.isSoftRebootPreferred
 import me.weishu.kernelsu.magica.MagicaService
 import me.weishu.kernelsu.ui.LocalUiMode
 import me.weishu.kernelsu.ui.UiMode
 import me.weishu.kernelsu.ui.component.dialog.rememberLoadingDialog
 import me.weishu.kernelsu.ui.navigation3.Navigator
 import me.weishu.kernelsu.ui.navigation3.Route
+import me.weishu.kernelsu.ui.util.reboot
 import me.weishu.kernelsu.ui.viewmodel.HomeViewModel
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -76,6 +78,9 @@ fun HomePager(
                     Toast.makeText(context, R.string.jailbreak_timeout, Toast.LENGTH_LONG).show()
                 }
             }
+        },
+        onKsudWarningClick = {
+            reboot(if (isSoftRebootPreferred()) "soft_reboot" else "")
         },
     )
 

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeUiState.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/screen/home/HomeUiState.kt
@@ -24,6 +24,7 @@ data class HomeUiState(
     val latestVersionInfo: LatestVersionInfo,
     val currentManagerVersionCode: Long,
     val systemInfo: SystemInfo,
+    val showKsudWarning: Boolean = false,
 ) {
     val isSELinuxPermissive: Boolean
         get() = systemInfo.selinuxStatus == "Permissive"
@@ -60,4 +61,5 @@ data class HomeActions(
     val onInstallClick: () -> Unit,
     val onOpenUrl: (String) -> Unit,
     val onJailbreakClick: () -> Unit = {},
+    val onKsudWarningClick: () -> Unit = {},
 )

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/util/KsuCli.kt
@@ -13,6 +13,8 @@ import android.util.Log
 import com.topjohnwu.superuser.CallbackList
 import com.topjohnwu.superuser.Shell
 import com.topjohnwu.superuser.ShellUtils
+import com.topjohnwu.superuser.io.SuFile
+import com.topjohnwu.superuser.io.SuFileInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
@@ -502,6 +504,21 @@ fun reboot(reason: String = "") {
 fun rootAvailable(): Boolean {
     val shell = getRootShell()
     return shell.isRoot
+}
+
+private fun readRootFile(path: String): String? {
+    val file = SuFile(path).apply { shell = getRootShell() }
+    return runCatching {
+        SuFileInputStream.open(file).use { input ->
+            input.bufferedReader().readText().trim()
+        }
+    }.getOrNull()?.takeIf { it.isNotEmpty() }
+}
+
+fun isLastSuccessfulBoot(): Boolean {
+    val currentBootId = readRootFile("/proc/sys/kernel/random/boot_id") ?: return false
+    val lastSuccessBootId = readRootFile("/data/adb/ksu/.last_success_boot_id") ?: return false
+    return currentBootId == lastSuccessBootId
 }
 
 suspend fun getCurrentKmi(): String = withContext(Dispatchers.IO) {

--- a/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
+++ b/manager/app/src/main/java/me/weishu/kernelsu/ui/viewmodel/HomeViewModel.kt
@@ -22,6 +22,7 @@ import me.weishu.kernelsu.ui.screen.home.SystemInfo
 import me.weishu.kernelsu.ui.screen.home.getManagerVersion
 import me.weishu.kernelsu.ui.util.checkNewVersion
 import me.weishu.kernelsu.ui.util.getSELinuxStatusRaw
+import me.weishu.kernelsu.ui.util.isLastSuccessfulBoot
 import me.weishu.kernelsu.ui.util.module.LatestVersionInfo
 import me.weishu.kernelsu.ui.util.resolveDeviceName
 import me.weishu.kernelsu.ui.util.rootAvailable
@@ -72,6 +73,7 @@ class HomeViewModel(
             checkUpdateEnabled = settingsRepo.checkUpdate,
             latestVersionInfo = LatestVersionInfo(),
             currentManagerVersionCode = managerVersion.versionCode,
+            showKsudWarning = isManager && !isLastSuccessfulBoot(),
             systemInfo = SystemInfo(
                 kernelVersion = Os.uname().release,
                 managerVersion = "${managerVersion.versionName} (${managerVersion.versionCode}-${managerUAPIVersion})",

--- a/manager/app/src/main/res/values-zh-rCN/strings.xml
+++ b/manager/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,8 @@
     <string name="home_working">工作中</string>
     <string name="home_working_version">版本：%s</string>
     <string name="home_lkm_update_available">内嵌 LKM 有可用更新，点击更新</string>
+    <string name="home_ksud_not_loaded_warning">未正常加载，模块等可能未生效，点击重启</string>
+    <string name="home_late_load_warning">所有模块未生效，点击此处进行软重启</string>
     <string name="home_lkm_custom">自定义</string>
     <string name="home_unsupported">不支持</string>
     <string name="home_unsupported_reason">KernelSU 现在只支持 GKI 内核，但是你可以为 GKI 设备补丁镜像</string>

--- a/manager/app/src/main/res/values/strings.xml
+++ b/manager/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="home_working">Working</string>
     <string name="home_working_version">Version: %s</string>
     <string name="home_lkm_update_available">A newer bundled LKM is available. Tap to update.</string>
+    <string name="home_ksud_not_loaded_warning">Not loaded correctly; modules and other features may not take effect. Tap to reboot</string>
+    <string name="home_late_load_warning">All modules are not effective; tap here to perform a soft reboot</string>
     <string name="home_lkm_custom">Custom</string>
     <string name="home_unsupported">Unsupported</string>
     <string name="home_unsupported_reason">KernelSU only supports GKI kernels now, but you can patch the image for GKI devices.</string>

--- a/userspace/ksud/src/init_event.rs
+++ b/userspace/ksud/src/init_event.rs
@@ -4,7 +4,7 @@ use crate::{
     assets, defs, ksucalls, metamodule, restorecon,
     utils::{self},
 };
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use libc::_exit;
 use log::{error, info, warn};
 use prop_rs_android::resetprop::ResetProp;
@@ -172,9 +172,35 @@ pub fn on_boot_completed() {
     }
 
     ksucalls::report_boot_complete();
+    if let Err(e) = write_last_success_boot_id() {
+        warn!("failed to write last successful boot id: {e:#}");
+    }
     info!("on_boot_completed triggered!");
 
     run_stage("boot-completed", false);
+}
+
+fn write_last_success_boot_id() -> Result<()> {
+    let boot_id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .with_context(|| format!("failed to read boot_id device node"))?
+        .trim()
+        .to_owned();
+    if boot_id.is_empty() {
+        bail!("boot_id device node is empty");
+    }
+
+    std::fs::write(
+        const_format::concatcp!(defs::WORKING_DIR, ".last_success_boot_id"),
+        boot_id.as_bytes(),
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            const_format::concatcp!(defs::WORKING_DIR, ".last_success_boot_id")
+        )
+    })?;
+
+    Ok(())
 }
 
 const fn resetprop() -> ResetProp {


### PR DESCRIPTION
Record boot_id to /data/adb/ksu/.last_success_boot_id
when boot_completed

Manager check this file compare with boot_id device node
to know ksud start during this boot or not.

For late-load mode, when manager found ksud haven't init during this boot
It will display a special notice,
which notify user every modules stop working unless soft-reboot

For normal mode, it will display a common notice,
which notify user working mode abnormal,
and need restart for fix